### PR TITLE
ChargingBase should take place in a stall

### DIFF
--- a/tests/.hive.yaml
+++ b/tests/.hive.yaml
@@ -5,4 +5,6 @@ log_events: False
 log_instructions: False
 log_stats: False
 log_station_capacities: False
+log_time_step_stats: False
+log_fleet_time_step_stats: False
 log_level: DEBUG


### PR DESCRIPTION
this PR has vehicles enter a stall when they are charging at a base. ChargingBase.enter reserves the stall, and ChargingBase.exit releases it. when transitioning from ReserveBase, the stall is exited, but since the transition happens as a single operation (ReserveBase.exit -> ChargingBase.enter, entity_state_ops.via transition_previous_to_next), we know the net effect is as if the vehicle stayed "at the stall" from the sim's POV.

i give an example of doing what's described in #63 here.

Closes #62.
