### PR TITLE
add soft range threshold for charging searches

### DIFF
--- a/hive/config/dispatcher_config.py
+++ b/hive/config/dispatcher_config.py
@@ -11,6 +11,7 @@ class DispatcherConfig(NamedTuple):
     default_update_interval_seconds: Seconds
     matching_range_km_threshold: Kilometers
     charging_range_km_threshold: Kilometers
+    charging_range_km_soft_threshold: Kilometers
     base_charging_range_km_threshold: Kilometers
     ideal_fastcharge_soc_limit: Ratio
     max_search_radius_km: Kilometers

--- a/hive/dispatcher/instruction_generator/charging_fleet_manager.py
+++ b/hive/dispatcher/instruction_generator/charging_fleet_manager.py
@@ -50,6 +50,10 @@ class ChargingFleetManager(NamedTuple, InstructionGenerator):
 
             mechatronics = environment.mechatronics.get(v.mechatronics_id)
             range_remaining_km = mechatronics.range_remaining_km(v)
+            if range_remaining_km > environment.config.dispatcher.charging_range_km_soft_threshold:
+                # don't even check station distance if vehicle range is over soft threshold
+                return False
+
             nearest_station_distance = get_nearest_valid_station_distance(
                 max_search_radius_km=self.config.max_search_radius_km,
                 vehicle=v,

--- a/hive/resources/defaults/hive_config.yaml
+++ b/hive/resources/defaults/hive_config.yaml
@@ -19,6 +19,7 @@ dispatcher:
   default_update_interval_seconds: 600          # 10 minutes
   matching_range_km_threshold: 20               # ignore matching requests when remaining range is less than 20km
   charging_range_km_threshold: 20               # ignore charging at stations when remaining range is greater than 20km plus the nearest station distance
+  charging_range_km_soft_threshold: 50          # ignore charging at stations when remaining range is greater than 50km
   base_charging_range_km_threshold: 100         # ignore base charging at bases more than 100 km away
   ideal_fastcharge_soc_limit: 0.8               # fast charging can finish when 80% state-of-charge is reached
   max_search_radius_km: 100.0                   # when searching, ignore entities that are further than 100km away


### PR DESCRIPTION
A suggestion for a minor performance enhancement with respect to the charging search.

When profiling the denver_demo scenario, I noticed that there was a large number of calls to the road network routing function. We previously called this for all idle and repositioning vehicles at every time step to test their distance against the nearest station. 

This introduces a new 'soft' charging range threshold (default 50km). If the vehicle's remaining range is above this value, the charging dispatcher doesn't test the nearest station distance and assumes the vehicle is okay to keep driving. If the range falls under this value, the charging dispatcher will start testing the distance to the nearest station.

For the denver demo scenario this reduces run times from ~18 seconds to ~12 seconds and produces almost identical results:

no soft threshold:
```
[INFO] - hive - done! time elapsed: 18.64 seconds
[INFO] - hive.reporting.handler.summary_stats - 52.59 %         Mean Final SOC
[INFO] - hive.reporting.handler.summary_stats - 98.16 %         Requests Served
[INFO] - hive.reporting.handler.summary_stats - 34.72 %         Time in State Idle
[INFO] - hive.reporting.handler.summary_stats - 0.09 %          Time in State DispatchBase
[INFO] - hive.reporting.handler.summary_stats - 5.4 %           Time in State ChargingBase
[INFO] - hive.reporting.handler.summary_stats - 20.92 %         Time in State DispatchTrip
[INFO] - hive.reporting.handler.summary_stats - 19.38 %         Time in State ServicingTrip
[INFO] - hive.reporting.handler.summary_stats - 15.28 %         Time in State ReserveBase
[INFO] - hive.reporting.handler.summary_stats - 0.3 %           Time in State DispatchStation
[INFO] - hive.reporting.handler.summary_stats - 3.9 %           Time in State ChargingStation
[INFO] - hive.reporting.handler.summary_stats - 0.01 %          Time in State Repositioning
[INFO] - hive.reporting.handler.summary_stats - 8090.88 km      Total Kilometers Traveled
[INFO] - hive.reporting.handler.summary_stats - 15.24 km        Kilometers Traveled in State DispatchBase
[INFO] - hive.reporting.handler.summary_stats - 3296.90 km      Kilometers Traveled in State DispatchTrip
[INFO] - hive.reporting.handler.summary_stats - 4723.54 km      Kilometers Traveled in State ServicingTrip
[INFO] - hive.reporting.handler.summary_stats - 52.68 km        Kilometers Traveled in State DispatchStation
[INFO] - hive.reporting.handler.summary_stats - 2.53 km         Kilometers Traveled in State Repositioning
[INFO] - hive.reporting.handler.summary_stats - $ 179.46        Station Revenue
[INFO] - hive.reporting.handler.summary_stats - $ 12199.42      Fleet Revenue
```

w/ soft threshold
```
[INFO] - hive - done! time elapsed: 12.05 seconds
[INFO] - hive.reporting.handler.summary_stats - 47.58 %         Mean Final SOC
[INFO] - hive.reporting.handler.summary_stats - 99.00 %         Requests Served
[INFO] - hive.reporting.handler.summary_stats - 33.02 %         Time in State Idle
[INFO] - hive.reporting.handler.summary_stats - 0.08 %          Time in State DispatchBase
[INFO] - hive.reporting.handler.summary_stats - 3.65 %          Time in State ChargingBase
[INFO] - hive.reporting.handler.summary_stats - 21.23 %         Time in State DispatchTrip
[INFO] - hive.reporting.handler.summary_stats - 19.56 %         Time in State ServicingTrip
[INFO] - hive.reporting.handler.summary_stats - 18.08 %         Time in State ReserveBase
[INFO] - hive.reporting.handler.summary_stats - 0.3 %           Time in State DispatchStation
[INFO] - hive.reporting.handler.summary_stats - 4.09 %          Time in State ChargingStation
[INFO] - hive.reporting.handler.summary_stats - 0.0 %           Time in State Repositioning
[INFO] - hive.reporting.handler.summary_stats - 8187.46 km      Total Kilometers Traveled
[INFO] - hive.reporting.handler.summary_stats - 13.19 km        Kilometers Traveled in State DispatchBase
[INFO] - hive.reporting.handler.summary_stats - 3357.00 km      Kilometers Traveled in State DispatchTrip
[INFO] - hive.reporting.handler.summary_stats - 4766.09 km      Kilometers Traveled in State ServicingTrip
[INFO] - hive.reporting.handler.summary_stats - 50.49 km        Kilometers Traveled in State DispatchStation
[INFO] - hive.reporting.handler.summary_stats - 0.69 km         Kilometers Traveled in State Repositioning
[INFO] - hive.reporting.handler.summary_stats - $ 187.73        Station Revenue
[INFO] - hive.reporting.handler.summary_stats - $ 12295.63      Fleet Revenue
```