### PR TITLE
move reporter out of initialize_simulation functions

### DIFF
--- a/hive/initialization/initialize_simulation.py
+++ b/hive/initialization/initialize_simulation.py
@@ -72,21 +72,9 @@ def initialize_simulation(
         sim_h3_search_resolution=config.sim.sim_h3_search_resolution
     )
 
-    # configure reporting
-    reporter = Reporter(config.global_config)
-    if config.global_config.log_events:
-        reporter.add_handler(EventfulHandler(config.global_config, config.scenario_output_directory))
-    if config.global_config.log_states:
-        reporter.add_handler(StatefulHandler(config.global_config, config.scenario_output_directory))
-    if config.global_config.log_instructions:
-        reporter.add_handler(InstructionHandler(config.global_config, config.scenario_output_directory))
-    if config.global_config.log_stats:
-        reporter.add_handler(StatsHandler())
-
     # create simulation environment
     fleet_ids = read_fleet_ids_from_file(config.input_config.fleets_file) if config.input_config.fleets_file else []
     env_initial = Environment(config=config,
-                              reporter=reporter,
                               mechatronics=build_mechatronics_table(config.input_config.mechatronics_file,
                                                                     config.input_config.scenario_directory),
                               chargers=build_chargers_table(config.input_config.chargers_file),
@@ -94,10 +82,6 @@ def initialize_simulation(
                                                               config.input_config.schedules_file),
                               fleet_ids=fleet_ids
                               )
-
-    # todo: maybe instead of reporting errors to the env.Reporter in these builder functions, we
-    #  should instead hold aside any error reports and then do something below after finishing,
-    #  such as allowing the user to decide how to respond (via a config param such as "fail on load errors")
 
     # read in fleet memberships for vehicles/stations/bases
     vehicle_member_ids = process_fleet_file(config.input_config.fleets_file,

--- a/hive/initialization/initialize_simulation_with_sampling.py
+++ b/hive/initialization/initialize_simulation_with_sampling.py
@@ -87,24 +87,12 @@ def initialize_simulation_with_sampling(
         sim_h3_search_resolution=config.sim.sim_h3_search_resolution
     )
 
-    # configure reporting
-    reporter = Reporter(config.global_config)
-    if config.global_config.log_events:
-        reporter.add_handler(EventfulHandler(config.global_config, config.scenario_output_directory))
-    if config.global_config.log_states:
-        reporter.add_handler(StatefulHandler(config.global_config, config.scenario_output_directory))
-    if config.global_config.log_instructions:
-        reporter.add_handler(InstructionHandler(config.global_config, config.scenario_output_directory))
-    if config.global_config.log_stats:
-        reporter.add_handler(StatsHandler())
-
     # create simulation environment
     if config.input_config.fleets_file:
         log.warning("the simulation is using sampling which doesn't support a fleet file input;\n"
                     "this input will be ignored and entities will not have any fleet information.")
 
     env = Environment(config=config,
-                      reporter=reporter,
                       mechatronics=build_mechatronics_table(config.input_config.mechatronics_file,
                                                             config.input_config.scenario_directory),
                       chargers=build_chargers_table(config.input_config.chargers_file),

--- a/hive/initialization/load.py
+++ b/hive/initialization/load.py
@@ -6,6 +6,11 @@ from typing import Tuple
 import yaml
 
 from hive.config import HiveConfig
+from hive.reporting.handler.eventful_handler import EventfulHandler
+from hive.reporting.handler.instruction_handler import InstructionHandler
+from hive.reporting.handler.stateful_handler import StatefulHandler
+from hive.reporting.handler.stats_handler import StatsHandler
+from hive.reporting.reporter import Reporter
 from hive.runner.environment import Environment
 from hive.initialization.initialize_simulation import initialize_simulation
 from hive.state.simulation_state.simulation_state import SimulationState
@@ -18,6 +23,7 @@ def load_simulation(scenario_file_path: Path) -> Tuple[SimulationState, Environm
     takes a scenario path and attempts to build all assets required to run a scenario
 
     :param scenario_file_path: the path to the scenario file we are using
+
     :return: the assets required to run a scenario
     :raises: Exception if the scenario_path is not found or if other scenario files are not found or fail to parse
     """
@@ -35,4 +41,17 @@ def load_simulation(scenario_file_path: Path) -> Tuple[SimulationState, Environm
 
     simulation_state, environment = initialize_simulation(config)
 
-    return simulation_state, environment
+    # configure reporting
+    reporter = Reporter()
+    if config.global_config.log_events:
+        reporter.add_handler(EventfulHandler(config.global_config, config.scenario_output_directory))
+    if config.global_config.log_states:
+        reporter.add_handler(StatefulHandler(config.global_config, config.scenario_output_directory))
+    if config.global_config.log_instructions:
+        reporter.add_handler(InstructionHandler(config.global_config, config.scenario_output_directory))
+    if config.global_config.log_stats:
+        reporter.add_handler(StatsHandler())
+
+    environment_w_reporter = environment.set_reporter(reporter)
+
+    return simulation_state, environment_w_reporter

--- a/hive/reporting/reporter.py
+++ b/hive/reporting/reporter.py
@@ -26,8 +26,7 @@ class Reporter:
     A class that generates reports for the simulation.
     """
 
-    def __init__(self, config: GlobalConfig):
-        self.config = config
+    def __init__(self):
         self.reports: List[Report] = []
         self.handlers: List[Handler] = []
 

--- a/hive/runner/environment.py
+++ b/hive/runner/environment.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 from typing import NamedTuple, TYPE_CHECKING, FrozenSet
 
+from hive.reporting.reporter import Reporter
+
 import immutables
 
 if TYPE_CHECKING:
     from hive.model.energy.charger import Charger
     from hive.model.vehicle.mechatronics.mechatronics_interface import MechatronicsInterface
-    from hive.reporting import Reporter
     from hive.config import HiveConfig
     from hive.util.typealiases import MechatronicsId, ChargerId, ScheduleId, ScheduleFunction, MembershipId
 
@@ -18,8 +19,19 @@ class Environment(NamedTuple):
 
     """
     config: HiveConfig
-    reporter: Reporter
     mechatronics: immutables.Map[MechatronicsId, MechatronicsInterface] = immutables.Map()
     chargers: immutables.Map[ChargerId, Charger] = immutables.Map()
     schedules: immutables.Map[ScheduleId, ScheduleFunction] = immutables.Map()
     fleet_ids: FrozenSet[MembershipId] = frozenset()
+
+    reporter: Reporter = Reporter()
+
+    def set_reporter(self, reporter: Reporter) -> Environment:
+        """
+        allows the reporter to be updated after the environment is built.
+
+        :param reporter: the reporter to be used
+
+        :return: the updated environment
+        """
+        return self._replace(reporter=reporter)


### PR DESCRIPTION
Moves the reporter building out of the scope of the `initialize_simulation` function and into the scope of the `load` function. 

This will be useful for loading a hive simulation state and an environment without any file writing side effects. 

Now, the reporter defaults to a silent reporter and can be added to the environment after it has been initialized. 