### PR TITLE
report fleet id for request-related events

### DIFF
--- a/hive/model/passenger.py
+++ b/hive/model/passenger.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import functools as ft
 from typing import NamedTuple, Optional
 
+from hive.model.membership import Membership
 from hive.model.sim_time import SimTime
 from hive.util.typealiases import *
 
@@ -31,6 +32,7 @@ class Passenger(NamedTuple):
     origin: GeoId
     destination: GeoId
     departure_time: SimTime
+    membership: Membership
     vehicle_id: Optional[VehicleId] = None
 
     def add_vehicle_id(self, vehicle_id: VehicleId) -> Passenger:

--- a/hive/model/request/request.py
+++ b/hive/model/request/request.py
@@ -68,19 +68,21 @@ class Request(NamedTuple):
         assert (passengers > 0)
         origin_link = road_network.stationary_location_from_geoid(origin)
         destination_link = road_network.stationary_location_from_geoid(destination)
-        request_as_passengers = [
-            Passenger(
-                create_passenger_id(request_id, pass_idx),
-                origin_link.start,
-                destination_link.end,
-                departure_time
-            )
-            for pass_idx in range(0, passengers)
-        ]
         if fleet_id:
             membership = Membership.single_membership(fleet_id)
         else:
             membership = Membership()
+
+        request_as_passengers = [
+            Passenger(
+                id=create_passenger_id(request_id, pass_idx),
+                origin=origin_link.start,
+                destination=destination_link.end,
+                departure_time=departure_time,
+                membership=membership
+            )
+            for pass_idx in range(0, passengers)
+        ]
 
         request = Request(
             id=request_id,

--- a/hive/state/simulation_state/update/cancel_requests.py
+++ b/hive/state/simulation_state/update/cancel_requests.py
@@ -68,16 +68,18 @@ def _gen_report(r_id: RequestId, sim: SimulationState) -> Report:
     """
     Report of a cancellation
 
-
     :param r_id: request cancelled
     :param sim: the state of the sim before cancellation occurs
     :return: a report
     """
     dep_t = sim.requests[r_id].departure_time
     sim_t = sim.sim_time
+    req = sim.requests.get(r_id)
+    membership = str(req.membership) if req else ""
     report_data = {
         'request_id': r_id,
         'departure_time': dep_t,
         'cancel_time': sim_t,
+        'fleet_id': membership,
     }
     return Report(ReportType.CANCEL_REQUEST_EVENT, report_data)

--- a/hive/state/simulation_state/update/update_requests_from_file.py
+++ b/hive/state/simulation_state/update/update_requests_from_file.py
@@ -167,6 +167,7 @@ def update_requests_from_iterator(it: Iterator[Dict[str, str]],
                     report_data = {
                         'request_id': req.id,
                         'departure_time': dep_t,
+                        'fleet_id': str(req.membership)
                     }
                     env.reporter.file_report(Report(ReportType.ADD_REQUEST_EVENT, report_data))
                     return sim_updated

--- a/hive/state/simulation_state/update/update_requests_sampling.py
+++ b/hive/state/simulation_state/update/update_requests_sampling.py
@@ -93,6 +93,7 @@ class UpdateRequestsSampling(NamedTuple, SimulationUpdateFunction):
                 report_data = {
                     'request_id': request.id,
                     'departure_time': request.departure_time,
+                    'fleet_id': str(request.membership),
                 }
                 env.reporter.file_report(Report(ReportType.ADD_REQUEST_EVENT, report_data))
             return new_sim

--- a/hive/state/vehicle_state/servicing_trip.py
+++ b/hive/state/vehicle_state/servicing_trip.py
@@ -6,7 +6,7 @@ from typing import NamedTuple, Tuple, Optional, TYPE_CHECKING
 from hive.model.passenger import Passenger
 from hive.model.roadnetwork.route import Route, route_cooresponds_with_entities
 from hive.model.sim_time import SimTime
-from hive.reporting.vehicle_event_ops import report_dropoff_request
+from hive.reporting.vehicle_event_ops import report_servicing_trip_dropoff_request
 from hive.runner.environment import Environment
 from hive.state.simulation_state import simulation_state_ops
 from hive.state.vehicle_state.idle import Idle
@@ -97,7 +97,7 @@ class ServicingTrip(NamedTuple, VehicleState):
                     return SimulationStateError(message), None
 
         # ok, we can drop off these passengers
-        report = report_dropoff_request(vehicle, sim)
+        report = report_servicing_trip_dropoff_request(vehicle, sim)
         env.reporter.file_report(report)
         return None, sim
 


### PR DESCRIPTION
this PR extends event reporting so that events related to requests (add/pickup/dropoff/cancel) all report the related `fleet_id`.

this required adding the Membership of a Request to the associated Passengers of a Vehicle.

to test, run denver_demo_fleets.yaml.

while doing this, i started to get the feeling that a Passenger could be memory-optimized so it is one class with a "passenger_count: int" instead of capturing each passenger as their own object instance. maybe renamed something like "Trip". i'm not sure we would be losing anything by doing this. this may be low-hanging fruit for performance improvement.

Closes #5.