### PR TITLE
return empty route when origin equals destination

### DIFF
--- a/hive/model/roadnetwork/haversine_roadnetwork.py
+++ b/hive/model/roadnetwork/haversine_roadnetwork.py
@@ -7,7 +7,7 @@ from hive.model.entity_position import EntityPosition
 from hive.model.roadnetwork.link import Link
 from hive.model.roadnetwork.linktraversal import LinkTraversal
 from hive.model.roadnetwork.roadnetwork import RoadNetwork
-from hive.model.roadnetwork.route import Route
+from hive.model.roadnetwork.route import Route, empty_route
 from hive.model.sim_time import SimTime
 from hive.util.h3_ops import H3Ops
 from hive.util.typealiases import GeoId, LinkId, H3Resolution
@@ -44,6 +44,9 @@ class HaversineRoadNetwork(RoadNetwork):
         self.geofence = geofence
 
     def route(self, origin: EntityPosition, destination: EntityPosition) -> Route:
+        if origin == destination:
+            return empty_route() 
+            
         link_id = h_ops.geoids_to_link_id(origin.geoid, destination.geoid)
         link_dist_km = self.distance_by_geoid_km(origin.geoid, destination.geoid)
         link = LinkTraversal(

--- a/hive/model/roadnetwork/osm/osm_roadnetwork.py
+++ b/hive/model/roadnetwork/osm/osm_roadnetwork.py
@@ -100,6 +100,8 @@ class OSMRoadNetwork(RoadNetwork):
         :param destination: the destination Link
         :return: a route between the origin and destination on the OSM road network
         """
+        if origin == destination:
+            return empty_route()
 
         # start path search from the end of the origin link, terminate search at the start of the destination link
         extract_src_err, src_nodes = extract_node_ids(origin.link_id)


### PR DESCRIPTION
Closes #71 by adding a check on all road network route methods for when the origin and destination position are equal. If this is true, the road network returns an empty route.

![image](https://user-images.githubusercontent.com/1743744/148097086-b75be7cd-33af-4c95-a65d-1737da708bb3.png)
