### PR TITLE
add ability to set scenario output on hive config

### DIFF
--- a/hive/config/global_config.py
+++ b/hive/config/global_config.py
@@ -23,6 +23,7 @@ class GlobalConfig(NamedTuple):
     lazy_file_reading: bool
     wkt_x_y_ordering: bool
 
+
     @classmethod
     def default_config(cls) -> Dict:
         return {}

--- a/hive/reporting/handler/eventful_handler.py
+++ b/hive/reporting/handler/eventful_handler.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+from pathlib import Path
 from typing import TYPE_CHECKING, List
 
 from hive.reporting import vehicle_event_ops
@@ -22,9 +23,9 @@ class EventfulHandler(Handler):
     handles events and appends them to the event.log output file based on global logging settings
     """
 
-    def __init__(self, global_config: GlobalConfig, scenario_output_directory: str):
+    def __init__(self, global_config: GlobalConfig, scenario_output_directory: Path):
 
-        log_path = os.path.join(scenario_output_directory, 'event.log')
+        log_path = scenario_output_directory / 'event.log'
         self.log_file = open(log_path, 'a')
 
         self.global_config = global_config

--- a/hive/reporting/handler/instruction_handler.py
+++ b/hive/reporting/handler/instruction_handler.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+from pathlib import Path
 from typing import TYPE_CHECKING, List
 
 from hive.reporting import vehicle_event_ops
@@ -22,9 +23,9 @@ class InstructionHandler(Handler):
     handles events and appends them to the event.log output file based on global logging settings
     """
 
-    def __init__(self, global_config: GlobalConfig, scenario_output_directory: str):
+    def __init__(self, global_config: GlobalConfig, scenario_output_directory: Path):
 
-        log_path = os.path.join(scenario_output_directory, 'instruction.log')
+        log_path = scenario_output_directory / 'instruction.log'
         self.log_file = open(log_path, 'a')
 
         self.global_config = global_config

--- a/hive/reporting/handler/stateful_handler.py
+++ b/hive/reporting/handler/stateful_handler.py
@@ -1,5 +1,6 @@
 import json
 import os
+from pathlib import Path
 from typing import List
 
 from hive.config.global_config import GlobalConfig
@@ -17,9 +18,9 @@ class StatefulHandler(Handler):
     prints the state of entities in the simulation to the state.log output file based on global logging settings
     """
 
-    def __init__(self, global_config: GlobalConfig, scenario_output_directory: str):
+    def __init__(self, global_config: GlobalConfig, scenario_output_directory: Path):
 
-        log_path = os.path.join(scenario_output_directory, 'state.log')
+        log_path = scenario_output_directory / 'state.log'
         self.log_file = open(log_path, 'a')
 
         self.global_config = global_config


### PR DESCRIPTION
Adds the ability to set the scenario output directory on a HiveConfig.

I anticipate this will be useful for the hive-distributed project where we can set a unique output directory for each worker and let them use the existing hive reporter.