### PR TITLE
apply yapf to all files

### DIFF
--- a/hive/app/hive_cosim.py
+++ b/hive/app/hive_cosim.py
@@ -84,9 +84,10 @@ def crank(runner_payload: RunnerPayload,
                 handler.clear()
 
         if new_events is None:
-            raise SimulationStateError(f'VehicleChargeEventsHandler missing from reporter in env {rp1.e}')
+            raise SimulationStateError(
+                f'VehicleChargeEventsHandler missing from reporter in env {rp1.e}')
 
-        updated_events = events + (new_events,)
+        updated_events = events + (new_events, )
 
         return rp1, updated_events
 

--- a/hive/app/run.py
+++ b/hive/app/run.py
@@ -26,14 +26,11 @@ if TYPE_CHECKING:
 parser = argparse.ArgumentParser(description="run hive")
 parser.add_argument(
     'scenario_file',
-    help='which scenario file to run (try "denver_downtown.yaml" or "manhattan.yaml")'
-)
-parser.add_argument(
-    '--defaults',
-    dest='defaults',
-    action='store_true',
-    help='prints the default hive configuration values'
-)
+    help='which scenario file to run (try "denver_downtown.yaml" or "manhattan.yaml")')
+parser.add_argument('--defaults',
+                    dest='defaults',
+                    action='store_true',
+                    help='prints the default hive configuration values')
 
 log = logging.getLogger("hive")
 
@@ -59,7 +56,8 @@ def run_sim(scenario_file, position=0):
         log_fh.setFormatter(formatter)
         log.addHandler(log_fh)
         log.info(
-            f"creating run log at {run_log_path} with log level {logging.getLevelName(log.getEffectiveLevel())}")
+            f"creating run log at {run_log_path} with log level {logging.getLevelName(log.getEffectiveLevel())}"
+        )
 
     if env.config.global_config.log_station_capacities:
         result = reporter_ops.log_station_capacities(sim, env)
@@ -76,8 +74,9 @@ def run_sim(scenario_file, position=0):
     update = Update.build(env.config, instruction_generators)
     initial_payload = RunnerPayload(sim, env, update)
 
-    log.info(f"running {env.config.sim.sim_name} for time {initial_payload.e.config.sim.start_time} "
-             f"to {initial_payload.e.config.sim.end_time}:")
+    log.info(
+        f"running {env.config.sim.sim_name} for time {initial_payload.e.config.sim.start_time} "
+        f"to {initial_payload.e.config.sim.end_time}:")
     start = time.time()
     sim_result = LocalSimulationRunner.run(initial_payload, position)
     end = time.time()
@@ -117,9 +116,9 @@ def run() -> int:
         try:
             scenario_file = fs.find_scenario(args.scenario_file)
         except FileNotFoundError as fe:
-            log.error(f"{repr(fe)}; please specify a path to a hive scenario file like denver_demo.yaml")
+            log.error(
+                f"{repr(fe)}; please specify a path to a hive scenario file like denver_demo.yaml")
             return 1
-
 
         run_sim(scenario_file)
 
@@ -149,7 +148,8 @@ def _welcome_to_hive():
 
 def print_defaults():
     print()
-    defaults_file_str = pkg_resources.resource_filename("hive.resources.defaults", "hive_config.yaml")
+    defaults_file_str = pkg_resources.resource_filename("hive.resources.defaults",
+                                                        "hive_config.yaml")
     log.info(f"printing the default scenario configuration stored at {defaults_file_str}:\n")
     # start build using the Hive config defaults file
     defaults_file = Path(defaults_file_str)

--- a/hive/app/run_batch.py
+++ b/hive/app/run_batch.py
@@ -17,10 +17,7 @@ if TYPE_CHECKING:
     pass
 
 parser = argparse.ArgumentParser(description="run hive")
-parser.add_argument(
-    'batch_config',
-    help='which batch config file to use?'
-)
+parser.add_argument('batch_config', help='which batch config file to use?')
 
 log = logging.getLogger("hive")
 

--- a/hive/app/run_tune.py
+++ b/hive/app/run_tune.py
@@ -19,8 +19,7 @@ from hive.util import fs
 parser = argparse.ArgumentParser(description="run hive")
 parser.add_argument(
     'scenario_file',
-    help='which scenario file to run (try "denver_downtown.yaml" or "manhattan.yaml")'
-)
+    help='which scenario file to run (try "denver_downtown.yaml" or "manhattan.yaml")')
 
 log = logging.getLogger("hive")
 
@@ -29,7 +28,6 @@ class DummyReporter(Reporter):
     """
     dummy reporter that does nothing
     """
-
     def log_sim_state(self, sim_state):
         pass
 
@@ -44,7 +42,6 @@ class OptimizationWrapper(tune.Trainable):
     """
     wrapper for a tune optimization.
     """
-
     @staticmethod
     def _scoring_function(payload: RunnerPayload) -> float:
         score = sum([v.balance for v in payload.s.vehicles.values()])
@@ -52,7 +49,7 @@ class OptimizationWrapper(tune.Trainable):
         print("VEHICLES ", payload.s.vehicles.values())
         return score
 
-    def _setup(self, config: Dict[str: int]):
+    def _setup(self, config: Dict[str:int]):
         scenarios = {
             1: 'denver_demo.yaml',
             2: 'denver_demo_constrained_charging.yaml',
@@ -89,11 +86,9 @@ def run() -> int:
 
     log.info('running tune experiments')
 
-    result = tune.run(
-        OptimizationWrapper,
-        stop={"training_iteration": 1},
-        config={'scenario': tune.grid_search([1, 2])}
-    )
+    result = tune.run(OptimizationWrapper,
+                      stop={"training_iteration": 1},
+                      config={'scenario': tune.grid_search([1, 2])})
 
     df = result.dataframe()
     df = df[['config/scenario', 'score']]

--- a/hive/config/config_builder.py
+++ b/hive/config/config_builder.py
@@ -23,7 +23,8 @@ class ConfigBuilder:
         :return: a Config, or, an error
         """
 
-        c = default_config if config is None else dict(list(default_config.items()) + list(config.items()))
+        c = default_config if config is None else dict(
+            list(default_config.items()) + list(config.items()))
         for key in required_config:
             value = c.get(key)
             if value is None:

--- a/hive/config/dispatcher_config.py
+++ b/hive/config/dispatcher_config.py
@@ -31,12 +31,10 @@ class DispatcherConfig(NamedTuple):
 
     @classmethod
     def build(cls, config: Optional[Dict] = None) -> DispatcherConfig:
-        return ConfigBuilder.build(
-            default_config=cls.default_config(),
-            required_config=cls.required_config(),
-            config_constructor=lambda c: DispatcherConfig.from_dict(c),
-            config=config
-        )
+        return ConfigBuilder.build(default_config=cls.default_config(),
+                                   required_config=cls.required_config(),
+                                   config_constructor=lambda c: DispatcherConfig.from_dict(c),
+                                   config=config)
 
     @classmethod
     def from_dict(cls, d: Dict) -> Union[IOError, DispatcherConfig]:

--- a/hive/config/global_config.py
+++ b/hive/config/global_config.py
@@ -25,7 +25,6 @@ class GlobalConfig(NamedTuple):
     lazy_file_reading: bool
     wkt_x_y_ordering: bool
 
-
     @classmethod
     def default_config(cls) -> Dict:
         return {}
@@ -55,20 +54,18 @@ class GlobalConfig(NamedTuple):
             default_config=cls.default_config(),
             required_config=cls.required_config(),
             config_constructor=lambda c: GlobalConfig.from_dict(c, global_settings_file_path),
-            config=config
-        )
+            config=config)
 
     @classmethod
     def from_dict(cls, d: Dict, global_settings_file_path) -> GlobalConfig:
         # allow Posix-style home directory paths ('~')
-        output_base_directory_absolute = Path(d['output_base_directory']).expanduser() if d[
-            'output_base_directory'].startswith("~") else Path(
-            d['output_base_directory'])
+        output_base_directory_absolute = Path(d['output_base_directory']).expanduser(
+        ) if d['output_base_directory'].startswith("~") else Path(d['output_base_directory'])
         d['output_base_directory'] = str(output_base_directory_absolute)
 
         # convert list of logged report types to a Set
-        d['log_sim_config'] = set(ReportType.from_string(rt) for rt in d['log_sim_config']) if d[
-            'log_sim_config'] else set()
+        d['log_sim_config'] = set(ReportType.from_string(rt)
+                                  for rt in d['log_sim_config']) if d['log_sim_config'] else set()
 
         # store the .hive.yaml file path used
         d['global_settings_file_path'] = global_settings_file_path
@@ -76,7 +73,7 @@ class GlobalConfig(NamedTuple):
 
     def asdict(self) -> Dict:
         return self._asdict()
-    
+
     @property
     def write_outputs(self):
         return self.log_run or self.log_states or self.log_events or self.log_stats or self.log_station_capacities or \

--- a/hive/config/input.py
+++ b/hive/config/input.py
@@ -42,8 +42,7 @@ class Input(NamedTuple):
             default_config=cls.default_config(),
             required_config=cls.required_config(),
             config_constructor=lambda c: Input.from_dict(c, scenario_file_path, cache),
-            config=config
-        )
+            config=config)
 
     @classmethod
     def from_dict(cls, d: Dict, scenario_file_path: Path, cache: Optional[Dict]) -> Input:
@@ -53,25 +52,42 @@ class Input(NamedTuple):
         scenario_file = scenario_file_path.name
 
         # required files
-        vehicles_file = fs.construct_scenario_asset_path(d['vehicles_file'], scenario_directory, 'vehicles')
-        requests_file = fs.construct_scenario_asset_path(d['requests_file'], scenario_directory, 'requests')
-        stations_file = fs.construct_scenario_asset_path(d['stations_file'], scenario_directory, 'stations')
+        vehicles_file = fs.construct_scenario_asset_path(d['vehicles_file'], scenario_directory,
+                                                         'vehicles')
+        requests_file = fs.construct_scenario_asset_path(d['requests_file'], scenario_directory,
+                                                         'requests')
+        stations_file = fs.construct_scenario_asset_path(d['stations_file'], scenario_directory,
+                                                         'stations')
         bases_file = fs.construct_scenario_asset_path(d['bases_file'], scenario_directory, 'bases')
 
         # may be found in hive.resources
-        mechatronics_file = fs.construct_asset_path(d['mechatronics_file'], scenario_directory, 'mechatronics', 'mechatronics')
+        mechatronics_file = fs.construct_asset_path(d['mechatronics_file'], scenario_directory,
+                                                    'mechatronics', 'mechatronics')
 
         # optional files
-        schedules_filename = d['schedules_file'] if d.get('schedules_file') else 'default_schedules.csv'
-        schedules_file = fs.construct_asset_path(schedules_filename, scenario_directory, 'schedules', 'schedules')
+        schedules_filename = d['schedules_file'] if d.get(
+            'schedules_file') else 'default_schedules.csv'
+        schedules_file = fs.construct_asset_path(schedules_filename, scenario_directory,
+                                                 'schedules', 'schedules')
         chargers_filename = d['chargers_file'] if d.get('chargers_file') else 'default_chargers.csv'
-        chargers_file = fs.construct_asset_path(chargers_filename, scenario_directory, 'chargers', 'chargers')
-        road_network_file = fs.construct_scenario_asset_path(d['road_network_file'], scenario_directory, 'road_network') if d.get('road_network_file') else None
-        geofence_file = fs.construct_scenario_asset_path(d['geofence_file'], scenario_directory, 'geofence') if d.get('geofence_file') else None
-        rate_structure_file = fs.construct_scenario_asset_path(d['rate_structure_file'], scenario_directory, 'service_prices') if d.get('rate_structure_file') else None
-        charging_price_file = fs.construct_scenario_asset_path(d['charging_price_file'], scenario_directory, 'charging_prices') if d.get('charging_price_file') else None
-        demand_forecast_file = fs.construct_scenario_asset_path(d['demand_forecast_file'], scenario_directory, 'demand_forecast') if d.get('demand_forecast_file') else None
-        fleets_file = fs.construct_scenario_asset_path(d['fleets_file'], scenario_directory, 'fleets') if d.get('fleets_file') else None
+        chargers_file = fs.construct_asset_path(chargers_filename, scenario_directory, 'chargers',
+                                                'chargers')
+        road_network_file = fs.construct_scenario_asset_path(
+            d['road_network_file'], scenario_directory,
+            'road_network') if d.get('road_network_file') else None
+        geofence_file = fs.construct_scenario_asset_path(
+            d['geofence_file'], scenario_directory, 'geofence') if d.get('geofence_file') else None
+        rate_structure_file = fs.construct_scenario_asset_path(
+            d['rate_structure_file'], scenario_directory,
+            'service_prices') if d.get('rate_structure_file') else None
+        charging_price_file = fs.construct_scenario_asset_path(
+            d['charging_price_file'], scenario_directory,
+            'charging_prices') if d.get('charging_price_file') else None
+        demand_forecast_file = fs.construct_scenario_asset_path(
+            d['demand_forecast_file'], scenario_directory,
+            'demand_forecast') if d.get('demand_forecast_file') else None
+        fleets_file = fs.construct_scenario_asset_path(d['fleets_file'], scenario_directory,
+                                                       'fleets') if d.get('fleets_file') else None
 
         input = {
             'scenario_directory': str(scenario_directory),
@@ -105,7 +121,9 @@ class Input(NamedTuple):
             data = f.read()
             new_md5_sum = hashlib.md5(data).hexdigest()
             if new_md5_sum != existing_md5_sum:
-                log.warning(f'this is a cached config file but the file {filepath} has changed since the last run')
+                log.warning(
+                    f'this is a cached config file but the file {filepath} has changed since the last run'
+                )
 
     def asdict(self) -> Dict:
         return self._asdict()

--- a/hive/config/network.py
+++ b/hive/config/network.py
@@ -19,12 +19,10 @@ class Network(NamedTuple):
 
     @classmethod
     def build(cls, config: Dict = None) -> Union[Exception, Network]:
-        return ConfigBuilder.build(
-            default_config=cls.default_config(),
-            required_config=cls.required_config(),
-            config_constructor=lambda c: Network.from_dict(c),
-            config=config
-        )
+        return ConfigBuilder.build(default_config=cls.default_config(),
+                                   required_config=cls.required_config(),
+                                   config_constructor=lambda c: Network.from_dict(c),
+                                   config=config)
 
     @classmethod
     def from_dict(cls, d: Dict) -> Network:

--- a/hive/config/sim.py
+++ b/hive/config/sim.py
@@ -32,12 +32,10 @@ class Sim(NamedTuple):
 
     @classmethod
     def build(cls, config: Dict = None) -> Union[IOError, Sim]:
-        return ConfigBuilder.build(
-            default_config=cls.default_config(),
-            required_config=cls.required_config(),
-            config_constructor=lambda c: Sim.from_dict(c),
-            config=config
-        )
+        return ConfigBuilder.build(default_config=cls.default_config(),
+                                   required_config=cls.required_config(),
+                                   config_constructor=lambda c: Sim.from_dict(c),
+                                   config=config)
 
     @classmethod
     def from_dict(cls, d: Dict) -> Union[IOError, Sim]:
@@ -51,16 +49,14 @@ class Sim(NamedTuple):
 
         schedule_type = ScheduleType.from_string(d['schedule_type'])
 
-        return Sim(
-            sim_name=d['sim_name'],
-            timestep_duration_seconds=int(d['timestep_duration_seconds']),
-            start_time=start_time,
-            end_time=end_time,
-            sim_h3_resolution=d['sim_h3_resolution'],
-            sim_h3_search_resolution=d['sim_h3_search_resolution'],
-            request_cancel_time_seconds=int(d['request_cancel_time_seconds']),
-            schedule_type=schedule_type
-        )
+        return Sim(sim_name=d['sim_name'],
+                   timestep_duration_seconds=int(d['timestep_duration_seconds']),
+                   start_time=start_time,
+                   end_time=end_time,
+                   sim_h3_resolution=d['sim_h3_resolution'],
+                   sim_h3_search_resolution=d['sim_h3_search_resolution'],
+                   request_cancel_time_seconds=int(d['request_cancel_time_seconds']),
+                   schedule_type=schedule_type)
 
     def asdict(self) -> Dict:
         return self._asdict()

--- a/hive/dispatcher/forecaster/basic_forecaster.py
+++ b/hive/dispatcher/forecaster/basic_forecaster.py
@@ -28,13 +28,16 @@ class BasicForecaster(NamedTuple, ForecasterInterface):
         if not Path(demand_forecast_file).is_file():
             raise IOError(f"{demand_forecast_file} is not a valid path to a request file")
 
-        error, reader = DictReaderStepper.build(demand_forecast_file, "sim_time", parser=SimTime.build)
+        error, reader = DictReaderStepper.build(demand_forecast_file,
+                                                "sim_time",
+                                                parser=SimTime.build)
         if error:
             raise error
         else:
             return BasicForecaster(reader)
 
-    def generate_forecast(self, simulation_state: 'SimulationState') -> Tuple[BasicForecaster, Forecast]:
+    def generate_forecast(self,
+                          simulation_state: 'SimulationState') -> Tuple[BasicForecaster, Forecast]:
         """
         Generate fleet targets to be consumed by the dispatcher.
 

--- a/hive/dispatcher/forecaster/forecaster_interface.py
+++ b/hive/dispatcher/forecaster/forecaster_interface.py
@@ -14,9 +14,9 @@ class ForecasterInterface(metaclass=ABCNamedTupleMeta):
     """
     A class that computes an optimal fleet state.
     """
-
     @abstractmethod
-    def generate_forecast(self, simulation_state: SimulationState) -> Tuple[ForecasterInterface, Forecast]:
+    def generate_forecast(
+            self, simulation_state: SimulationState) -> Tuple[ForecasterInterface, Forecast]:
         """
         Generate forecast of some future state.
 

--- a/hive/dispatcher/instruction/instruction.py
+++ b/hive/dispatcher/instruction/instruction.py
@@ -18,11 +18,10 @@ class Instruction(metaclass=ABCNamedTupleMeta):
     """
     an abstract base class for instructions.
     """
-
     @abstractmethod
-    def apply_instruction(self,
-                          sim_state: SimulationState,
-                          env: Environment) -> Tuple[Optional[Exception], Optional[InstructionResult]]:
+    def apply_instruction(
+            self, sim_state: SimulationState,
+            env: Environment) -> Tuple[Optional[Exception], Optional[InstructionResult]]:
         """
         attempts to apply an instruction to a vehicle
 

--- a/hive/dispatcher/instruction/instruction_ops.py
+++ b/hive/dispatcher/instruction/instruction_ops.py
@@ -37,8 +37,7 @@ def trip_plan_covers_previous(previous_state: ServicingPoolingTrip,
 
 
 def trip_plan_ordering_is_valid(new_trip_plan: Tuple[Tuple[RequestId, TripPhase], ...],
-                                previous_state: Optional[ServicingPoolingTrip] = None
-                                ) -> bool:
+                                previous_state: Optional[ServicingPoolingTrip] = None) -> bool:
     """
     checks that the incoming trip plan has a logical pickup and dropoff ordering and that
     no passengers are left on the vehicle after all steps in the trip plan.
@@ -82,8 +81,9 @@ def trip_plan_ordering_is_valid(new_trip_plan: Tuple[Tuple[RequestId, TripPhase]
     return has_valid_order and no_passengers_at_end_of_trip_plan
 
 
-def trip_plan_all_requests_allow_pooling(sim: 'SimulationState',
-                                         trip_plan: Tuple[Tuple[RequestId, TripPhase], ...]) -> Optional[str]:
+def trip_plan_all_requests_allow_pooling(
+        sim: 'SimulationState', trip_plan: Tuple[Tuple[RequestId, TripPhase],
+                                                 ...]) -> Optional[str]:
     """
     confirm that each request in the trip plan allows pooling
 
@@ -99,7 +99,7 @@ def trip_plan_all_requests_allow_pooling(sim: 'SimulationState',
             updated_sim_error_ids = sim_error_ids + (r_id, )
             return updated_sim_error_ids, pool_error_ids
         elif not req.allows_pooling:
-            updated_pool_error_ids = sim_error_ids + (r_id,)
+            updated_pool_error_ids = sim_error_ids + (r_id, )
             return sim_error_ids, updated_pool_error_ids
         else:
             return test_errors

--- a/hive/dispatcher/instruction/instructions.py
+++ b/hive/dispatcher/instruction/instructions.py
@@ -6,7 +6,8 @@ from typing import NamedTuple, Optional, TYPE_CHECKING, Tuple, Union
 from hive.dispatcher.instruction.instruction import Instruction
 from hive.dispatcher.instruction.instruction_ops import (
     trip_plan_ordering_is_valid,
-    trip_plan_all_requests_allow_pooling, trip_plan_covers_previous,
+    trip_plan_all_requests_allow_pooling,
+    trip_plan_covers_previous,
 )
 from hive.dispatcher.instruction.instruction_result import InstructionResult
 from hive.model.roadnetwork.link import Link, EntityPosition
@@ -43,14 +44,13 @@ class IdleInstruction(NamedTuple, Instruction):
     vehicle_id: VehicleId
 
     def apply_instruction(
-        self, sim_state: SimulationState, env: Environment
-    ) -> Tuple[Optional[Exception], Optional[InstructionResult]]:
+            self, sim_state: SimulationState,
+            env: Environment) -> Tuple[Optional[Exception], Optional[InstructionResult]]:
         vehicle = sim_state.vehicles.get(self.vehicle_id)
         if not vehicle:
             return (
                 SimulationStateError(
-                    f"vehicle {vehicle} not found; context: applying idle instruction."
-                ),
+                    f"vehicle {vehicle} not found; context: applying idle instruction."),
                 None,
             )
         else:
@@ -64,8 +64,8 @@ class DispatchTripInstruction(NamedTuple, Instruction):
     request_id: RequestId
 
     def apply_instruction(
-        self, sim_state: SimulationState, env: Environment
-    ) -> Tuple[Optional[Exception], Optional[InstructionResult]]:
+            self, sim_state: SimulationState,
+            env: Environment) -> Tuple[Optional[Exception], Optional[InstructionResult]]:
         vehicle = sim_state.vehicles.get(self.vehicle_id)
         request = sim_state.requests.get(self.request_id)
         if not vehicle:
@@ -97,18 +97,18 @@ class DispatchPoolingTripInstruction(NamedTuple, Instruction):
     trip_plan: Tuple[Tuple[RequestId, TripPhase], ...]
 
     def apply_instruction(
-        self, sim_state: SimulationState, env: Environment
-    ) -> Tuple[Optional[Exception], Optional[InstructionResult]]:
+            self, sim_state: SimulationState,
+            env: Environment) -> Tuple[Optional[Exception], Optional[InstructionResult]]:
         # see https://github.com/NREL/hive/issues/9 for implementation plan
         vehicle = sim_state.vehicles.get(self.vehicle_id)
         v_state = vehicle.vehicle_state
 
         req_allow_pooling_error_msg = trip_plan_all_requests_allow_pooling(
-            sim_state, self.trip_plan
-        )
+            sim_state, self.trip_plan)
         # seating_error = check_if_vehicle_has_seats(sim_state, vehicle, self.trip_plan)
 
-        if isinstance(v_state, ServicingPoolingTrip) and not trip_plan_covers_previous(v_state, self.trip_plan):
+        if isinstance(v_state, ServicingPoolingTrip) and not trip_plan_covers_previous(
+                v_state, self.trip_plan):
             msg = "DispatchPoolingTripInstruction updates an active pooling state but doesn't include all previous requests"
             error = InstructionError(msg)
             return error, None
@@ -135,8 +135,7 @@ class DispatchPoolingTripInstruction(NamedTuple, Instruction):
             return error, None
         else:
             error, next_state = dispatch_ops.begin_or_replan_dispatch_pooling_state(
-                sim_state, self.vehicle_id, self.trip_plan
-            )
+                sim_state, self.vehicle_id, self.trip_plan)
             if error is not None:
                 return error, None
             else:
@@ -149,23 +148,25 @@ class DispatchStationInstruction(NamedTuple, Instruction):
     charger_id: ChargerId
 
     def apply_instruction(
-        self, sim_state: SimulationState, env: Environment
-    ) -> Tuple[Optional[Exception], Optional[InstructionResult]]:
+            self, sim_state: SimulationState,
+            env: Environment) -> Tuple[Optional[Exception], Optional[InstructionResult]]:
         vehicle = sim_state.vehicles.get(self.vehicle_id)
         station = sim_state.stations.get(self.station_id)
         if not vehicle:
-            return SimulationStateError(f"vehicle {vehicle} not found: context: applying dispatch station instruction to station {self.station_id}"), None
+            return SimulationStateError(
+                f"vehicle {vehicle} not found: context: applying dispatch station instruction to station {self.station_id}"
+            ), None
         elif not station:
-            return SimulationStateError(f"station {station} not found: context: applying dispatch station instruction for vehicle {self.vehicle_id}"), None
+            return SimulationStateError(
+                f"station {station} not found: context: applying dispatch station instruction for vehicle {self.vehicle_id}"
+            ), None
         else:
             start = vehicle.position
             end = station.position
             route = sim_state.road_network.route(start, end)
 
             prev_state = vehicle.vehicle_state
-            next_state = DispatchStation(
-                self.vehicle_id, self.station_id, route, self.charger_id
-            )
+            next_state = DispatchStation(self.vehicle_id, self.station_id, route, self.charger_id)
 
             return None, InstructionResult(prev_state, next_state)
 
@@ -176,16 +177,16 @@ class ChargeStationInstruction(NamedTuple, Instruction):
     charger_id: ChargerId
 
     def apply_instruction(
-        self, sim_state: SimulationState, env: Environment
-    ) -> Tuple[Optional[Exception], Optional[InstructionResult]]:
+            self, sim_state: SimulationState,
+            env: Environment) -> Tuple[Optional[Exception], Optional[InstructionResult]]:
         vehicle = sim_state.vehicles.get(self.vehicle_id)
         if not vehicle:
-            return SimulationStateError(f"vehicle {vehicle} not found: context: applying charge station instruction at {self.station_id} with {self.charger_id} charger"), None
+            return SimulationStateError(
+                f"vehicle {vehicle} not found: context: applying charge station instruction at {self.station_id} with {self.charger_id} charger"
+            ), None
         else:
             prev_state = vehicle.vehicle_state
-            next_state = ChargingStation(
-                self.vehicle_id, self.station_id, self.charger_id
-            )
+            next_state = ChargingStation(self.vehicle_id, self.station_id, self.charger_id)
 
             return None, InstructionResult(prev_state, next_state)
 
@@ -196,11 +197,13 @@ class ChargeBaseInstruction(NamedTuple, Instruction):
     charger_id: ChargerId
 
     def apply_instruction(
-        self, sim_state: SimulationState, env: Environment
-    ) -> Tuple[Optional[Exception], Optional[InstructionResult]]:
+            self, sim_state: SimulationState,
+            env: Environment) -> Tuple[Optional[Exception], Optional[InstructionResult]]:
         vehicle = sim_state.vehicles.get(self.vehicle_id)
         if not vehicle:
-            return SimulationStateError(f"vehicle {vehicle} not found; context: applying charge base instruction at base {self.base_id} with {self.charger_id} charger"), None
+            return SimulationStateError(
+                f"vehicle {vehicle} not found; context: applying charge base instruction at base {self.base_id} with {self.charger_id} charger"
+            ), None
         else:
             prev_state = vehicle.vehicle_state
             next_state = ChargingBase(self.vehicle_id, self.base_id, self.charger_id)
@@ -213,14 +216,18 @@ class DispatchBaseInstruction(NamedTuple, Instruction):
     base_id: BaseId
 
     def apply_instruction(
-        self, sim_state: SimulationState, env: Environment
-    ) -> Tuple[Optional[Exception], Optional[InstructionResult]]:
+            self, sim_state: SimulationState,
+            env: Environment) -> Tuple[Optional[Exception], Optional[InstructionResult]]:
         vehicle = sim_state.vehicles.get(self.vehicle_id)
         base = sim_state.bases.get(self.base_id)
         if not vehicle:
-            return SimulationStateError(f"vehicle {self.vehicle_id} not found; context: applying dispatch base instruction to {self.base_id}"), None
+            return SimulationStateError(
+                f"vehicle {self.vehicle_id} not found; context: applying dispatch base instruction to {self.base_id}"
+            ), None
         if not base:
-            return SimulationStateError(f"base {self.base_id} not found; context: applying dispatch base instruction for {self.vehicle_id}"), None
+            return SimulationStateError(
+                f"base {self.base_id} not found; context: applying dispatch base instruction for {self.vehicle_id}"
+            ), None
         else:
             start = vehicle.position
             end = base.position
@@ -237,17 +244,21 @@ class RepositionInstruction(NamedTuple, Instruction):
     destination: LinkId
 
     def apply_instruction(
-        self, sim_state: SimulationState, env: Environment
-    ) -> Tuple[Optional[Exception], Optional[InstructionResult]]:
+            self, sim_state: SimulationState,
+            env: Environment) -> Tuple[Optional[Exception], Optional[InstructionResult]]:
         vehicle = sim_state.vehicles.get(self.vehicle_id)
         if not vehicle:
-            return SimulationStateError(f"vehicle {self.vehicle_id} not found; context: applying reposition instruction to link {self.destination}"), None
+            return SimulationStateError(
+                f"vehicle {self.vehicle_id} not found; context: applying reposition instruction to link {self.destination}"
+            ), None
         else:
             start = vehicle.position
 
             link = sim_state.road_network.link_from_link_id(self.destination)
             if not link:
-                return SimulationStateError(f"link {self.destination} not found; context: applying reposition instruction for vehicle {self.vehicle_id}"), None
+                return SimulationStateError(
+                    f"link {self.destination} not found; context: applying reposition instruction for vehicle {self.vehicle_id}"
+                ), None
             else:
                 destination_position = EntityPosition(link.link_id, link.end)
                 route = sim_state.road_network.route(start, destination_position)
@@ -263,11 +274,13 @@ class ReserveBaseInstruction(NamedTuple, Instruction):
     base_id: BaseId
 
     def apply_instruction(
-        self, sim_state: SimulationState, env: Environment
-    ) -> Tuple[Optional[Exception], Optional[InstructionResult]]:
+            self, sim_state: SimulationState,
+            env: Environment) -> Tuple[Optional[Exception], Optional[InstructionResult]]:
         vehicle = sim_state.vehicles.get(self.vehicle_id)
         if not vehicle:
-            return SimulationStateError(f"vehicle {self.vehicle_id} not found; context: applying reserve base instruction at base {self.base_id}"), None
+            return SimulationStateError(
+                f"vehicle {self.vehicle_id} not found; context: applying reserve base instruction at base {self.base_id}"
+            ), None
 
         prev_state = vehicle.vehicle_state
         next_state = ReserveBase(self.vehicle_id, self.base_id)

--- a/hive/dispatcher/instruction_generator/charging_fleet_manager.py
+++ b/hive/dispatcher/instruction_generator/charging_fleet_manager.py
@@ -28,9 +28,9 @@ class ChargingFleetManager(NamedTuple, InstructionGenerator):
     config: DispatcherConfig
 
     def generate_instructions(
-            self,
-            simulation_state: SimulationState,
-            environment: Environment,
+        self,
+        simulation_state: SimulationState,
+        environment: Environment,
     ) -> Tuple[ChargingFleetManager, Tuple[Instruction, ...]]:
         """
         Generate fleet targets for the dispatcher to execute based on the simulation state.
@@ -44,7 +44,8 @@ class ChargingFleetManager(NamedTuple, InstructionGenerator):
         # find vehicles that fall below the sum of the threshold distance and nearest valid station distance
 
         def charge_candidate(v: Vehicle) -> bool:
-            proper_state = isinstance(v.vehicle_state, Idle) or isinstance(v.vehicle_state, Repositioning)
+            proper_state = isinstance(v.vehicle_state, Idle) or isinstance(
+                v.vehicle_state, Repositioning)
             if not proper_state:
                 return False
 
@@ -61,19 +62,17 @@ class ChargingFleetManager(NamedTuple, InstructionGenerator):
                 simulation_state=simulation_state,
                 environment=environment,
                 target_soc=environment.config.dispatcher.ideal_fastcharge_soc_limit,
-                charging_search_type=environment.config.dispatcher.charging_search_type
-            )
-            is_charge_candidate = (environment.config.dispatcher.charging_range_km_threshold
-                                   + nearest_station_distance) >= range_remaining_km
+                charging_search_type=environment.config.dispatcher.charging_search_type)
+            is_charge_candidate = (environment.config.dispatcher.charging_range_km_threshold +
+                                   nearest_station_distance) >= range_remaining_km
             return is_charge_candidate
 
-        low_soc_vehicles = simulation_state.get_vehicles(
-            filter_function=charge_candidate,
-        )
+        low_soc_vehicles = simulation_state.get_vehicles(filter_function=charge_candidate, )
 
         # for each low_soc_vehicle that will conduct a refuel search, report the search event
         for v in low_soc_vehicles:
-            report = instruction_generator_event_ops.refuel_search_event(v, simulation_state, environment)
+            report = instruction_generator_event_ops.refuel_search_event(
+                v, simulation_state, environment)
             environment.reporter.file_report(report)
 
         charge_instructions = instruct_vehicles_to_dispatch_to_station(
@@ -83,7 +82,6 @@ class ChargingFleetManager(NamedTuple, InstructionGenerator):
             simulation_state=simulation_state,
             environment=environment,
             target_soc=environment.config.dispatcher.ideal_fastcharge_soc_limit,
-            charging_search_type=environment.config.dispatcher.charging_search_type
-        )
+            charging_search_type=environment.config.dispatcher.charging_search_type)
 
         return self, charge_instructions

--- a/hive/dispatcher/instruction_generator/charging_search_type.py
+++ b/hive/dispatcher/instruction_generator/charging_search_type.py
@@ -24,4 +24,5 @@ class ChargingSearchType(Enum):
             return ChargingSearchType.SHORTEST_TIME_TO_CHARGE
         else:
             valid_names = "{nearest_shortest_queue|shortest_time_to_charge}"
-            raise NameError(f"charging search type {string} is not known, must be one of {valid_names}")
+            raise NameError(
+                f"charging search type {string} is not known, must be one of {valid_names}")

--- a/hive/dispatcher/instruction_generator/dispatcher.py
+++ b/hive/dispatcher/instruction_generator/dispatcher.py
@@ -26,9 +26,9 @@ class Dispatcher(NamedTuple, InstructionGenerator):
     config: DispatcherConfig
 
     def generate_instructions(
-            self,
-            simulation_state: SimulationState,
-            environment: Environment,
+        self,
+        simulation_state: SimulationState,
+        environment: Environment,
     ) -> Tuple[Dispatcher, Tuple[Instruction, ...]]:
         """
         Generate fleet targets for the dispatcher to execute based on the simulation state.
@@ -40,8 +40,8 @@ class Dispatcher(NamedTuple, InstructionGenerator):
         base_charging_range_km_threshold = environment.config.dispatcher.base_charging_range_km_threshold
 
         def _solve_assignment(
-                inst_acc: Tuple[DispatchTripInstruction, ...],
-                membership_id: Optional[MembershipId],
+            inst_acc: Tuple[DispatchTripInstruction, ...],
+            membership_id: Optional[MembershipId],
         ) -> Tuple[DispatchTripInstruction, ...]:
             def _is_valid_for_dispatch(vehicle: Vehicle) -> bool:
                 vehicle_state_str = vehicle.vehicle_state.__class__.__name__.lower()
@@ -49,18 +49,21 @@ class Dispatcher(NamedTuple, InstructionGenerator):
                     return False
                 elif not vehicle.driver_state.available:
                     return False
-                elif membership_id is not None and not vehicle.membership.grant_access_to_membership_id(membership_id):
+                elif membership_id is not None and not vehicle.membership.grant_access_to_membership_id(
+                        membership_id):
                     return False
 
                 mechatronics = environment.mechatronics.get(vehicle.mechatronics_id)
                 range_remaining_km = mechatronics.range_remaining_km(vehicle)
 
                 # if we are at a base, do we have enough remaining range to leave the base?
-                if isinstance(vehicle.vehicle_state,
-                              ChargingBase) and range_remaining_km < base_charging_range_km_threshold:
+                if isinstance(
+                        vehicle.vehicle_state,
+                        ChargingBase) and range_remaining_km < base_charging_range_km_threshold:
                     return False
                 # do we have enough remaining range to allow us to match?
-                return bool(range_remaining_km > environment.config.dispatcher.matching_range_km_threshold)
+                return bool(
+                    range_remaining_km > environment.config.dispatcher.matching_range_km_threshold)
 
             def _valid_request(r: Request) -> bool:
                 not_already_dispatched = not r.dispatched_vehicle
@@ -69,8 +72,7 @@ class Dispatcher(NamedTuple, InstructionGenerator):
 
             # collect the vehicles and requests for the assignment algorithm
             available_vehicles = simulation_state.get_vehicles(
-                filter_function=_is_valid_for_dispatch,
-            )
+                filter_function=_is_valid_for_dispatch, )
 
             unassigned_requests = simulation_state.get_requests(
                 sort=True,

--- a/hive/dispatcher/instruction_generator/instruction_generator.py
+++ b/hive/dispatcher/instruction_generator/instruction_generator.py
@@ -15,12 +15,11 @@ class InstructionGenerator(metaclass=ABCNamedTupleMeta):
     """
     A module that produces a set of vehicle instructions based on the state of the simulation
     """
-
     @abstractmethod
     def generate_instructions(
-            self,
-            simulation_state: SimulationState,
-            environment: Environment,
+        self,
+        simulation_state: SimulationState,
+        environment: Environment,
     ) -> Tuple[InstructionGenerator, Tuple[Instruction, ...]]:
         """
         generates vehicle instructions which can perform vehicle state transitions

--- a/hive/external/demo_base_target/fleet_targets.py
+++ b/hive/external/demo_base_target/fleet_targets.py
@@ -22,14 +22,14 @@ class FleetTarget:
             self.base_target = self.base_target.sort_index().interpolate(method="index")
 
         return self.base_target[sim_time]
-    
+
     def get_station_target(self, sim_time: SimTime) -> int:
         if sim_time not in self.station_target:
             self.station_target.at[sim_time] = np.nan
             self.station_target = self.station_target.sort_index().interpolate(method="index")
 
         return self.station_target[sim_time]
-    
+
     def get_active_target(self, sim_time: SimTime) -> int:
         if sim_time not in self.active_target:
             self.active_target.at[sim_time] = np.nan

--- a/hive/external/miniosmnx/core.py
+++ b/hive/external/miniosmnx/core.py
@@ -11,9 +11,10 @@ from .geo_utils import overpass_json_from_file
 # useful osm tags - note that load_graphml expects a consistent set of tag names
 # for parsing
 USEFUL_TAGS_NODE = ['ref', 'highway']
-USEFUL_TAGS_PATH = ['bridge', 'tunnel', 'oneway', 'lanes', 'ref', 'name',
-                    'highway', 'maxspeed', 'service', 'access', 'area',
-                    'landuse', 'width', 'est_width', 'junction']
+USEFUL_TAGS_PATH = [
+    'bridge', 'tunnel', 'oneway', 'lanes', 'ref', 'name', 'highway', 'maxspeed', 'service',
+    'access', 'area', 'landuse', 'width', 'est_width', 'junction'
+]
 # all one-way mode to maintain original OSM node order
 # when constructing graphs specifically to save to .osm xml file
 ALL_ONEWAY = True
@@ -139,8 +140,9 @@ def add_edge_lengths(G):
 
     # first load all the edges' origin and destination coordinates as a
     # dataframe indexed by u, v, key
-    coords = np.array([[u, v, k, G.nodes[u]['y'], G.nodes[u]['x'], G.nodes[v]['y'], G.nodes[v]['x']] for u, v, k in
-                       G.edges(keys=True)])
+    coords = np.array(
+        [[u, v, k, G.nodes[u]['y'], G.nodes[u]['x'], G.nodes[v]['y'], G.nodes[v]['x']]
+         for u, v, k in G.edges(keys=True)])
     df_coords = pd.DataFrame(coords, columns=['u', 'v', 'k', 'u_y', 'u_x', 'v_y', 'v_x'])
     df_coords[['u', 'v', 'k']] = df_coords[['u', 'v', 'k']].astype(np.int64)
     df_coords = df_coords.set_index(['u', 'v', 'k'])
@@ -219,7 +221,7 @@ def add_paths(G, paths, bidirectional=False):
     """
 
     # the list of values OSM uses in its 'oneway' tag to denote True
-    # updated list of of values OSM uses based on https://www.geofabrik.de/de/data/geofabrik-osm-gis-standard-0.7.pdf 
+    # updated list of of values OSM uses based on https://www.geofabrik.de/de/data/geofabrik-osm-gis-standard-0.7.pdf
     osm_oneway_values = ['yes', 'true', '1', '-1', 'T', 'F']
 
     for data in paths.values():
@@ -231,7 +233,7 @@ def add_paths(G, paths, bidirectional=False):
         elif ('oneway' in data and data['oneway'] in osm_oneway_values) and not bidirectional:
             if data['oneway'] == '-1' or data['oneway'] == 'T':
                 # paths with a one-way value of -1 or T are one-way, but in the
-                # reverse direction of the nodes' order, see osm documentation 
+                # reverse direction of the nodes' order, see osm documentation
                 data['nodes'] = list(reversed(data['nodes']))
             # add this path (in only one direction) to the graph
             add_path(G, data, one_way=True)
@@ -312,8 +314,7 @@ def create_graph(response_jsons, name='unnamed', retain_all=False, bidirectional
     return G
 
 
-def graph_from_file(filename, bidirectional=False,
-                    retain_all=False, name='unnamed'):
+def graph_from_file(filename, bidirectional=False, retain_all=False, name='unnamed'):
     """
     Create a networkx graph from OSM data in an XML file.
 
@@ -338,7 +339,6 @@ def graph_from_file(filename, bidirectional=False,
     response_jsons = [overpass_json_from_file(filename)]
 
     # create graph using this response JSON
-    G = create_graph(response_jsons, bidirectional=bidirectional,
-                     retain_all=retain_all, name=name)
+    G = create_graph(response_jsons, bidirectional=bidirectional, retain_all=retain_all, name=name)
 
     return G

--- a/hive/external/miniosmnx/geo_utils.py
+++ b/hive/external/miniosmnx/geo_utils.py
@@ -35,7 +35,7 @@ def great_circle_vec(lat1, lng1, lat2, lng2, earth_radius=6371009):
     theta2 = np.deg2rad(lng2)
     d_theta = theta2 - theta1
 
-    h = np.sin(d_phi / 2) ** 2 + np.cos(phi1) * np.cos(phi2) * np.sin(d_theta / 2) ** 2
+    h = np.sin(d_phi / 2)**2 + np.cos(phi1) * np.cos(phi2) * np.sin(d_theta / 2)**2
     h = np.minimum(1.0, h)  # protect against floating point errors
 
     arc = 2 * np.arcsin(np.sqrt(h))
@@ -53,22 +53,21 @@ class OSMContentHandler(xml.sax.handler.ContentHandler):
     notes, see http://wiki.openstreetmap.org/wiki/OSM_XML#OSM_XML_file_format_notes
     and http://overpass-api.de/output_formats.html#json
     """
-
     def __init__(self):
         self._element = None
         self.object = {'elements': []}
 
     def startElement(self, name, attrs):
         if name == 'osm':
-            self.object.update({k: attrs[k] for k in attrs.keys()
-                                if k in ('version', 'generator')})
+            self.object.update({k: attrs[k] for k in attrs.keys() if k in ('version', 'generator')})
 
         elif name in ('node', 'way'):
             self._element = dict(type=name, tags={}, nodes=[], **attrs)
-            self._element.update({k: float(attrs[k]) for k in attrs.keys()
-                                  if k in ('lat', 'lon')})
-            self._element.update({k: int(attrs[k]) for k in attrs.keys()
-                                  if k in ('id', 'uid', 'version', 'changeset')})
+            self._element.update({k: float(attrs[k]) for k in attrs.keys() if k in ('lat', 'lon')})
+            self._element.update({
+                k: int(attrs[k])
+                for k in attrs.keys() if k in ('id', 'uid', 'version', 'changeset')
+            })
 
         elif name == 'tag':
             self._element['tags'].update({attrs['k']: attrs['v']})
@@ -110,13 +109,11 @@ def induce_subgraph(G, node_subset):
 
     # copy edges to new graph, including parallel edges
     if G2.is_multigraph:
-        G2.add_edges_from((n, nbr, key, d)
-                          for n, nbrs in G.adj.items() if n in node_subset
+        G2.add_edges_from((n, nbr, key, d) for n, nbrs in G.adj.items() if n in node_subset
                           for nbr, keydict in nbrs.items() if nbr in node_subset
                           for key, d in keydict.items())
     else:
-        G2.add_edges_from((n, nbr, d)
-                          for n, nbrs in G.adj.items() if n in node_subset
+        G2.add_edges_from((n, nbr, d) for n, nbrs in G.adj.items() if n in node_subset
                           for nbr, d in nbrs.items() if nbr in node_subset)
 
     # update graph attribute dict, and return graph
@@ -149,7 +146,6 @@ def get_largest_component(G, strongly=False):
             sccs = nx.strongly_connected_components(G)
             largest_scc = max(sccs, key=len)
             G = induce_subgraph(G, largest_scc)
-
 
     else:
         # if the graph is not connected retain only the largest weakly connected component

--- a/hive/external/nyc_tlc/nyc_tlc_parsers.py
+++ b/hive/external/nyc_tlc/nyc_tlc_parsers.py
@@ -63,23 +63,16 @@ def parse_yellow_tripdata_row(row: Dict[str, str],
         passengers = int(row['passengers']) if 'passengers' in row else default_passengers
 
         request_as_passengers = [
-            Passenger(
-                create_passenger_id(agent_id, pass_idx),
-                origin_link.start,
-                destination_link.end,
-                departure_time
-            )
-            for pass_idx in range(0, passengers)
+            Passenger(create_passenger_id(agent_id, pass_idx), origin_link.start,
+                      destination_link.end, departure_time) for pass_idx in range(0, passengers)
         ]
 
-        return Request(
-            id=agent_id,
-            origin_link=origin_link,
-            destination_link=destination_link,
-            departure_time=departure_time,
-            cancel_time=cancel_time,
-            passengers=tuple(request_as_passengers)
-        )
+        return Request(id=agent_id,
+                       origin_link=origin_link,
+                       destination_link=destination_link,
+                       departure_time=departure_time,
+                       cancel_time=cancel_time,
+                       passengers=tuple(request_as_passengers))
 
     except Exception as e:
         return e

--- a/hive/external/nyc_tlc/nyc_tlc_sampler.py
+++ b/hive/external/nyc_tlc/nyc_tlc_sampler.py
@@ -39,23 +39,15 @@ def down_sample_nyc_tlc_data(in_file: str,
         # needs to be a Polygon, not a MultiPolygon feature
         # used for ETL to confirm that requests sampled are in fact within the study area (some are not)
         geojson = json.load(f)
-        hexes = h3.polyfill(
-            geojson=geojson['geometry'],
-            res=boundary_h3_resolution,
-            geo_json_conformant=True
-        )
+        hexes = h3.polyfill(geojson=geojson['geometry'],
+                            res=boundary_h3_resolution,
+                            geo_json_conformant=True)
 
         with open(in_file) as f:
             with open(out_file, 'w', newline='') as w:
                 reader = DictReader(f)
                 header = [
-                    'request_id',
-                    'o_lat',
-                    'o_lon',
-                    'd_lat',
-                    'd_lon',
-                    'departure_time',
-                    'passengers'
+                    'request_id', 'o_lat', 'o_lon', 'd_lat', 'd_lon', 'departure_time', 'passengers'
                 ]
 
                 writer = DictWriter(w, header)
@@ -69,14 +61,11 @@ def down_sample_nyc_tlc_data(in_file: str,
                 while recorded_count < sample_size and attempted_count < absolute_cutoff:
                     # parse the next row of data
                     row = next(reader)
-                    req = parse_yellow_tripdata_row(
-                        row,
-                        recorded_count,
-                        request_cancel_time_buffer,
-                        sim_h3_location_resolution
-                    )
+                    req = parse_yellow_tripdata_row(row, recorded_count, request_cancel_time_buffer,
+                                                    sim_h3_location_resolution)
 
-                    if not isinstance(req, Exception) and h3.h3_to_parent(req.geoid, boundary_h3_resolution) in hexes:
+                    if not isinstance(req, Exception) and h3.h3_to_parent(
+                            req.geoid, boundary_h3_resolution) in hexes:
                         # request_id,o_lat,o_lon,d_lat,d_lon,departure_time,cancel_time,passengers
                         out_row = {
                             'request_id': req.id,
@@ -93,16 +82,13 @@ def down_sample_nyc_tlc_data(in_file: str,
                         print(f"row for id {recorded_count} failed: {row}")
 
     if attempted_count == absolute_cutoff:
-        raise IOError(f"too many errors, input_config file {in_file} (and corresponding file {out_file}) may be corrupt")
+        raise IOError(
+            f"too many errors, input_config file {in_file} (and corresponding file {out_file}) may be corrupt"
+        )
 
 
-def sample_vehicles_in_geofence(num: int,
-                                out_file: str,
-                                powertrain_id: str,
-                                powercurve_id: str,
-                                capacity: KwH,
-                                initial_soc: float,
-                                ideal_energy_limit: KwH,
+def sample_vehicles_in_geofence(num: int, out_file: str, powertrain_id: str, powercurve_id: str,
+                                capacity: KwH, initial_soc: float, ideal_energy_limit: KwH,
                                 max_charge_acceptance_kw: Kw):
     """
     samples points in the NYC polygon and creates Vehicles from them, writing to an output file
@@ -129,15 +115,13 @@ def sample_vehicles_in_geofence(num: int,
 
         # needs to be a Polygon, not a MultiPolygon feature
         geojson = json.load(f)
-        hexes = list(h3.polyfill(
-            geojson=geojson['geometry'],
-            res=10,
-            geo_json_conformant=True)
-        )
+        hexes = list(h3.polyfill(geojson=geojson['geometry'], res=10, geo_json_conformant=True))
 
         with open(out_file, 'w', newline='') as w:
-            header = ["vehicle_id", "lat", "lon", "powertrain_id", "powercurve_id", "capacity", "ideal_energy_limit",
-                      "max_charge_acceptance", "initial_soc"]
+            header = [
+                "vehicle_id", "lat", "lon", "powertrain_id", "powercurve_id", "capacity",
+                "ideal_energy_limit", "max_charge_acceptance", "initial_soc"
+            ]
 
             writer = DictWriter(w, header)
             writer.writeheader()

--- a/hive/initialization/initialize_ops.py
+++ b/hive/initialization/initialize_ops.py
@@ -26,9 +26,10 @@ def process_fleet_file(fleet_file: str, entity_type: str) -> MembershipMap:
         for fleet_id in config_dict:
             for entity_id in config_dict[fleet_id][entity_type]:
                 if entity_id in fleet_id_map_mutation:
-                    fleet_id_map_mutation[entity_id] = fleet_id_map_mutation[entity_id] + (fleet_id,)
+                    fleet_id_map_mutation[entity_id] = fleet_id_map_mutation[entity_id] + (
+                        fleet_id, )
                 else:
-                    fleet_id_map_mutation.set(entity_id, (fleet_id,))
+                    fleet_id_map_mutation.set(entity_id, (fleet_id, ))
         fleet_id_map = fleet_id_map_mutation.finish()
     return fleet_id_map
 

--- a/hive/initialization/initialize_simulation.py
+++ b/hive/initialization/initialize_simulation.py
@@ -98,12 +98,12 @@ def initialize_simulation(
                               chargers=build_chargers_table(config.input_config.chargers_file),
                               schedules=build_schedules_table(config.sim.schedule_type,
                                                               config.input_config.schedules_file),
-                              fleet_ids=fleet_ids
-                              )
+                              fleet_ids=fleet_ids)
 
     # populate simulation with entities
-    sim_with_vehicles, env_updated = _build_vehicles(config.input_config.vehicles_file, vehicle_member_ids, 
-                                                     sim_initial, env_initial, vehicle_filter)
+    sim_with_vehicles, env_updated = _build_vehicles(config.input_config.vehicles_file,
+                                                     vehicle_member_ids, sim_initial, env_initial,
+                                                     vehicle_filter)
     sim_with_bases = _build_bases(config.input_config.bases_file, base_member_ids,
                                   sim_with_vehicles, base_filter)
     sim_with_stations = _build_stations(config.input_config.stations_file, station_member_ids,
@@ -137,7 +137,7 @@ def _build_vehicles(
 
         sim, env = payload
         veh = Vehicle.from_row(row, sim.road_network, env)
-                              
+
         if not vehicle_filter(veh):
             return sim, env
 

--- a/hive/initialization/initialize_simulation_with_sampling.py
+++ b/hive/initialization/initialize_simulation_with_sampling.py
@@ -38,11 +38,11 @@ log = logging.getLogger(__name__)
 
 
 def initialize_simulation_with_sampling(
-        config: HiveConfig,
-        vehicle_count: int,
-        vehicle_location_sampling_function: Optional[Callable[..., Link]] = None,
-        vehicle_soc_sampling_function: Optional[Callable[..., Ratio]] = None,
-        random_seed: int = 0,
+    config: HiveConfig,
+    vehicle_count: int,
+    vehicle_location_sampling_function: Optional[Callable[..., Link]] = None,
+    vehicle_soc_sampling_function: Optional[Callable[..., Ratio]] = None,
+    random_seed: int = 0,
 ) -> Tuple[SimulationState, Environment]:
     """
     constructs a SimulationState and Environment with sampled vehicles.
@@ -66,7 +66,8 @@ def initialize_simulation_with_sampling(
 
     # set up road network based on user-configured road network type
     if config.network.network_type == 'euclidean':
-        road_network = HaversineRoadNetwork(geofence=geofence, sim_h3_resolution=config.sim.sim_h3_resolution)
+        road_network = HaversineRoadNetwork(geofence=geofence,
+                                            sim_h3_resolution=config.sim.sim_h3_resolution)
     elif config.network.network_type == 'osm_network':
         road_network = OSMRoadNetwork(
             geofence=geofence,
@@ -76,7 +77,8 @@ def initialize_simulation_with_sampling(
         )
     else:
         raise IOError(
-            f"road network type {config.network.network_type} not valid, must be one of {{euclidean|osm_network}}")
+            f"road network type {config.network.network_type} not valid, must be one of {{euclidean|osm_network}}"
+        )
 
     # initial sim state with road network and no entities
     sim_initial = SimulationState(
@@ -84,21 +86,21 @@ def initialize_simulation_with_sampling(
         sim_time=config.sim.start_time,
         sim_timestep_duration_seconds=config.sim.timestep_duration_seconds,
         sim_h3_location_resolution=config.sim.sim_h3_resolution,
-        sim_h3_search_resolution=config.sim.sim_h3_search_resolution
-    )
+        sim_h3_search_resolution=config.sim.sim_h3_search_resolution)
 
     # create simulation environment
     if config.input_config.fleets_file:
         log.warning("the simulation is using sampling which doesn't support a fleet file input;\n"
                     "this input will be ignored and entities will not have any fleet information.")
 
-    env = Environment(config=config,
-                      mechatronics=build_mechatronics_table(config.input_config.mechatronics_file,
-                                                            config.input_config.scenario_directory),
-                      chargers=build_chargers_table(config.input_config.chargers_file),
-                      schedules=build_schedules_table(config.sim.schedule_type,
-                                                      config.input_config.schedules_file),
-                      )
+    env = Environment(
+        config=config,
+        mechatronics=build_mechatronics_table(config.input_config.mechatronics_file,
+                                              config.input_config.scenario_directory),
+        chargers=build_chargers_table(config.input_config.chargers_file),
+        schedules=build_schedules_table(config.sim.schedule_type,
+                                        config.input_config.schedules_file),
+    )
 
     # populate simulation with static entities
     sim_with_bases = _build_bases(config.input_config.bases_file, sim_initial)
@@ -126,9 +128,10 @@ def initialize_simulation_with_sampling(
     return sim_w_vehicles, env
 
 
-def _build_bases(bases_file: str,
-                 simulation_state: SimulationState,
-                 ) -> SimulationState:
+def _build_bases(
+    bases_file: str,
+    simulation_state: SimulationState,
+) -> SimulationState:
     """
     all your base are belong to us
 
@@ -137,7 +140,6 @@ def _build_bases(bases_file: str,
     :return: the simulation state with all bases in it
     :raises Exception if a parse error in Base.from_row or any error adding the Base to the Sim
     """
-
     def _add_row_unsafe(sim: SimulationState, row: Dict[str, str]) -> SimulationState:
         base = Base.from_row(row, simulation_state.road_network)
         error, updated_sim = simulation_state_ops.add_base(sim, base)
@@ -155,9 +157,10 @@ def _build_bases(bases_file: str,
     return sim_with_bases
 
 
-def _build_stations(stations_file: str,
-                    simulation_state: SimulationState,
-                    ) -> SimulationState:
+def _build_stations(
+    stations_file: str,
+    simulation_state: SimulationState,
+) -> SimulationState:
     """
     all your station are belong to us
 
@@ -166,8 +169,8 @@ def _build_stations(stations_file: str,
     :return: the resulting simulation state with all stations in it
     :raises Exception if parsing a Station row failed or adding a Station to the Simulation failed
     """
-
-    def _add_row_unsafe(builder: immutables.Map[str, Station], row: Dict[str, str]) -> immutables.Map[str, Station]:
+    def _add_row_unsafe(builder: immutables.Map[str, Station],
+                        row: Dict[str, str]) -> immutables.Map[str, Station]:
         station = Station.from_row(row, builder, simulation_state.road_network)
         updated_builder = DictOps.add_to_dict(builder, station.id, station)
         return updated_builder

--- a/hive/initialization/load.py
+++ b/hive/initialization/load.py
@@ -45,15 +45,19 @@ def load_simulation(scenario_file_path: Path) -> Tuple[SimulationState, Environm
     # configure reporting
     reporter = Reporter()
     if config.global_config.log_events:
-        reporter.add_handler(EventfulHandler(config.global_config, config.scenario_output_directory))
+        reporter.add_handler(EventfulHandler(config.global_config,
+                                             config.scenario_output_directory))
     if config.global_config.log_states:
-        reporter.add_handler(StatefulHandler(config.global_config, config.scenario_output_directory))
+        reporter.add_handler(StatefulHandler(config.global_config,
+                                             config.scenario_output_directory))
     if config.global_config.log_instructions:
-        reporter.add_handler(InstructionHandler(config.global_config, config.scenario_output_directory))
+        reporter.add_handler(
+            InstructionHandler(config.global_config, config.scenario_output_directory))
     if config.global_config.log_stats:
         reporter.add_handler(StatsHandler())
     if config.global_config.log_time_step_stats or config.global_config.log_fleet_time_step_stats:
-        reporter.add_handler(TimeStepStatsHandler(config, config.scenario_output_directory, environment.fleet_ids))
+        reporter.add_handler(
+            TimeStepStatsHandler(config, config.scenario_output_directory, environment.fleet_ids))
 
     environment_w_reporter = environment.set_reporter(reporter)
 

--- a/hive/initialization/sample_requests.py
+++ b/hive/initialization/sample_requests.py
@@ -7,13 +7,11 @@ from hive.state.simulation_state.simulation_state import SimulationState
 from hive.model.roadnetwork.osm.osm_roadnetwork import OSMRoadNetwork
 
 
-def default_request_sampler(
-        count: int,
-        simulation_state: SimulationState,
-        environment: Environment,
-        allow_pooling: bool = False,
-        random_seed: int = 0
-) -> Tuple[Request, ...]:
+def default_request_sampler(count: int,
+                            simulation_state: SimulationState,
+                            environment: Environment,
+                            allow_pooling: bool = False,
+                            random_seed: int = 0) -> Tuple[Request, ...]:
     """
     samples `count` requests uniformly across time and space
 
@@ -31,11 +29,12 @@ def default_request_sampler(
 
     requests = []
 
-    possible_timesteps = list(range(
-        int(environment.config.sim.start_time),
-        int(environment.config.sim.end_time),
-        environment.config.sim.timestep_duration_seconds,
-    ))
+    possible_timesteps = list(
+        range(
+            int(environment.config.sim.start_time),
+            int(environment.config.sim.end_time),
+            environment.config.sim.timestep_duration_seconds,
+        ))
     possible_links = list(simulation_state.road_network.link_helper.links.values())
 
     id_counter = 0
@@ -47,15 +46,13 @@ def default_request_sampler(
             # skip if the request starts and ends at the same location
             continue
 
-        request = Request.build(
-            request_id="r" + str(id_counter),
-            origin=random_source_link.start,
-            destination=random_destination_link.end,
-            road_network=simulation_state.road_network,
-            departure_time=random.choice(possible_timesteps),
-            passengers=random.choice([1, 2, 3, 4]),
-            allows_pooling=allow_pooling
-        )
+        request = Request.build(request_id="r" + str(id_counter),
+                                origin=random_source_link.start,
+                                destination=random_destination_link.end,
+                                road_network=simulation_state.road_network,
+                                departure_time=random.choice(possible_timesteps),
+                                passengers=random.choice([1, 2, 3, 4]),
+                                allows_pooling=allow_pooling)
 
         requests.append(request)
 

--- a/hive/initialization/sample_vehicles.py
+++ b/hive/initialization/sample_vehicles.py
@@ -21,13 +21,13 @@ log = logging.getLogger(__name__)
 
 
 def sample_vehicles(
-        count: int,
-        sim: SimulationState,
-        env: Environment,
-        location_sampling_function: Callable[[SimulationState], Link],
-        soc_sampling_function: Callable[[], Ratio],
-        total_seats: int = 4,
-        offset: int = 0,
+    count: int,
+    sim: SimulationState,
+    env: Environment,
+    location_sampling_function: Callable[[SimulationState], Link],
+    soc_sampling_function: Callable[[], Ratio],
+    total_seats: int = 4,
+    offset: int = 0,
 ) -> Result[SimulationState, Exception]:
     """
     creates {count} vehicles using the provided sampling functions
@@ -54,7 +54,6 @@ def sample_vehicles(
             :param i: the number to associate with this sampled vehicle
             :return: a function that adds vehicle i to the SimulationState
             """
-
             def _inner(s: SimulationState) -> Result[SimulationState, Exception]:
                 """
                 attempts to add the i'th vehicle to this simulation state
@@ -70,15 +69,13 @@ def sample_vehicles(
                     position = EntityPosition(link.link_id, link.start)
                     vehicle_state = Idle(vehicle_id)
                     driver_state = AutonomousAvailable(AutonomousDriverAttributes(vehicle_id))
-                    vehicle = Vehicle(
-                        id=vehicle_id,
-                        mechatronics_id=mechatronics_id,
-                        energy=energy,
-                        position=position,
-                        vehicle_state=vehicle_state,
-                        driver_state=driver_state,
-                        total_seats=total_seats
-                    )
+                    vehicle = Vehicle(id=vehicle_id,
+                                      mechatronics_id=mechatronics_id,
+                                      energy=energy,
+                                      position=position,
+                                      vehicle_state=vehicle_state,
+                                      driver_state=driver_state,
+                                      total_seats=total_seats)
                     add_result = add_vehicle_returns(s, vehicle)
                     return add_result
                 except Exception as e:
@@ -87,15 +84,14 @@ def sample_vehicles(
             return _inner
 
         log.info(
-            f"sampling vehicles {offset} through {offset + count - 1} ({count} vehicles) with mechatronics id {mechatronics_id}")
+            f"sampling vehicles {offset} through {offset + count - 1} ({count} vehicles) with mechatronics id {mechatronics_id}"
+        )
 
         # sample i vehicles, adding each to the sim
         # fail fast if an exception is encountered
-        result: Result[SimulationState, Exception] = ft.reduce(
-            lambda acc, i: acc.bind(_add_sample(i)),
-            range(offset, offset + count),
-            Success(sim)
-        )
+        result: Result[SimulationState,
+                       Exception] = ft.reduce(lambda acc, i: acc.bind(_add_sample(i)),
+                                              range(offset, offset + count), Success(sim))
 
         return result
 
@@ -113,7 +109,8 @@ def build_default_location_sampling_fn(seed: int = 0) -> Callable[[], Link]:
 
     def _inner(sim: SimulationState) -> Link:
         if not isinstance(sim.road_network, OSMRoadNetwork):
-            raise NotImplementedError(f"this sampling function is only implemented for the OSMRoadNetwork")
+            raise NotImplementedError(
+                f"this sampling function is only implemented for the OSMRoadNetwork")
         links = list(sim.road_network.link_helper.links.values())
         if len(links) == 0:
             raise AssertionError(f"must have at least one link to sample from")
@@ -123,8 +120,9 @@ def build_default_location_sampling_fn(seed: int = 0) -> Callable[[], Link]:
     return _inner
 
 
-def build_default_soc_sampling_fn(lower_bound: Ratio = 1.0, upper_bound: Ratio = 1.0, seed: int = 0) -> Callable[
-    [], Ratio]:
+def build_default_soc_sampling_fn(lower_bound: Ratio = 1.0,
+                                  upper_bound: Ratio = 1.0,
+                                  seed: int = 0) -> Callable[[], Ratio]:
     """
     constructs an SoC sampling function that uniformly samples between a lower and upper bound value
 
@@ -135,10 +133,14 @@ def build_default_soc_sampling_fn(lower_bound: Ratio = 1.0, upper_bound: Ratio =
     """
     assert lower_bound <= upper_bound, ArithmeticError(
         f"lower bound {lower_bound} must be less than or equal to upper bound {upper_bound}")
-    assert lower_bound >= 0, ArithmeticError(f"lower bound {lower_bound} must be in the range [0, 1]")
-    assert lower_bound <= 1, ArithmeticError(f"lower bound {lower_bound} must be in the range [0, 1]")
-    assert upper_bound >= 0, ArithmeticError(f"upper bound {upper_bound} must be in the range [0, 1]")
-    assert upper_bound <= 1, ArithmeticError(f"upper bound {upper_bound} must be in the range [0, 1]")
+    assert lower_bound >= 0, ArithmeticError(
+        f"lower bound {lower_bound} must be in the range [0, 1]")
+    assert lower_bound <= 1, ArithmeticError(
+        f"lower bound {lower_bound} must be in the range [0, 1]")
+    assert upper_bound >= 0, ArithmeticError(
+        f"upper bound {upper_bound} must be in the range [0, 1]")
+    assert upper_bound <= 1, ArithmeticError(
+        f"upper bound {upper_bound} must be in the range [0, 1]")
     random.seed(seed)
 
     def _inner() -> Ratio:

--- a/hive/model/base.py
+++ b/hive/model/base.py
@@ -50,17 +50,16 @@ class Base(NamedTuple):
               road_network: RoadNetwork,
               station_id: Optional[StationId],
               stall_count: int,
-              membership: Membership = Membership()
-              ):
+              membership: Membership = Membership()):
 
         position = road_network.position_from_geoid(geoid)
         return Base(id, position, stall_count, stall_count, station_id, membership)
 
     @classmethod
     def from_row(
-            cls,
-            row: Dict[str, str],
-            road_network: RoadNetwork,
+        cls,
+        row: Dict[str, str],
+        road_network: RoadNetwork,
     ) -> Base:
         """
         converts a csv row to a base
@@ -99,7 +98,8 @@ class Base(NamedTuple):
                 )
 
             except ValueError:
-                raise IOError(f"unable to parse request {base_id} from row due to invalid value(s): {row}")
+                raise IOError(
+                    f"unable to parse request {base_id} from row due to invalid value(s): {row}")
 
     def has_available_stall(self, membership: Membership) -> bool:
         """
@@ -107,7 +107,8 @@ class Base(NamedTuple):
 
         :return: Boolean
         """
-        return bool(self.available_stalls > 0) and self.membership.grant_access_to_membership(membership)
+        return bool(
+            self.available_stalls > 0) and self.membership.grant_access_to_membership(membership)
 
     def checkout_stall(self) -> Optional[Base]:
         """
@@ -129,7 +130,8 @@ class Base(NamedTuple):
         """
         stalls = self.available_stalls
         if (stalls + 1) > self.total_stalls:
-            return SimulationStateError(f'base {self.id} already has max ({self.total_stalls}) stalls'), None
+            return SimulationStateError(
+                f'base {self.id} already has max ({self.total_stalls}) stalls'), None
         else:
             return None, self._replace(available_stalls=stalls + 1)
 

--- a/hive/model/energy/charger/__init__.py
+++ b/hive/model/energy/charger/__init__.py
@@ -40,10 +40,14 @@ def build_chargers_table(chargers_file: str) -> Dict[ChargerId, Charger]:
                     try:
                         rate = float(rate_str)
                     except TypeError as e:
-                        raise TypeError(f"unable to parse charger rate as number for row {row}") from e
+                        raise TypeError(
+                            f"unable to parse charger rate as number for row {row}") from e
                     energy_type = EnergyType.from_string(energy_type_srt)
                     if not energy_type:
                         raise TypeError(f"unable to parse energy type for row {row}")
-                    new_charger = Charger(id=charger_id, energy_type=energy_type, rate=rate, units=units)
+                    new_charger = Charger(id=charger_id,
+                                          energy_type=energy_type,
+                                          rate=rate,
+                                          units=units)
                     chargers_table.update({charger_id: new_charger})
         return chargers_table

--- a/hive/model/energy/energytype.py
+++ b/hive/model/energy/energytype.py
@@ -13,10 +13,7 @@ class EnergyType(Enum):
 
     @classmethod
     def from_string(cls, s: str) -> Optional[EnergyType]:
-        values = {
-            "electric": cls.ELECTRIC,
-            "gasoline": cls.GASOLINE
-        }
+        values = {"electric": cls.ELECTRIC, "gasoline": cls.GASOLINE}
         if s in values.keys():
             return values[s]
         else:

--- a/hive/model/membership.py
+++ b/hive/model/membership.py
@@ -36,7 +36,7 @@ class Membership(NamedTuple):
         """
         if membership_id == PUBLIC_MEMBERSHIP_ID:
             raise TypeError(f"{PUBLIC_MEMBERSHIP_ID} is reserved, please use another membership id")
-        return Membership(frozenset((membership_id,)))
+        return Membership(frozenset((membership_id, )))
 
     @property
     def public(self) -> bool:

--- a/hive/model/passenger.py
+++ b/hive/model/passenger.py
@@ -59,7 +59,8 @@ def create_passenger_id(request_id: RequestId, passenger_id: int) -> PassengerId
     return f"{request_id}-{passenger_id}"
 
 
-def board_vehicle(passengers: Tuple[Passenger, ...], vehicle_id: VehicleId) -> Tuple[Passenger, ...]:
+def board_vehicle(passengers: Tuple[Passenger, ...],
+                  vehicle_id: VehicleId) -> Tuple[Passenger, ...]:
     """
     updates each passenger with a vehicle_id
 
@@ -67,4 +68,4 @@ def board_vehicle(passengers: Tuple[Passenger, ...], vehicle_id: VehicleId) -> T
     :param vehicle_id: the vehicle they are boarding
     :return: the passengers with their vehicle_id updated
     """
-    return ft.reduce(lambda acc, p: acc + (p.add_vehicle_id(vehicle_id),), passengers, ())
+    return ft.reduce(lambda acc, p: acc + (p.add_vehicle_id(vehicle_id), ), passengers, ())

--- a/hive/model/request/request.py
+++ b/hive/model/request/request.py
@@ -64,8 +64,7 @@ class Request(NamedTuple):
               passengers: int,
               allows_pooling: bool,
               fleet_id: Optional[MembershipId] = None,
-              value: Currency = 0
-              ) -> Request:
+              value: Currency = 0) -> Request:
         assert (departure_time >= 0)
         assert (passengers > 0)
         origin_position = road_network.position_from_geoid(origin)
@@ -76,14 +75,11 @@ class Request(NamedTuple):
             membership = Membership()
 
         request_as_passengers = [
-            Passenger(
-                id=create_passenger_id(request_id, pass_idx),
-                origin=origin_position.geoid,
-                destination=destination_position.geoid,
-                departure_time=departure_time,
-                membership=membership
-            )
-            for pass_idx in range(0, passengers)
+            Passenger(id=create_passenger_id(request_id, pass_idx),
+                      origin=origin_position.geoid,
+                      destination=destination_position.geoid,
+                      departure_time=departure_time,
+                      membership=membership) for pass_idx in range(0, passengers)
         ]
 
         request = Request(
@@ -103,8 +99,7 @@ class Request(NamedTuple):
         return self.origin
 
     @classmethod
-    def from_row(cls, row: Dict[str, str],
-                 env: Environment,
+    def from_row(cls, row: Dict[str, str], env: Environment,
                  road_network: RoadNetwork) -> Tuple[Optional[Exception], Optional[Request]]:
         """
         takes a csv row and turns it into a Request
@@ -146,21 +141,22 @@ class Request(NamedTuple):
                     return departure_time_result, None
 
                 passengers = int(row['passengers'])
-                allows_pooling = bool(row['allows_pooling']) if row.get('allows_pooling') is not None else False
+                allows_pooling = bool(
+                    row['allows_pooling']) if row.get('allows_pooling') is not None else False
 
-                request = Request.build(
-                    request_id=request_id,
-                    fleet_id=fleet_id,
-                    origin=o_geoid,
-                    destination=d_geoid,
-                    road_network=road_network,
-                    departure_time=departure_time_result,
-                    passengers=passengers,
-                    allows_pooling=allows_pooling
-                )
+                request = Request.build(request_id=request_id,
+                                        fleet_id=fleet_id,
+                                        origin=o_geoid,
+                                        destination=d_geoid,
+                                        road_network=road_network,
+                                        departure_time=departure_time_result,
+                                        passengers=passengers,
+                                        allows_pooling=allows_pooling)
                 return None, request
             except ValueError:
-                return IOError(f"unable to parse request {request_id} from row due to invalid value(s): {row}"), None
+                return IOError(
+                    f"unable to parse request {request_id} from row due to invalid value(s): {row}"
+                ), None
 
     def assign_dispatched_vehicle(self, vehicle_id: VehicleId, current_time: SimTime) -> Request:
         """
@@ -183,7 +179,8 @@ class Request(NamedTuple):
         updated = self._replace(dispatched_vehicle=None, dispatched_vehicle_time=None)
         return updated
 
-    def assign_value(self, rate_structure: RequestRateStructure, road_network: RoadNetwork) -> Request:
+    def assign_value(self, rate_structure: RequestRateStructure,
+                     road_network: RoadNetwork) -> Request:
         """
         used to assign a value to this request based on it's properties as well as possible surge pricing.
 

--- a/hive/model/roadnetwork/geofence.py
+++ b/hive/model/roadnetwork/geofence.py
@@ -21,10 +21,11 @@ class GeoFence(NamedTuple):
 
     @classmethod
     def from_geojson(cls, geojson: Dict, h3_resolution: H3Resolution = 10) -> GeoFence:
-        geofence_set = frozenset(h3.polyfill(
-            geojson=geojson['features'][0]['geometry'] if 'features' in geojson else geojson['geometry'],
-            res=h3_resolution,
-            geo_json_conformant=True))
+        geofence_set = frozenset(
+            h3.polyfill(geojson=geojson['features'][0]['geometry']
+                        if 'features' in geojson else geojson['geometry'],
+                        res=h3_resolution,
+                        geo_json_conformant=True))
 
         return GeoFence(
             geofence_set=geofence_set,

--- a/hive/model/roadnetwork/haversine_roadnetwork.py
+++ b/hive/model/roadnetwork/haversine_roadnetwork.py
@@ -36,9 +36,9 @@ class HaversineRoadNetwork(RoadNetwork):
     _AVG_SPEED_KMPH = 40  # kilometer / hour
 
     def __init__(
-            self,
-            geofence: Optional[GeoFence] = None,
-            sim_h3_resolution: H3Resolution = 15,
+        self,
+        geofence: Optional[GeoFence] = None,
+        sim_h3_resolution: H3Resolution = 15,
     ):
         self.sim_h3_resolution = sim_h3_resolution
         self.geofence = geofence
@@ -54,7 +54,7 @@ class HaversineRoadNetwork(RoadNetwork):
             speed_kmph=self._AVG_SPEED_KMPH,
         )
 
-        route = (link,)
+        route = (link, )
 
         return route
 

--- a/hive/model/roadnetwork/link.py
+++ b/hive/model/roadnetwork/link.py
@@ -51,12 +51,12 @@ class Link(NamedTuple):
 
     @classmethod
     def build(
-            cls,
-            link_id: LinkId,
-            start: GeoId,
-            end: GeoId,
-            speed_kmph: Kmph,
-            distance_km: Optional[Kilometers] = None,
+        cls,
+        link_id: LinkId,
+        start: GeoId,
+        end: GeoId,
+        speed_kmph: Kmph,
+        distance_km: Optional[Kilometers] = None,
     ) -> Link:
         if not distance_km:
             distance_km = H3Ops.great_circle_distance(start, end)

--- a/hive/model/roadnetwork/link_id.py
+++ b/hive/model/roadnetwork/link_id.py
@@ -5,6 +5,7 @@ import re
 
 NodeId = TypeVar('NodeId')
 
+
 def create_link_id(src: int, dst: int) -> LinkId:
     """
     creates a LinkId from its source and destination node ids
@@ -15,7 +16,8 @@ def create_link_id(src: int, dst: int) -> LinkId:
     return f"{src}-{dst}"
 
 
-def extract_node_ids(link_id: LinkId) -> Tuple[Optional[Exception], Optional[Tuple[NodeId, NodeId]]]:
+def extract_node_ids(
+        link_id: LinkId) -> Tuple[Optional[Exception], Optional[Tuple[NodeId, NodeId]]]:
     """
     expects the provided string is of the form {src_node_id}-{dst_node_id}
     :param link_id: a string that is a LinkId
@@ -25,7 +27,9 @@ def extract_node_ids(link_id: LinkId) -> Tuple[Optional[Exception], Optional[Tup
     if len(result) < 2:
         return Exception(f"LinkId {link_id} does not take the form src_node_id-dst_node_id"), None
     elif len(result) > 2:
-        return Exception(f"LinkId {link_id} can only have one dash (-) character in the form src_node_id-dst_node_id"), None
+        return Exception(
+            f"LinkId {link_id} can only have one dash (-) character in the form src_node_id-dst_node_id"
+        ), None
     else:
         try:
             src = literal_eval(result[0])

--- a/hive/model/roadnetwork/linktraversal.py
+++ b/hive/model/roadnetwork/linktraversal.py
@@ -22,12 +22,12 @@ class LinkTraversal(NamedTuple):
 
     @classmethod
     def build(
-            cls,
-            link_id: LinkId,
-            start: GeoId,
-            end: GeoId,
-            speed_kmph: Kmph,
-            distance_km: Optional[Kilometers] = None,
+        cls,
+        link_id: LinkId,
+        start: GeoId,
+        end: GeoId,
+        speed_kmph: Kmph,
+        distance_km: Optional[Kilometers] = None,
     ) -> LinkTraversal:
         if not distance_km:
             distance_km = H3Ops.great_circle_distance(start, end)
@@ -88,8 +88,9 @@ class LinkTraversalResult(NamedTuple):
     remaining_time_seconds: Seconds
 
 
-def traverse_up_to(link: LinkTraversal,
-                   available_time_seconds: Seconds) -> Tuple[Optional[Exception], Optional[LinkTraversalResult]]:
+def traverse_up_to(
+        link: LinkTraversal, available_time_seconds: Seconds
+) -> Tuple[Optional[Exception], Optional[LinkTraversalResult]]:
     """
     using the ground truth road network, and some agent Link traversal, attempt to traverse
     the link, based on travel time calculations from the Link's PropertyLink attributes.
@@ -108,21 +109,18 @@ def traverse_up_to(link: LinkTraversal,
         return AttributeError(f"attempting to traverse link which does not exist"), None
     elif link.start == link.end:
         # already done!
-        result = LinkTraversalResult(
-            traversed=None,
-            remaining=None,
-            remaining_time_seconds=available_time_seconds
-        )
+        result = LinkTraversalResult(traversed=None,
+                                     remaining=None,
+                                     remaining_time_seconds=available_time_seconds)
         return None, result
     else:
         # traverse up to available_time_hours across this link
         if link.travel_time_seconds <= available_time_seconds:
             # we can complete this link, so we return (remaining) Link = None
-            result = LinkTraversalResult(
-                traversed=link,
-                remaining=None,
-                remaining_time_seconds=(available_time_seconds - link.travel_time_seconds)
-            )
+            result = LinkTraversalResult(traversed=link,
+                                         remaining=None,
+                                         remaining_time_seconds=(available_time_seconds -
+                                                                 link.travel_time_seconds))
             return None, result
         else:
             # we do not have enough time to finish traversing this link, so, just traverse part of it,
@@ -132,8 +130,14 @@ def traverse_up_to(link: LinkTraversal,
             mid_geoid = H3Ops.point_along_link(link, available_time_seconds)
 
             # create two sub-links, one for the part that was traversed, and one for the remaining part
-            traversed = LinkTraversal.build(link.link_id, link.start, mid_geoid, speed_kmph=link.speed_kmph)
-            remaining = LinkTraversal.build(link.link_id, mid_geoid, link.end, speed_kmph=link.speed_kmph)
+            traversed = LinkTraversal.build(link.link_id,
+                                            link.start,
+                                            mid_geoid,
+                                            speed_kmph=link.speed_kmph)
+            remaining = LinkTraversal.build(link.link_id,
+                                            mid_geoid,
+                                            link.end,
+                                            speed_kmph=link.speed_kmph)
 
             result = LinkTraversalResult(
                 traversed=traversed,

--- a/hive/model/roadnetwork/osm/osm_road_network_link_helper.py
+++ b/hive/model/roadnetwork/osm/osm_road_network_link_helper.py
@@ -43,7 +43,9 @@ class OSMRoadNetworkLinkHelper(NamedTuple):
             link_id = self.links_linkid_lookup[index] if 0 <= index < self.link_count else None
             link = self.links.get(link_id) if link_id else None
             if not link_id or not link:
-                return Exception(f"internal error on nearest link for geoid {geoid}: resulting spatial index value '{index}' is invalid"), None
+                return Exception(
+                    f"internal error on nearest link for geoid {geoid}: resulting spatial index value '{index}' is invalid"
+                ), None
             else:
                 return None, link
 
@@ -52,11 +54,12 @@ class OSMRoadNetworkLinkHelper(NamedTuple):
 
     @classmethod
     def build(
-            cls,
-            graph: MultiDiGraph,
-            sim_h3_resolution: int,
-            default_speed_kmph: Kmph = 40.0,
-            default_distance_km: Kilometers = 0.01) -> Tuple[Optional[Exception], Optional[OSMRoadNetworkLinkHelper]]:
+        cls,
+        graph: MultiDiGraph,
+        sim_h3_resolution: int,
+        default_speed_kmph: Kmph = 40.0,
+        default_distance_km: Kilometers = 0.01
+    ) -> Tuple[Optional[Exception], Optional[OSMRoadNetworkLinkHelper]]:
         """
         reads in the graph links from a networkx graph and builds a table with Links by LinkId
         :param graph: the input graph
@@ -65,7 +68,6 @@ class OSMRoadNetworkLinkHelper(NamedTuple):
         :param default_distance_km: default link length for unlabeled links
         :return: either an error, or, the lookup table
         """
-
         class Accumulator(NamedTuple):
             """
             builds data structures used to provide lookup features in the road network
@@ -94,13 +96,13 @@ class OSMRoadNetworkLinkHelper(NamedTuple):
                     # we aim here to make both centroids _just barely_ different by subtracting the midpoint index by 1.
                     midpoint_h3_line_index = round(len(h3_line) / 2) if len(h3_line) > 0 else None
                     src_oriented_midpoint_index = midpoint_h3_line_index - 1 if midpoint_h3_line_index > 0 else midpoint_h3_line_index
-                    midpoint_hex = h3_line[src_oriented_midpoint_index] if src_oriented_midpoint_index else link.start
+                    midpoint_hex = h3_line[
+                        src_oriented_midpoint_index] if src_oriented_midpoint_index else link.start
                     link_centroid_lat, link_centroid_lon = h3.h3_to_geo(midpoint_hex)
-                    updated_acc = self._replace(
-                        lookup=self.lookup.set(link.link_id, link),
-                        link_ids=self.link_ids + (link.link_id,),
-                        link_centroids=self.link_centroids + ((link_centroid_lat, link_centroid_lon),)
-                    )
+                    updated_acc = self._replace(lookup=self.lookup.set(link.link_id, link),
+                                                link_ids=self.link_ids + (link.link_id, ),
+                                                link_centroids=self.link_centroids +
+                                                ((link_centroid_lat, link_centroid_lon), ))
                     return None, updated_acc
                 except Exception as e:
                     return e, None
@@ -108,7 +110,8 @@ class OSMRoadNetworkLinkHelper(NamedTuple):
         # inner loop function that attaches a LinkId -> Link pair to a Map
         def create_link_entry(
                 acc: Tuple[Optional[Exception], Optional[Accumulator]],
-                link_tuple: Tuple[int, int, int]) -> Tuple[Optional[Exception], Optional[Accumulator]]:
+                link_tuple: Tuple[int, int,
+                                  int]) -> Tuple[Optional[Exception], Optional[Accumulator]]:
             acc_error, accumulator = acc
             if acc_error:
                 return acc
@@ -121,11 +124,15 @@ class OSMRoadNetworkLinkHelper(NamedTuple):
                     src_coord_err, src_coord = safe_get_node_coordinates(src_node, src)
                     dst_coord_err, dst_coord = safe_get_node_coordinates(dst_node, dst)
                     if src_coord_err:
-                        response = Exception(f"failure getting node coordinates while building OSMRoadNetworkLinkHelper")
+                        response = Exception(
+                            f"failure getting node coordinates while building OSMRoadNetworkLinkHelper"
+                        )
                         response.__cause__ = src_coord_err
                         return response, None
                     elif dst_coord_err:
-                        response = Exception(f"failure getting node coordinates while building OSMRoadNetworkLinkHelper")
+                        response = Exception(
+                            f"failure getting node coordinates while building OSMRoadNetworkLinkHelper"
+                        )
                         response.__cause__ = dst_coord_err
                         return response, None
                     else:
@@ -133,14 +140,19 @@ class OSMRoadNetworkLinkHelper(NamedTuple):
                         dst_lat, dst_lon = dst_coord
                         src_geoid = h3.geo_to_h3(src_lat, src_lon, resolution=sim_h3_resolution)
                         dst_geoid = h3.geo_to_h3(dst_lat, dst_lon, resolution=sim_h3_resolution)
-                        data = graph.get_edge_data(src, dst, 0, None)  # data index "0" as this uses networkx's multigraph implementation
-                        speed = data.get('speed_kmph', default_speed_kmph) if data else default_speed_kmph
-                        distance_miles = data.get('length', default_distance_km) if data else default_distance_km
+                        data = graph.get_edge_data(
+                            src, dst, 0, None
+                        )  # data index "0" as this uses networkx's multigraph implementation
+                        speed = data.get('speed_kmph',
+                                         default_speed_kmph) if data else default_speed_kmph
+                        distance_miles = data.get(
+                            'length', default_distance_km) if data else default_distance_km
                         distance = distance_miles * M_TO_KM if distance_miles else default_distance_km
                         link = Link.build(link_id, src_geoid, dst_geoid, speed, distance)
                         add_link_error, updated_accumulator = accumulator.add_link(link)
                         if add_link_error:
-                            response = Exception(f"failure adding link while building OSMRoadNetworkLinkHelper")
+                            response = Exception(
+                                f"failure adding link while building OSMRoadNetworkLinkHelper")
                             response.__cause__ = add_link_error
                             return response, None
                         else:
@@ -159,5 +171,7 @@ class OSMRoadNetworkLinkHelper(NamedTuple):
         else:
             # construct the spatial index
             tree = cKDTree(accumulator.link_centroids)
-            osm_road_network_links = OSMRoadNetworkLinkHelper(accumulator.lookup, tree, accumulator.link_ids, len(accumulator.link_ids))
+            osm_road_network_links = OSMRoadNetworkLinkHelper(accumulator.lookup, tree,
+                                                              accumulator.link_ids,
+                                                              len(accumulator.link_ids))
             return None, osm_road_network_links

--- a/hive/model/roadnetwork/osm/osm_roadnetwork.py
+++ b/hive/model/roadnetwork/osm/osm_roadnetwork.py
@@ -29,27 +29,27 @@ class OSMRoadNetwork(RoadNetwork):
     Implements an open street maps road network utilizing the osmnx and networkx libraries
 
     """
-
-    def __init__(
-            self,
-            road_network_file: Path,
-            geofence: Optional[GeoFence] = None,
-            sim_h3_resolution: H3Resolution = 15,
-            default_speed_kmph: Kmph = 40.0,
-            default_distance_km: Kilometers = 100
-    ):
+    def __init__(self,
+                 road_network_file: Path,
+                 geofence: Optional[GeoFence] = None,
+                 sim_h3_resolution: H3Resolution = 15,
+                 default_speed_kmph: Kmph = 40.0,
+                 default_distance_km: Kilometers = 100):
         self.sim_h3_resolution = sim_h3_resolution
         self.geofence = geofence
 
         # read in the network file
         if road_network_file.suffix == ".xml":
-            log.warning(".xml files have been deprecated in hive. please switch to using .json formats")
+            log.warning(
+                ".xml files have been deprecated in hive. please switch to using .json formats")
             graph = graph_from_file(str(road_network_file))
         elif road_network_file.suffix == ".json":
             with road_network_file.open('r') as f:
                 graph = nx.node_link_graph(json.load(f))
         else:
-            raise TypeError(f"road network file of type {road_network_file.suffix} not supported by OSMRoadNetwork.")
+            raise TypeError(
+                f"road network file of type {road_network_file.suffix} not supported by OSMRoadNetwork."
+            )
 
         # validate network
 
@@ -78,14 +78,17 @@ class OSMRoadNetwork(RoadNetwork):
             if 'speed_kmph' not in d:
                 missing_speed += 1
         if missing_length > 0:
-            raise Exception(f"found {missing_length} links in the road network that don't have length information")
+            raise Exception(
+                f"found {missing_length} links in the road network that don't have length information"
+            )
         elif missing_speed > 0:
-            log.warning(f"found {missing_speed} links in the road network that don't have speed information.\n"
-                        f"hive will automatically set these to {self.default_speed_kmph} kmph.")
+            log.warning(
+                f"found {missing_speed} links in the road network that don't have speed information.\n"
+                f"hive will automatically set these to {self.default_speed_kmph} kmph.")
 
         # build tables on the network edges for spatial lookup and LinkId lookup
-        link_helper_error, link_helper = OSMRoadNetworkLinkHelper.build(graph, sim_h3_resolution, default_speed_kmph,
-                                                                        default_distance_km)
+        link_helper_error, link_helper = OSMRoadNetworkLinkHelper.build(
+            graph, sim_h3_resolution, default_speed_kmph, default_distance_km)
         if link_helper_error:
             raise link_helper_error
         else:
@@ -122,13 +125,17 @@ class OSMRoadNetwork(RoadNetwork):
                 log.error(f"unable to build route from {origin} to {destination}")
                 log.error(link_path_error)
                 log.error(
-                    f"origin node {origin_node_id}, destination node {destination_node_id}, shortest path node list result: {nx_path}")
+                    f"origin node {origin_node_id}, destination node {destination_node_id}, shortest path node list result: {nx_path}"
+                )
                 return empty_route()
             else:
                 # modify the start and end GeoIds based on the positions in the src/dst links
-                resolved_route = resolve_route_src_dst_positions(inner_link_path, origin, destination, self)
+                resolved_route = resolve_route_src_dst_positions(inner_link_path, origin,
+                                                                 destination, self)
                 if not resolved_route:
-                    log.error(f"unable to resolve the route from/to/via:\n {origin}\n{destination}\n{inner_link_path}")
+                    log.error(
+                        f"unable to resolve the route from/to/via:\n {origin}\n{destination}\n{inner_link_path}"
+                    )
                     return empty_route()
                 else:
                     return resolved_route
@@ -144,7 +151,9 @@ class OSMRoadNetwork(RoadNetwork):
         o = self.position_from_geoid(origin)
         d = self.position_from_geoid(destination)
         if not o or not d:
-            log.error(f"failed finding nearest links to distance query between GeoIds {origin}, {destination}")
+            log.error(
+                f"failed finding nearest links to distance query between GeoIds {origin}, {destination}"
+            )
             return 0.0
         else:
             distance = route_distance_km(self.route(o, d))

--- a/hive/model/roadnetwork/osm/osm_roadnetwork_ops.py
+++ b/hive/model/roadnetwork/osm/osm_roadnetwork_ops.py
@@ -16,7 +16,8 @@ if TYPE_CHECKING:
     from hive.model.roadnetwork.osm.osm_roadnetwork import OSMRoadNetwork
 
 
-def safe_get_node_coordinates(node: NodeView, node_id: int) -> Tuple[Optional[Exception], Optional[Tuple[float, float]]]:
+def safe_get_node_coordinates(
+        node: NodeView, node_id: int) -> Tuple[Optional[Exception], Optional[Tuple[float, float]]]:
     """
     attempts to extract lat/lon location from a graph node attribute
     :param node: the node attribute
@@ -29,10 +30,13 @@ def safe_get_node_coordinates(node: NodeView, node_id: int) -> Tuple[Optional[Ex
         try:
             return None, (node['lat'], node['lon'])
         except KeyError:
-            return KeyError(f"node {node_id} does not have either (y, x) or (lat, lon) information"), None
+            return KeyError(
+                f"node {node_id} does not have either (y, x) or (lat, lon) information"), None
 
 
-def route_from_nx_path(nx_path: Union[list, dict], link_lookup: immutables.Map[LinkId, Link]) -> Tuple[Optional[Exception], Optional[Route]]:
+def route_from_nx_path(
+        nx_path: Union[list, dict],
+        link_lookup: immutables.Map[LinkId, Link]) -> Tuple[Optional[Exception], Optional[Route]]:
     """
     takes a networkx shortest path result (a list of node ids) and turns it into a Route (list of Links)
     :param nx_path: the networkx path result
@@ -45,9 +49,10 @@ def route_from_nx_path(nx_path: Union[list, dict], link_lookup: immutables.Map[L
         # with an empty route.
         return None, ()
     else:
+
         def _accumulate_links(
-                acc: Tuple[Optional[Exception], Optional[Tuple[LinkTraversal, ...]]],
-                node_id_pair: Tuple[int, int]
+            acc: Tuple[Optional[Exception], Optional[Tuple[LinkTraversal,
+                                                           ...]]], node_id_pair: Tuple[int, int]
         ) -> Tuple[Optional[Exception], Optional[Tuple[LinkTraversal, ...]]]:
             err, prev_links = acc
             if err:
@@ -58,23 +63,22 @@ def route_from_nx_path(nx_path: Union[list, dict], link_lookup: immutables.Map[L
                 link_id = create_link_id(src, dst)
                 link = link_lookup.get(link_id)
                 if not link:
-                    link_err = Exception(f"networkx shortest path traverses link id {link_id} which does not exist")
+                    link_err = Exception(
+                        f"networkx shortest path traverses link id {link_id} which does not exist")
                     return link_err, None
                 else:
-                    updated_links = prev_links + (link.to_link_traversal(),)
+                    updated_links = prev_links + (link.to_link_traversal(), )
                     return None, updated_links
 
-        nx_path_adj_pairs = [(nx_path[i], nx_path[i+1]) for i in range(0, len(nx_path) - 1)]
+        nx_path_adj_pairs = [(nx_path[i], nx_path[i + 1]) for i in range(0, len(nx_path) - 1)]
         initial = None, ()
         result = ft.reduce(_accumulate_links, nx_path_adj_pairs, initial)
         return result
 
 
-def resolve_route_src_dst_positions(
-        inner_route: Route,
-        src_link_pos: EntityPosition,
-        dst_link_pos: EntityPosition,
-        road_network: OSMRoadNetwork) -> Optional[Route]:
+def resolve_route_src_dst_positions(inner_route: Route, src_link_pos: EntityPosition,
+                                    dst_link_pos: EntityPosition,
+                                    road_network: OSMRoadNetwork) -> Optional[Route]:
     """
     our inner_route is a shortest path from the destination of the source link to the start
     of the destination link. a 'positional' Link has been provided in the search query, assumed
@@ -98,6 +102,5 @@ def resolve_route_src_dst_positions(
         # align with the search start/end locations
         src_link_traversal = src_link.to_link_traversal().update_start(src_link_pos.geoid)
         dst_link_traversal = dst_link.to_link_traversal().update_end(dst_link_pos.geoid)
-        updated_route = (src_link_traversal,) + inner_route + (dst_link_traversal,)
+        updated_route = (src_link_traversal, ) + inner_route + (dst_link_traversal, )
         return updated_route
-

--- a/hive/model/roadnetwork/route.py
+++ b/hive/model/roadnetwork/route.py
@@ -89,7 +89,8 @@ def to_linestring(route: Route, env: Environment) -> str:
         linestring = wkt.linestring_2d((src, dst), env.config.global_config.wkt_x_y_ordering)
         return linestring
     else:
-        points = ft.reduce(lambda acc, l: acc + (h3.h3_to_geo(l.start), h3.h3_to_geo(l.end)), route, ())
+        points = ft.reduce(lambda acc, l: acc + (h3.h3_to_geo(l.start), h3.h3_to_geo(l.end)), route,
+                           ())
         linestring = wkt.linestring_2d(points, env.config.global_config.wkt_x_y_ordering)
         return linestring
 

--- a/hive/model/roadnetwork/routetraversal.py
+++ b/hive/model/roadnetwork/routetraversal.py
@@ -74,9 +74,7 @@ class RouteTraversal(NamedTuple):
         :param link: a link traversal for the remaining route
         :return: the updated RouteTraversal
         """
-        return self._replace(
-            remaining_route=self.remaining_route + (link,)
-        )
+        return self._replace(remaining_route=self.remaining_route + (link, ))
 
 
 def traverse(route_estimate: Route,

--- a/hive/model/vehicle/mechatronics/__init__.py
+++ b/hive/model/vehicle/mechatronics/__init__.py
@@ -17,8 +17,9 @@ mechatronic_models = {
 }
 
 
-def build_mechatronics_table(mechatronics_file: str, scenario_directory: str) -> Dict[
-    MechatronicsId, MechatronicsInterface]:
+def build_mechatronics_table(
+        mechatronics_file: str,
+        scenario_directory: str) -> Dict[MechatronicsId, MechatronicsInterface]:
     """
     constructs a dictionary containing all of the provided vehicle configurations where the key is the mechatronics ID
     and the contents are the appropriate mechatronics models with the desired attributes

--- a/hive/model/vehicle/mechatronics/bev.py
+++ b/hive/model/vehicle/mechatronics/bev.py
@@ -60,15 +60,13 @@ class BEV(NamedTuple, MechatronicsInterface):
         powercurve = build_powercurve(d)
         idle_kwh_per_hour = float(d['idle_kwh_per_hour'])
         charge_taper_cutoff_kw = float(d['charge_taper_cutoff_kw'])
-        return BEV(
-            mechatronics_id=d['mechatronics_id'],
-            battery_capacity_kwh=battery_capacity_kwh,
-            idle_kwh_per_hour=idle_kwh_per_hour,
-            powertrain=powertrain,
-            powercurve=powercurve,
-            nominal_watt_hour_per_mile=nominal_watt_hour_per_mile,
-            charge_taper_cutoff_kw=charge_taper_cutoff_kw
-        )
+        return BEV(mechatronics_id=d['mechatronics_id'],
+                   battery_capacity_kwh=battery_capacity_kwh,
+                   idle_kwh_per_hour=idle_kwh_per_hour,
+                   powertrain=powertrain,
+                   powercurve=powercurve,
+                   nominal_watt_hour_per_mile=nominal_watt_hour_per_mile,
+                   charge_taper_cutoff_kw=charge_taper_cutoff_kw)
 
     def valid_charger(self, charger: Charger) -> bool:
         """
@@ -102,7 +100,8 @@ class BEV(NamedTuple, MechatronicsInterface):
         :param required_range: the distance the vehicle needs to travel
         :return:
         """
-        required_energy_kwh = (required_range / MILE_TO_KM) * (self.nominal_watt_hour_per_mile * WH_TO_KWH)
+        required_energy_kwh = (required_range / MILE_TO_KM) * (self.nominal_watt_hour_per_mile *
+                                                               WH_TO_KWH)
         return required_energy_kwh / self.battery_capacity_kwh
 
     def fuel_source_soc(self, vehicle: Vehicle) -> Ratio:
@@ -143,7 +142,8 @@ class BEV(NamedTuple, MechatronicsInterface):
         :return:
         """
         energy_used = self.powertrain.energy_cost(route)
-        energy_used_kwh = energy_used * get_unit_conversion(self.powertrain.energy_units, "kilowatthour")
+        energy_used_kwh = energy_used * get_unit_conversion(self.powertrain.energy_units,
+                                                            "kilowatthour")
         vehicle_energy_kwh = vehicle.energy[EnergyType.ELECTRIC]
         new_energy_kwh = max(0.0, vehicle_energy_kwh - energy_used_kwh)
         updated_vehicle = vehicle.modify_energy({EnergyType.ELECTRIC: new_energy_kwh})
@@ -167,7 +167,8 @@ class BEV(NamedTuple, MechatronicsInterface):
 
         return updated_vehicle
 
-    def add_energy(self, vehicle: Vehicle, charger: Charger, time_seconds: Seconds) -> Tuple[Vehicle, Seconds]:
+    def add_energy(self, vehicle: Vehicle, charger: Charger,
+                   time_seconds: Seconds) -> Tuple[Vehicle, Seconds]:
         """
         add energy into the system
 
@@ -180,7 +181,9 @@ class BEV(NamedTuple, MechatronicsInterface):
         :return: the updated vehicle, along with the time spent charging
         """
         if not self.valid_charger(charger):
-            log.warning(f"BEV vehicle attempting to use charger of energy type: {charger.energy_type}. Not charging.")
+            log.warning(
+                f"BEV vehicle attempting to use charger of energy type: {charger.energy_type}. Not charging."
+            )
             return vehicle, 0
 
         start_energy_kwh = vehicle.energy[EnergyType.ELECTRIC]
@@ -199,7 +202,6 @@ class BEV(NamedTuple, MechatronicsInterface):
                 duration_seconds=time_seconds,
             )
             new_energy_kwh = min(self.battery_capacity_kwh, charger_energy_kwh)
-
 
         updated_vehicle = vehicle.modify_energy({EnergyType.ELECTRIC: new_energy_kwh})
 

--- a/hive/model/vehicle/mechatronics/ice.py
+++ b/hive/model/vehicle/mechatronics/ice.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
+
 class ICE(NamedTuple, MechatronicsInterface):
     """
     Mechatronics for an internal combustion engine (ICE)
@@ -128,7 +129,8 @@ class ICE(NamedTuple, MechatronicsInterface):
         :return:
         """
         energy_used = self.powertrain.energy_cost(route)
-        energy_used_gal_gas = energy_used * get_unit_conversion(self.powertrain.energy_units, "gal_gas")
+        energy_used_gal_gas = energy_used * get_unit_conversion(self.powertrain.energy_units,
+                                                                "gal_gas")
 
         vehicle_energy_gal_gas = vehicle.energy[EnergyType.GASOLINE]
         new_energy_gal_gas = max(0.0, vehicle_energy_gal_gas - energy_used_gal_gas)
@@ -153,7 +155,8 @@ class ICE(NamedTuple, MechatronicsInterface):
 
         return updated_vehicle
 
-    def add_energy(self, vehicle: Vehicle, charger: Charger, time_seconds: Seconds) -> Tuple[Vehicle, Seconds]:
+    def add_energy(self, vehicle: Vehicle, charger: Charger,
+                   time_seconds: Seconds) -> Tuple[Vehicle, Seconds]:
         """
         add energy into the system. units for the charger are gallons per second
 
@@ -166,7 +169,9 @@ class ICE(NamedTuple, MechatronicsInterface):
         :return: the updated vehicle, along with the time spent charging
         """
         if not self.valid_charger(charger):
-            log.warning(f"ICE vehicle attempting to use charger of energy type: {charger.energy_type}. Not charging.")
+            log.warning(
+                f"ICE vehicle attempting to use charger of energy type: {charger.energy_type}. Not charging."
+            )
             return vehicle, 0
         start_gal_gas = vehicle.energy[EnergyType.GASOLINE]
 

--- a/hive/model/vehicle/mechatronics/mechatronics_interface.py
+++ b/hive/model/vehicle/mechatronics/mechatronics_interface.py
@@ -18,7 +18,6 @@ class MechatronicsInterface(metaclass=ABCNamedTupleMeta):
     """
     Interface for creating energy sources
     """
-
     @property
     @abstractmethod
     def mechatronics_id(self) -> MechatronicsId:
@@ -114,7 +113,8 @@ class MechatronicsInterface(metaclass=ABCNamedTupleMeta):
         """
 
     @abstractmethod
-    def add_energy(self, vehicle: Vehicle, charger: Charger, time_seconds: Seconds) -> Tuple[Vehicle, Seconds]:
+    def add_energy(self, vehicle: Vehicle, charger: Charger,
+                   time_seconds: Seconds) -> Tuple[Vehicle, Seconds]:
         """
         add energy into the system
 

--- a/hive/model/vehicle/mechatronics/powercurve/__init__.py
+++ b/hive/model/vehicle/mechatronics/powercurve/__init__.py
@@ -5,9 +5,7 @@ import yaml
 from hive.model.vehicle.mechatronics.powercurve.powercurve import Powercurve
 from hive.model.vehicle.mechatronics.powercurve.tabular_powercurve import TabularPowercurve
 
-powercurve_models = {
-    'tabular': TabularPowercurve
-}
+powercurve_models = {'tabular': TabularPowercurve}
 
 
 def build_powercurve(config: dict) -> Powercurve:
@@ -28,6 +26,8 @@ def build_powercurve(config: dict) -> Powercurve:
         if not powercurve_type:
             raise KeyError(f"powertrain file {file} missing required 'type' field")
         if powercurve_type not in powercurve_models:
-            raise IOError(f"PowerCurve with type {powercurve_type} is not recognized, must be one of {powercurve_models.keys()}")
+            raise IOError(
+                f"PowerCurve with type {powercurve_type} is not recognized, must be one of {powercurve_models.keys()}"
+            )
         else:
             return powercurve_models[powercurve_type](data=config)

--- a/hive/model/vehicle/mechatronics/powercurve/powercurve.py
+++ b/hive/model/vehicle/mechatronics/powercurve/powercurve.py
@@ -11,14 +11,14 @@ class Powercurve(ABC):
     """
     a powertrain has a behavior where it calculates energy consumption in KwH
     """
-
     @abstractmethod
-    def charge(self,
-               start_soc: Ratio,
-               full_soc: Ratio,
-               power_kw: Kw,
-               duration_seconds: Seconds = 1  # seconds
-               ) -> Tuple[KwH, Seconds]:
+    def charge(
+            self,
+            start_soc: Ratio,
+            full_soc: Ratio,
+            power_kw: Kw,
+            duration_seconds: Seconds = 1  # seconds
+    ) -> Tuple[KwH, Seconds]:
         """
 
 
@@ -28,4 +28,3 @@ class Powercurve(ABC):
         :param duration_seconds:
         :return: the charge amount along with the time spent charging
         """
-

--- a/hive/model/vehicle/mechatronics/powercurve/powercurve_ops.py
+++ b/hive/model/vehicle/mechatronics/powercurve/powercurve_ops.py
@@ -5,11 +5,11 @@ from hive.util import Seconds, Ratio
 
 
 def time_to_full(
-        vehicle: Vehicle,
-        mechatronics: MechatronicsInterface,
-        charger: Charger,
-        target_soc: Ratio,
-        sim_timestep_duration_seconds: Seconds,
+    vehicle: Vehicle,
+    mechatronics: MechatronicsInterface,
+    charger: Charger,
+    target_soc: Ratio,
+    sim_timestep_duration_seconds: Seconds,
 ) -> Seconds:
     """
     fills an imaginary vehicle in order to determine the estimated time to charge
@@ -25,8 +25,7 @@ def time_to_full(
         if mechatronics.fuel_source_soc(charging_vehicle) >= target_soc:
             return time_charged_accumulator
         else:
-            updated_veh, time_delta = mechatronics.add_energy(charging_vehicle,
-                                                              charger,
+            updated_veh, time_delta = mechatronics.add_energy(charging_vehicle, charger,
                                                               sim_timestep_duration_seconds)
             updated_time_charged_acc = time_charged_accumulator + time_delta
             return _fill(updated_veh, updated_time_charged_acc)
@@ -34,4 +33,3 @@ def time_to_full(
     time_charged = _fill(vehicle)
 
     return time_charged
-

--- a/hive/model/vehicle/mechatronics/powercurve/tabular_powercurve.py
+++ b/hive/model/vehicle/mechatronics/powercurve/tabular_powercurve.py
@@ -16,48 +16,52 @@ class TabularPowercurve(Powercurve):
     """
     builds a tabular, interpolated lookup model from a file
     """
-
     def __init__(
-            self,
-            data: Dict[str, str],
-            nominal_max_charge_kw: Optional[Kw] = None,
-            battery_capacity_kwh: Optional[KwH] = None,
+        self,
+        data: Dict[str, str],
+        nominal_max_charge_kw: Optional[Kw] = None,
+        battery_capacity_kwh: Optional[KwH] = None,
     ):
         if not nominal_max_charge_kw:
             try:
                 nominal_max_charge_kw = float(data['nominal_max_charge_kw'])
             except KeyError:
-                raise AttributeError("Must initialize TabularPowercurve with attribute nominal_max_charge_kw")
+                raise AttributeError(
+                    "Must initialize TabularPowercurve with attribute nominal_max_charge_kw")
         if not battery_capacity_kwh:
             try:
                 battery_capacity_kwh = float(data['battery_capacity_kwh'])
             except KeyError:
-                raise AttributeError("Must initialize TabularPowercurve with attribute battery_capacity_kwh")
+                raise AttributeError(
+                    "Must initialize TabularPowercurve with attribute battery_capacity_kwh")
 
         expected_keys = ['name', 'power_type', 'step_size_seconds', 'power_curve']
         for key in expected_keys:
             if key not in data:
-                raise IOError(f"invalid input file for tabular energy curve model missing key {key}")
+                raise IOError(
+                    f"invalid input file for tabular energy curve model missing key {key}")
 
         self.id = data['name']
         self.energy_type = EnergyType.from_string(data['power_type'])
         self.step_size_seconds = data['step_size_seconds']  # seconds
 
         if self.energy_type is None:
-            raise AttributeError(f"TabularPowercurve initialized with invalid energy type {self.energy_type}")
+            raise AttributeError(
+                f"TabularPowercurve initialized with invalid energy type {self.energy_type}")
 
         charging_model = sorted(data['power_curve'], key=lambda x: x['energy_kwh'])
-        self._charging_energy_kwh = np.array(
-            list(map(lambda x: x['energy_kwh'], charging_model))) * battery_capacity_kwh
-        self._charging_rate_kw = np.array(list(map(lambda x: x['power_kw'], charging_model))) * nominal_max_charge_kw
+        self._charging_energy_kwh = np.array(list(map(lambda x: x['energy_kwh'],
+                                                      charging_model))) * battery_capacity_kwh
+        self._charging_rate_kw = np.array(list(map(lambda x: x['power_kw'],
+                                                   charging_model))) * nominal_max_charge_kw
 
-    def charge(self,
-               start_soc: Ratio,
-               full_soc: Ratio,
-               power_kw: Kw,
-               duration_seconds: Seconds = 1  # seconds
-               ) -> Tuple[KwH, Seconds]:
-
+    def charge(
+            self,
+            start_soc: Ratio,
+            full_soc: Ratio,
+            power_kw: Kw,
+            duration_seconds: Seconds = 1  # seconds
+    ) -> Tuple[KwH, Seconds]:
         """
          (estimated) energy rate due to fueling, based on an interpolated tabular lookup model
 
@@ -72,7 +76,8 @@ class TabularPowercurve(Powercurve):
         t = 0
         energy_kwh = start_soc
         while t < duration_seconds and energy_kwh < full_soc:
-            veh_kw_rate = np.interp(energy_kwh, self._charging_energy_kwh, self._charging_rate_kw)  # kilowatt
+            veh_kw_rate = np.interp(energy_kwh, self._charging_energy_kwh,
+                                    self._charging_rate_kw)  # kilowatt
             charge_power_kw = min(veh_kw_rate, power_kw)  # kilowatt
             kwh = charge_power_kw * (self.step_size_seconds * SECONDS_TO_HOURS)  # kilowatt-hours
 

--- a/hive/model/vehicle/mechatronics/powertrain/__init__.py
+++ b/hive/model/vehicle/mechatronics/powertrain/__init__.py
@@ -5,9 +5,7 @@ import yaml
 from hive.model.vehicle.mechatronics.powertrain.powertrain import Powertrain
 from hive.model.vehicle.mechatronics.powertrain.tabular_powertrain import TabularPowertrain
 
-powertrain_models = {
-    'tabular': TabularPowertrain
-}
+powertrain_models = {'tabular': TabularPowertrain}
 
 
 def build_powertrain(config: dict) -> Powertrain:
@@ -26,6 +24,8 @@ def build_powertrain(config: dict) -> Powertrain:
         if not powertrain_type:
             raise KeyError(f"powertrain file {file} missing required 'type' field")
         elif powertrain_type not in powertrain_models:
-            raise IOError(f"PowerCurve with type {powertrain_type} is not recognized, must be one of {powertrain_models.keys()}")
+            raise IOError(
+                f"PowerCurve with type {powertrain_type} is not recognized, must be one of {powertrain_models.keys()}"
+            )
         else:
             return powertrain_models[powertrain_type](data=config)

--- a/hive/model/vehicle/mechatronics/powertrain/tabular_powertrain.py
+++ b/hive/model/vehicle/mechatronics/powertrain/tabular_powertrain.py
@@ -12,10 +12,9 @@ class TabularPowertrain(Powertrain):
     """
     builds a tabular, interpolated lookup model for energy consumption
     """
-
     def __init__(
-            self,
-            data: Dict[str, str],
+        self,
+        data: Dict[str, str],
     ):
         try:
             scale_factor = float(data['scale_factor'])
@@ -60,8 +59,7 @@ class TabularPowertrain(Powertrain):
         # convert kilometers per hour to whatever units are used by this powertrain
         link_speed = link.speed_kmph * get_unit_conversion("kmph", self.speed_units)
 
-        energy_per_distance = np.interp(link_speed,
-                                        self._consumption_speed,
+        energy_per_distance = np.interp(link_speed, self._consumption_speed,
                                         self._consumption_energy_per_distance)
         # link distance is in kilometers
         link_distance = link.distance_km * get_unit_conversion("kilometer", self.distance_units)

--- a/hive/model/vehicle/schedules/__init__.py
+++ b/hive/model/vehicle/schedules/__init__.py
@@ -4,14 +4,12 @@ from hive.model.vehicle.schedules.time_range_schedule import time_range_schedule
 from hive.util.typealiases import ScheduleFunction, ScheduleId
 from hive.model.vehicle.schedules.schedule_type import ScheduleType
 
-
 # each is expected to be a one-argument function that takes a file path
-_constructors = {
-    ScheduleType.TIME_RANGE: time_range_schedules_from_file
-}
+_constructors = {ScheduleType.TIME_RANGE: time_range_schedules_from_file}
 
 
-def build_schedules_table(schedule_type: ScheduleType, schedules_file: str) -> Map[ScheduleId, ScheduleFunction]:
+def build_schedules_table(schedule_type: ScheduleType,
+                          schedules_file: str) -> Map[ScheduleId, ScheduleFunction]:
     """
     builds the schedule table based on the provided schedule type and file
 

--- a/hive/model/vehicle/schedules/schedule_type.py
+++ b/hive/model/vehicle/schedules/schedule_type.py
@@ -21,5 +21,5 @@ class ScheduleType(Enum):
         else:
             valid_names_list = list(ScheduleType)
             valid_names = ", ".join(list(map(lambda x: x.name, valid_names_list)))
-            raise NameError(f"schedule type '{string}' is not known, must be one of {{{valid_names}}}")
-
+            raise NameError(
+                f"schedule type '{string}' is not known, must be one of {{{valid_names}}}")

--- a/hive/model/vehicle/vehicle.py
+++ b/hive/model/vehicle/vehicle.py
@@ -56,7 +56,8 @@ class Vehicle(NamedTuple):
         return self.position.geoid
 
     @classmethod
-    def from_row(cls, row: Dict[str, str], road_network: RoadNetwork, environment: Environment) -> Vehicle:
+    def from_row(cls, row: Dict[str, str], road_network: RoadNetwork,
+                 environment: Environment) -> Vehicle:
         """
         reads a csv row from file to generate a Vehicle
 
@@ -88,18 +89,23 @@ class Vehicle(NamedTuple):
                 if not mechatronics:
                     found = set(environment.mechatronics.keys())
                     raise IOError(
-                        f"was not able to find mechatronics '{mechatronics_id}' for vehicle {vehicle_id} in environment: found {found}")
+                        f"was not able to find mechatronics '{mechatronics_id}' for vehicle {vehicle_id} in environment: found {found}"
+                    )
                 energy = mechatronics.initial_energy(float(row['initial_soc']))
 
                 schedule_id = row.get(
-                    'schedule_id')  # if None, it signals an autonomous vehicle, otherwise, human with schedule
+                    'schedule_id'
+                )  # if None, it signals an autonomous vehicle, otherwise, human with schedule
                 home_base_id = row.get('home_base_id')
                 if schedule_id and not schedule_id in environment.schedules.keys():
                     raise IOError(
-                        f"was not able to find schedule '{schedule_id}' in environment for vehicle {vehicle_id}")
-                allows_pooling = bool(row['allows_pooling']) if row.get('allows_pooling') is not None else False
+                        f"was not able to find schedule '{schedule_id}' in environment for vehicle {vehicle_id}"
+                    )
+                allows_pooling = bool(
+                    row['allows_pooling']) if row.get('allows_pooling') is not None else False
                 available_seats = int(row.get('available_seats', 0))
-                driver_state = DriverState.build(vehicle_id, schedule_id, home_base_id, allows_pooling)
+                driver_state = DriverState.build(vehicle_id, schedule_id, home_base_id,
+                                                 allows_pooling)
 
                 geoid = h3.geo_to_h3(lat, lon, road_network.sim_h3_resolution)
                 start_position = road_network.position_from_geoid(geoid)

--- a/hive/reporting/driver_event_ops.py
+++ b/hive/reporting/driver_event_ops.py
@@ -12,9 +12,7 @@ class ScheduleEventType(Enum):
     ON = "on"
 
 
-def driver_schedule_event(sim: 'SimulationState',
-                          env: Environment,
-                          vehicle: Vehicle,
+def driver_schedule_event(sim: 'SimulationState', env: Environment, vehicle: Vehicle,
                           schedule_event: ScheduleEventType) -> Report:
 
     lat, lon = h3.h3_to_geo(vehicle.geoid)

--- a/hive/reporting/handler/eventful_handler.py
+++ b/hive/reporting/handler/eventful_handler.py
@@ -22,7 +22,6 @@ class EventfulHandler(Handler):
     """
     handles events and appends them to the event.log output file based on global logging settings
     """
-
     def __init__(self, global_config: GlobalConfig, scenario_output_directory: Path):
 
         log_path = scenario_output_directory / 'event.log'
@@ -34,12 +33,14 @@ class EventfulHandler(Handler):
 
         sim_state = runner_payload.s
 
-        reports_not_instructions = tuple(filter(lambda r: r.report_type != ReportType.INSTRUCTION, reports))
+        reports_not_instructions = tuple(
+            filter(lambda r: r.report_type != ReportType.INSTRUCTION, reports))
 
         # station load events, written with reference to a specific station, take the sum of
         # charge events over a time step associated with a single station
         if ReportType.STATION_LOAD_EVENT in self.global_config.log_sim_config:
-            station_load_reports = vehicle_event_ops.construct_station_load_events(reports_not_instructions, sim_state)
+            station_load_reports = vehicle_event_ops.construct_station_load_events(
+                reports_not_instructions, sim_state)
             for report in station_load_reports:
                 entry = json.dumps(report.as_json(), default=str)
                 self.log_file.write(entry + '\n')

--- a/hive/reporting/handler/handler.py
+++ b/hive/reporting/handler/handler.py
@@ -13,7 +13,6 @@ class Handler(ABC):
     """
     A reporting.Handler handles simulation reports in varying ways.
     """
-
     @abstractmethod
     def handle(self, reports: List[Report], runner_payload: RunnerPayload):
         """

--- a/hive/reporting/handler/instruction_handler.py
+++ b/hive/reporting/handler/instruction_handler.py
@@ -22,7 +22,6 @@ class InstructionHandler(Handler):
     """
     handles events and appends them to the event.log output file based on global logging settings
     """
-
     def __init__(self, global_config: GlobalConfig, scenario_output_directory: Path):
 
         log_path = scenario_output_directory / 'instruction.log'

--- a/hive/reporting/handler/stateful_handler.py
+++ b/hive/reporting/handler/stateful_handler.py
@@ -17,7 +17,6 @@ class StatefulHandler(Handler):
     """
     prints the state of entities in the simulation to the state.log output file based on global logging settings
     """
-
     def __init__(self, global_config: GlobalConfig, scenario_output_directory: Path):
 
         log_path = scenario_output_directory / 'state.log'
@@ -68,7 +67,8 @@ class StatefulHandler(Handler):
         output = {
             'vehicle_id': vehicle.id,
             'driver_state': vehicle.driver_state.__class__.__name__,
-            'schedule_id': vehicle.driver_state.schedule_id if vehicle.driver_state.schedule_id else "",
+            'schedule_id':
+            vehicle.driver_state.schedule_id if vehicle.driver_state.schedule_id else "",
             'available': vehicle.driver_state.available,
         }
 
@@ -101,7 +101,7 @@ class StatefulHandler(Handler):
     @staticmethod
     def station_asdict(station: Station) -> dict:
         out_dict = station._asdict()
-        del(out_dict["id"])
+        del (out_dict["id"])
 
         out_dict["station_id"] = station.id
         out_dict["memberships"] = str(station.membership)

--- a/hive/reporting/handler/stats_handler.py
+++ b/hive/reporting/handler/stats_handler.py
@@ -26,7 +26,6 @@ class StatsHandler(Handler):
     """
     The StatsHandler compiles various simulation statistics and stores them.
     """
-
     def __init__(self):
         self.stats = SummaryStats()
 
@@ -52,20 +51,12 @@ class StatsHandler(Handler):
         # update the proportion of time spent by vehicles in each vehicle state
         sim_state = runner_payload.s
         state_counts = Counter(
-            map(
-                lambda v: v.vehicle_state.__class__.__name__,
-                sim_state.get_vehicles()
-            )
-        )
+            map(lambda v: v.vehicle_state.__class__.__name__, sim_state.get_vehicles()))
         self.stats.state_count += state_counts
 
         # capture the distance traveled in move states
-        move_events = list(
-            filter(
-                lambda r: r.report_type == ReportType.VEHICLE_MOVE_EVENT,
-                reports
-            )
-        )
+        move_events = list(filter(lambda r: r.report_type == ReportType.VEHICLE_MOVE_EVENT,
+                                  reports))
         for me in move_events:
             self.stats.vkt[me.report['vehicle_state']] += me.report['distance_km']
 
@@ -82,8 +73,8 @@ class StatsHandler(Handler):
         """
         output = self.stats.compile_stats(runner_payload)
         self.stats.log()
-        output_path = Path(runner_payload.e.config.scenario_output_directory).joinpath("summary_stats.json")
+        output_path = Path(
+            runner_payload.e.config.scenario_output_directory).joinpath("summary_stats.json")
         with output_path.open(mode="w") as f:
             json.dump(output, f, indent=4)
             log.info(f"summary stats written to {output_path}")
-

--- a/hive/reporting/handler/summary_stats.py
+++ b/hive/reporting/handler/summary_stats.py
@@ -37,33 +37,27 @@ class SummaryStats:
         env = rp.e
 
         self.mean_final_soc = np.mean([
-            env.mechatronics.get(v.mechatronics_id).fuel_source_soc(v) for v in sim_state.vehicles.values()
+            env.mechatronics.get(v.mechatronics_id).fuel_source_soc(v)
+            for v in sim_state.vehicles.values()
         ])
 
-        self.station_revenue = reduce(
-            lambda income, station: income + station.balance,
-            sim_state.stations.values(),
-            0.0
-        )
+        self.station_revenue = reduce(lambda income, station: income + station.balance,
+                                      sim_state.stations.values(), 0.0)
 
-        self.fleet_revenue = reduce(
-            lambda income, vehicle: income + vehicle.balance,
-            sim_state.vehicles.values(),
-            0.0
-        )
+        self.fleet_revenue = reduce(lambda income, vehicle: income + vehicle.balance,
+                                    sim_state.vehicles.values(), 0.0)
 
-        requests_served_percent = 1 - (self.cancelled_requests / self.requests) if self.requests > 0 else 0
+        requests_served_percent = 1 - (self.cancelled_requests /
+                                       self.requests) if self.requests > 0 else 0
         total_state_count = sum(self.state_count.values())
         total_vkt = sum(self.vkt.values())
         vehicle_state_output = {}
         vehicle_states_observed = set(self.state_count.keys()).union(self.vkt.keys())
         for v in vehicle_states_observed:
-            observed_pct = self.state_count.get(v) / total_state_count if self.state_count.get(v) else 0
+            observed_pct = self.state_count.get(v) / total_state_count if self.state_count.get(
+                v) else 0
             vkt = self.vkt.get(v, 0)
-            data = {
-                "observed_percent": observed_pct,
-                "vkt": vkt
-            }
+            data = {"observed_percent": observed_pct, "vkt": vkt}
             vehicle_state_output.update({v: data})
 
         output = {
@@ -80,15 +74,14 @@ class SummaryStats:
 
     def log(self):
         log.info(f"{self.mean_final_soc * 100:.2f} % \t Mean Final SOC".expandtabs(15))
-        requests_served_percent = (1 - (self.cancelled_requests / self.requests)) * 100 if self.requests > 0 else 0
-        log.info(
-            f"{requests_served_percent:.2f} % \t Requests Served"
-                .expandtabs(15)
-        )
+        requests_served_percent = (
+            1 - (self.cancelled_requests / self.requests)) * 100 if self.requests > 0 else 0
+        log.info(f"{requests_served_percent:.2f} % \t Requests Served".expandtabs(15))
 
         total_state_count = sum(self.state_count.values())
         for s, v in self.state_count.items():
-            log.info(f"{round(v / total_state_count * 100, 2)} % \t Time in State {s}".expandtabs(15))
+            log.info(
+                f"{round(v / total_state_count * 100, 2)} % \t Time in State {s}".expandtabs(15))
 
         total_vkt = sum(self.vkt.values())
         log.info(f"{total_vkt:.2f} km \t Total Kilometers Traveled".expandtabs(15))

--- a/hive/reporting/handler/time_step_stats_handler.py
+++ b/hive/reporting/handler/time_step_stats_handler.py
@@ -25,7 +25,6 @@ log = logging.getLogger(__name__)
 
 
 class TimeStepStatsHandler(Handler):
-
     def __init__(self,
                  config: HiveConfig,
                  scenario_output_directory: Path,
@@ -41,13 +40,15 @@ class TimeStepStatsHandler(Handler):
         if config.global_config.log_time_step_stats:
             self.log_time_step_stats = True
             self.data = []
-            self.time_step_stats_outpath = scenario_output_directory.joinpath(f"{file_name}_all.csv")
+            self.time_step_stats_outpath = scenario_output_directory.joinpath(
+                f"{file_name}_all.csv")
         else:
             self.log_time_step_stats = False
 
         if config.global_config.log_fleet_time_step_stats and len(fleet_ids) > 0:
             self.log_fleet_time_step_stats = True
-            self.fleets_timestep_stats_outpath = scenario_output_directory.joinpath('fleet_time_step_stats/')
+            self.fleets_timestep_stats_outpath = scenario_output_directory.joinpath(
+                'fleet_time_step_stats/')
             self.fleets_data = {}
             for fleet_id in fleet_ids:
                 self.fleets_data[fleet_id] = []
@@ -74,9 +75,10 @@ class TimeStepStatsHandler(Handler):
         """
         if not self.log_fleet_time_step_stats:
             return None
-        result = Map(
-            {fleet_id: DataFrame(data) if len(data) > 0 else None for fleet_id, data in self.fleets_data.items()}
-        )
+        result = Map({
+            fleet_id: DataFrame(data) if len(data) > 0 else None
+            for fleet_id, data in self.fleets_data.items()
+        })
         return result
 
     def handle(self, reports: List[Report], runner_payload: RunnerPayload):
@@ -94,7 +96,8 @@ class TimeStepStatsHandler(Handler):
 
         # get the time step
         sim_time = sim_state.sim_time
-        time_step = int((sim_time.as_epoch_time() - self.start_time.as_epoch_time()) / self.timestep_duration_seconds)
+        time_step = int((sim_time.as_epoch_time() - self.start_time.as_epoch_time()) /
+                        self.timestep_duration_seconds)
 
         # sort reports by type
         reports_by_type = {}
@@ -104,7 +107,8 @@ class TimeStepStatsHandler(Handler):
             reports_by_type[report.report_type].append(report)
 
         # get number of assigned requests in this time step
-        assigned_requests_count = len(sim_state.get_requests(filter_function=lambda r: r.dispatched_vehicle is not None))
+        assigned_requests_count = len(
+            sim_state.get_requests(filter_function=lambda r: r.dispatched_vehicle is not None))
 
         # get number of active requests in this time step (unassigned)
         active_requests_count = len(sim_state.get_requests()) - assigned_requests_count
@@ -119,32 +123,30 @@ class TimeStepStatsHandler(Handler):
 
             # grab all vehicles that are pooling
             veh_pooling = sim_state.get_vehicles(
-                filter_function=lambda
-                    v: v.vehicle_state.vehicle_state_type == VehicleStateType.SERVICING_POOLING_TRIP)
+                filter_function=lambda v: v.vehicle_state.vehicle_state_type == VehicleStateType.
+                SERVICING_POOLING_TRIP)
 
             # count the number of vehicles in each vehicle state
             veh_state_counts = Counter(
-                map(
-                    lambda v: v.vehicle_state.vehicle_state_type.name,
-                    sim_state.get_vehicles()
-                )
-            )
+                map(lambda v: v.vehicle_state.vehicle_state_type.name, sim_state.get_vehicles()))
 
-            stats_row = {'time_step': time_step,
-                         'sim_time': sim_time.as_iso_time()}
+            stats_row = {'time_step': time_step, 'sim_time': sim_time.as_iso_time()}
 
             # get average SOC of vehicles
             if len(sim_state.get_vehicles()) > 0:
-                stats_row['avg_soc_percent'] = 100 * np.mean(
-                    [env.mechatronics.get(v.mechatronics_id).fuel_source_soc(v) for v in sim_state.get_vehicles()]
-                )
+                stats_row['avg_soc_percent'] = 100 * np.mean([
+                    env.mechatronics.get(v.mechatronics_id).fuel_source_soc(v)
+                    for v in sim_state.get_vehicles()
+                ])
             else:
                 stats_row['avg_soc_percent'] = None
 
             # get the total vkt
             if ReportType.VEHICLE_MOVE_EVENT in reports_by_type.keys():
-                stats_row['vkt'] = sum(
-                    [me.report['distance_km'] for me in reports_by_type[ReportType.VEHICLE_MOVE_EVENT]])
+                stats_row['vkt'] = sum([
+                    me.report['distance_km']
+                    for me in reports_by_type[ReportType.VEHICLE_MOVE_EVENT]
+                ])
             else:
                 stats_row['vkt'] = 0
 
@@ -158,10 +160,10 @@ class TimeStepStatsHandler(Handler):
             stats_row['canceled_requests'] = canceled_requests_count
 
             # get count of requests currently being serviced by a vehicle
-            pooling_request_count = sum([len(v.vehicle_state.boarded_requests)
-                                         for v in veh_pooling])
+            pooling_request_count = sum(
+                [len(v.vehicle_state.boarded_requests) for v in veh_pooling])
             stats_row['servicing_requests'] = veh_state_counts[
-                                                  VehicleStateType.SERVICING_TRIP.name] + pooling_request_count
+                VehicleStateType.SERVICING_TRIP.name] + pooling_request_count
 
             # add the number of vehicles in each vehicle state
             stats_row['vehicles'] = len(sim_state.vehicles)
@@ -169,22 +171,15 @@ class TimeStepStatsHandler(Handler):
                 stats_row[f'vehicles_{state.lower()}'] = veh_state_counts[state]
 
             available_driver_counts = Counter(
-                map(
-                    lambda v: v.driver_state.available,
-                    sim_state.get_vehicles()
-                )
-            )
+                map(lambda v: v.driver_state.available, sim_state.get_vehicles()))
             stats_row['drivers_available'] = available_driver_counts[True]
             stats_row['drivers_unavailable'] = available_driver_counts[False]
 
             # count number of chargers in use by type
             if ReportType.VEHICLE_CHARGE_EVENT in reports_by_type.keys():
                 charger_counts = Counter(
-                    map(
-                        lambda r: r.report['charger_id'],
-                        reports_by_type[ReportType.VEHICLE_CHARGE_EVENT]
-                    )
-                )
+                    map(lambda r: r.report['charger_id'],
+                        reports_by_type[ReportType.VEHICLE_CHARGE_EVENT]))
                 for charger in env.chargers.keys():
                     stats_row[f'charger_{charger.lower()}'] = charger_counts[charger]
             else:
@@ -203,75 +198,67 @@ class TimeStepStatsHandler(Handler):
                     else:
                         return lambda v: fleet_id in v.membership.memberships
 
-                def _get_report_filter_func(membership_id: MembershipId) -> Callable[[Report], bool]:
+                def _get_report_filter_func(
+                        membership_id: MembershipId) -> Callable[[Report], bool]:
                     if membership_id == 'none':
-                        return lambda r: not any(set(env.fleet_ids) & set(r.report['vehicle_memberships']))
+                        return lambda r: not any(
+                            set(env.fleet_ids) & set(r.report['vehicle_memberships']))
                     else:
                         return lambda r: fleet_id in r.report['vehicle_memberships']
 
                 # get vehicles in this fleet
                 veh_in_fleet = sim_state.get_vehicles(
-                    filter_function=_get_veh_filter_func(fleet_id)
-                )
+                    filter_function=_get_veh_filter_func(fleet_id))
 
                 # get vehicle reports in this fleet
                 requests_in_fleet = {}
                 for report_type in reports_by_type:
-                    if report_type in (ReportType.VEHICLE_MOVE_EVENT, ReportType.VEHICLE_CHARGE_EVENT):
+                    if report_type in (ReportType.VEHICLE_MOVE_EVENT,
+                                       ReportType.VEHICLE_CHARGE_EVENT):
                         requests_in_fleet[report_type] = list(
-                            filter(
-                                _get_report_filter_func(fleet_id),
-                                reports_by_type[report_type]
-                            )
-                        )
+                            filter(_get_report_filter_func(fleet_id), reports_by_type[report_type]))
 
                 # get vehicles pooling in this fleet
                 veh_pooling_in_fleet = list(
                     filter(
-                        lambda
-                            v: v.vehicle_state.vehicle_state_type == VehicleStateType.SERVICING_POOLING_TRIP,
-                        veh_in_fleet
-                    )
-                )
+                        lambda v: v.vehicle_state.vehicle_state_type == VehicleStateType.
+                        SERVICING_POOLING_TRIP, veh_in_fleet))
 
                 # get vehicles dispatched to service pooling trips in this fleet
                 veh_dispatch_pooling_in_fleet = list(
                     filter(
-                        lambda
-                            v: v.vehicle_state.vehicle_state_type == VehicleStateType.DISPATCH_POOLING_TRIP,
-                        veh_in_fleet
-                    )
-                )
+                        lambda v: v.vehicle_state.vehicle_state_type == VehicleStateType.
+                        DISPATCH_POOLING_TRIP, veh_in_fleet))
 
                 # count the number of vehicles in each vehicle state in this fleet
                 veh_state_counts_in_fleet = Counter(
-                    map(
-                        lambda v: v.vehicle_state.vehicle_state_type.name,
-                        veh_in_fleet
-                    )
-                )
+                    map(lambda v: v.vehicle_state.vehicle_state_type.name, veh_in_fleet))
 
                 # create stats row with the time step
-                fleet_stats_row = {'time_step': time_step,
-                                   'sim_time': sim_time.as_iso_time()}
+                fleet_stats_row = {'time_step': time_step, 'sim_time': sim_time.as_iso_time()}
 
                 # get average SOC of vehicles in this fleet
                 if len(veh_in_fleet) > 0:
-                    fleet_stats_row['avg_soc_percent'] = 100 * np.mean(
-                        [env.mechatronics.get(v.mechatronics_id).fuel_source_soc(v) for v in veh_in_fleet]
-                    )
+                    fleet_stats_row['avg_soc_percent'] = 100 * np.mean([
+                        env.mechatronics.get(v.mechatronics_id).fuel_source_soc(v)
+                        for v in veh_in_fleet
+                    ])
                 else:
                     fleet_stats_row['avg_soc_percent'] = None
 
                 # get the total vkt of vehicles in this fleet
                 if ReportType.VEHICLE_MOVE_EVENT in requests_in_fleet.keys():
-                    fleet_stats_row['vkt'] = sum([me.report['distance_km'] for me in requests_in_fleet[ReportType.VEHICLE_MOVE_EVENT]])
+                    fleet_stats_row['vkt'] = sum([
+                        me.report['distance_km']
+                        for me in requests_in_fleet[ReportType.VEHICLE_MOVE_EVENT]
+                    ])
                 else:
                     fleet_stats_row['vkt'] = 0
 
                 # get number of assigned requests in this fleet
                 assigned_requests = veh_state_counts_in_fleet[VehicleStateType.DISPATCH_TRIP.name]
-                assigned_pooling_requests = sum([len(v.vehicle_state.trip_plan) for v in veh_dispatch_pooling_in_fleet])
+                assigned_pooling_requests = sum(
+                    [len(v.vehicle_state.trip_plan) for v in veh_dispatch_pooling_in_fleet])
                 fleet_stats_row['assigned_requests'] = assigned_requests + assigned_pooling_requests
 
                 # add number of active requests in this time step (unassigned)
@@ -282,8 +269,10 @@ class TimeStepStatsHandler(Handler):
 
                 # get count of requests currently being serviced by a vehicle
                 servicing_requests = veh_state_counts_in_fleet[VehicleStateType.SERVICING_TRIP.name]
-                servicing_pooling_requests = sum([len(v.vehicle_state.boarded_requests) for v in veh_pooling_in_fleet])
-                fleet_stats_row['servicing_requests'] = servicing_requests + servicing_pooling_requests
+                servicing_pooling_requests = sum(
+                    [len(v.vehicle_state.boarded_requests) for v in veh_pooling_in_fleet])
+                fleet_stats_row[
+                    'servicing_requests'] = servicing_requests + servicing_pooling_requests
 
                 # add the number of vehicles in each vehicle state in this fleet
                 fleet_stats_row['vehicles'] = len(veh_in_fleet)
@@ -291,24 +280,18 @@ class TimeStepStatsHandler(Handler):
                     fleet_stats_row[f'vehicles_{state.lower()}'] = veh_state_counts_in_fleet[state]
 
                 available_driver_counts_in_fleet = Counter(
-                    map(
-                        lambda v: v.driver_state.available,
-                        veh_in_fleet
-                    )
-                )
+                    map(lambda v: v.driver_state.available, veh_in_fleet))
                 fleet_stats_row['drivers_available'] = available_driver_counts_in_fleet[True]
                 fleet_stats_row['drivers_unavailable'] = available_driver_counts_in_fleet[False]
 
                 # count number of chargers in use by type
                 if ReportType.VEHICLE_CHARGE_EVENT in requests_in_fleet.keys():
                     charger_counts_in_fleet = Counter(
-                        map(
-                            lambda r: r.report['charger_id'],
-                            requests_in_fleet[ReportType.VEHICLE_CHARGE_EVENT]
-                        )
-                    )
+                        map(lambda r: r.report['charger_id'],
+                            requests_in_fleet[ReportType.VEHICLE_CHARGE_EVENT]))
                     for charger in env.chargers.keys():
-                        fleet_stats_row[f'charger_{charger.lower()}'] = charger_counts_in_fleet[charger]
+                        fleet_stats_row[f'charger_{charger.lower()}'] = charger_counts_in_fleet[
+                            charger]
                 else:
                     for charger in env.chargers.keys():
                         fleet_stats_row[f'charger_{charger.lower()}'] = 0
@@ -323,13 +306,16 @@ class TimeStepStatsHandler(Handler):
         :return:
         """
         if self.log_time_step_stats:
-            pd.DataFrame.to_csv(self.get_time_step_stats(), self.time_step_stats_outpath, index=False)
+            pd.DataFrame.to_csv(self.get_time_step_stats(),
+                                self.time_step_stats_outpath,
+                                index=False)
             log.info(f"time step stats written to {self.time_step_stats_outpath}")
 
         if self.log_fleet_time_step_stats:
             os.mkdir(self.fleets_timestep_stats_outpath)
             for fleet_id, fleet_df in self.get_fleet_time_step_stats().items():
                 if fleet_df is not None:
-                    outpath = self.fleets_timestep_stats_outpath.joinpath(f'{self.file_name}_{fleet_id}.csv')
+                    outpath = self.fleets_timestep_stats_outpath.joinpath(
+                        f'{self.file_name}_{fleet_id}.csv')
                     pd.DataFrame.to_csv(fleet_df, outpath, index=False)
                     log.info(f"fleet id: {fleet_id} time step stats written to {outpath}")

--- a/hive/reporting/handler/vehicle_charge_events_handler.py
+++ b/hive/reporting/handler/vehicle_charge_events_handler.py
@@ -12,10 +12,14 @@ class VehicleChargeEventsHandler(Handler):
     """
     allows grid co-simulation to observe the charging events within a time delta of hive
     """
-
-
     def __init__(self) -> None:
-        self.prototype = {'vehicle_id': [], 'sim_time_start': [], 'sim_time_end': [], 'energy': [], 'units': []}
+        self.prototype = {
+            'vehicle_id': [],
+            'sim_time_start': [],
+            'sim_time_end': [],
+            'energy': [],
+            'units': []
+        }
         self.events = self.prototype.copy()
 
     def handle(self, reports: List[Report], runner_payload: RunnerPayload):
@@ -28,7 +32,8 @@ class VehicleChargeEventsHandler(Handler):
                     self.events['energy'].append(report.report['energy'])
                     self.events['units'].append(report.report['energy_units'])
                 except KeyError as e:
-                    raise SimulationStateError(f'unable to parse charge event from report {report}, missing entry for {e}')
+                    raise SimulationStateError(
+                        f'unable to parse charge event from report {report}, missing entry for {e}')
 
     def get_events(self):
         """
@@ -47,4 +52,3 @@ class VehicleChargeEventsHandler(Handler):
 
     def close(self, runner_payload: RunnerPayload):
         pass
-

--- a/hive/reporting/instruction_generator_event_ops.py
+++ b/hive/reporting/instruction_generator_event_ops.py
@@ -25,18 +25,16 @@ def refuel_search_event(vehicle: Vehicle, sim: SimulationState, env: Environment
     lat, lon = h3.h3_to_geo(vehicle.geoid)
     point_wkt = wkt.point_2d((lat, lon), env.config.global_config.wkt_x_y_ordering)
     next_sim_time = sim.sim_time + sim.sim_timestep_duration_seconds
-    report = Report(
-        report_type=ReportType.REFUEL_SEARCH_EVENT,
-        report={
-            'vehicle_id': vehicle.id,
-            'vehicle_state': vehicle.vehicle_state.__class__.__name__,
-            'vehicle_memberships': vehicle.membership.to_json(),
-            'sim_time_start': sim.sim_time,
-            'sim_time_end': next_sim_time,
-            'lat': lat,
-            'lon': lon,
-            'geoid': vehicle.geoid,
-            'wkt': point_wkt
-        }
-    )
+    report = Report(report_type=ReportType.REFUEL_SEARCH_EVENT,
+                    report={
+                        'vehicle_id': vehicle.id,
+                        'vehicle_state': vehicle.vehicle_state.__class__.__name__,
+                        'vehicle_memberships': vehicle.membership.to_json(),
+                        'sim_time_start': sim.sim_time,
+                        'sim_time_end': next_sim_time,
+                        'lat': lat,
+                        'lon': lon,
+                        'geoid': vehicle.geoid,
+                        'wkt': point_wkt
+                    })
     return report

--- a/hive/reporting/reporter.py
+++ b/hive/reporting/reporter.py
@@ -29,7 +29,6 @@ class Reporter:
     """
     A class that generates reports for the simulation.
     """
-
     def __init__(self):
         self.reports: List[Report] = []
         self.handlers: List[Handler] = []
@@ -71,7 +70,8 @@ class Reporter:
                 final_report = handler.get_stats(rp)
         return final_report
 
-    def get_time_step_stats(self) -> Tuple[Optional[DataFrame], Optional[Map[MembershipId, DataFrame]]]:
+    def get_time_step_stats(
+            self) -> Tuple[Optional[DataFrame], Optional[Map[MembershipId, DataFrame]]]:
         """
         if a TimeStepStatsHandler exists, return the time step stats DataFrame and the fleet time step stats DataFrames
         :return: the time step stats DataFrame and the fleet time step stats collection of DataFrames if they exist

--- a/hive/reporting/reporter_ops.py
+++ b/hive/reporting/reporter_ops.py
@@ -20,7 +20,6 @@ def log_station_capacities(sim: SimulationState, env: Environment) -> IOResultE[
     :param env: the environment with a Reporter instance
     :return: nothing, or, any exception
     """
-
     def _station_energy(station: Station) -> dict:
         """
         get the Kw capacity of a given station
@@ -31,19 +30,14 @@ def log_station_capacities(sim: SimulationState, env: Environment) -> IOResultE[
         # TODO: now that we've introduced other energy types, we should return a summary of charger rate by
         #  energy time with corresponding units - ndr
         rate: float = ft.reduce(
-            lambda acc, charger_id: acc + station.total_chargers.get(charger_id) * env.chargers.get(charger_id).rate,
-            station.available_chargers.keys(),
-            0.0
-        )
+            lambda acc, charger_id: acc + station.total_chargers.get(charger_id) * env.chargers.get(
+                charger_id).rate, station.available_chargers.keys(), 0.0)
 
         return {'station_id': station.id, 'rate': rate}
 
     try:
-        result: Tuple[immutables.Map, ...] = ft.reduce(
-            lambda acc, s: acc + (_station_energy(s),),
-            sim.stations.values(),
-            ()
-        )
+        result: Tuple[immutables.Map, ...] = ft.reduce(lambda acc, s: acc + (_station_energy(s), ),
+                                                       sim.stations.values(), ())
 
         output_file = Path(env.config.scenario_output_directory).joinpath("station_capacities.csv")
         with output_file.open('w') as f:

--- a/hive/resources/mock_lobster.py
+++ b/hive/resources/mock_lobster.py
@@ -53,7 +53,6 @@ from hive.util.units import *
 
 
 class DefaultIds:
-
     @classmethod
     def mock_request_id(cls) -> RequestId:
         return "r0"
@@ -96,19 +95,26 @@ def somewhere_else() -> GeoId:
 
 
 def mock_geojson() -> Dict:
-    return {'type': 'Feature',
-            'properties': {'id': None},
-            'geometry': {'type': 'Polygon',
-                         'coordinates': [[[-105.00029227609865, 39.74962517224048],
-                                          [-104.98738065320869, 39.73994639686878],
-                                          [-104.97341667234025, 39.74000864414065],
-                                          [-104.97337619703339, 39.767951988786585],
-                                          [-104.97511663522859, 39.769196417473],
-                                          [-105.00029227609865, 39.74962517224048]]]}}
+    return {
+        'type': 'Feature',
+        'properties': {
+            'id': None
+        },
+        'geometry': {
+            'type':
+            'Polygon',
+            'coordinates': [[[-105.00029227609865, 39.74962517224048],
+                             [-104.98738065320869, 39.73994639686878],
+                             [-104.97341667234025, 39.74000864414065],
+                             [-104.97337619703339, 39.767951988786585],
+                             [-104.97511663522859, 39.769196417473],
+                             [-105.00029227609865, 39.74962517224048]]]
+        }
+    }
 
 
 def mock_membership():
-    return Membership().from_tuple((DefaultIds.mock_membership_id(),))
+    return Membership().from_tuple((DefaultIds.mock_membership_id(), ))
 
 
 def mock_geofence(geojson: Dict = mock_geojson(), resolution: H3Resolution = 10) -> GeoFence:
@@ -142,13 +148,14 @@ def mock_base(
         road_network: RoadNetwork = mock_network(),
         membership: Membership = Membership(),
 ) -> Base:
-    return Base.build(base_id,
-                      h3.geo_to_h3(lat, lon, h3_res),
-                      road_network,
-                      station_id,
-                      stall_count,
-                      membership,
-                      )
+    return Base.build(
+        base_id,
+        h3.geo_to_h3(lat, lon, h3_res),
+        road_network,
+        station_id,
+        stall_count,
+        membership,
+    )
 
 
 def mock_base_from_geoid(
@@ -176,8 +183,8 @@ def mock_station(
         chargers = immutables.Map({mock_l2_charger_id(): 1, mock_dcfc_charger_id(): 1})
     if on_shift_access_chargers is None:
         on_shift_access_chargers = frozenset(chargers.keys())
-    return Station.build(station_id, h3.geo_to_h3(lat, lon, h3_res), road_network, chargers, on_shift_access_chargers,
-                         membership)
+    return Station.build(station_id, h3.geo_to_h3(lat, lon, h3_res), road_network, chargers,
+                         on_shift_access_chargers, membership)
 
 
 def mock_station_from_geoid(
@@ -194,14 +201,13 @@ def mock_station_from_geoid(
         chargers = immutables.Map(chargers)
     if on_shift_access_chargers is None:
         on_shift_access_chargers = frozenset(chargers.keys())
-    return Station.build(station_id, geoid, road_network, chargers, on_shift_access_chargers, membership)
+    return Station.build(station_id, geoid, road_network, chargers, on_shift_access_chargers,
+                         membership)
 
 
-def mock_rate_structure(
-        base_price: Currency = 2.2,
-        price_per_mile: Currency = 1.6,
-        minimum_price: Currency = 5
-) -> RequestRateStructure:
+def mock_rate_structure(base_price: Currency = 2.2,
+                        price_per_mile: Currency = 1.6,
+                        minimum_price: Currency = 5) -> RequestRateStructure:
     return RequestRateStructure(
         base_price=base_price,
         price_per_mile=price_per_mile,
@@ -209,53 +215,45 @@ def mock_rate_structure(
     )
 
 
-def mock_request(
-        request_id: RequestId = DefaultIds.mock_request_id(),
-        o_lat: float = 39.7539,
-        o_lon: float = -104.974,
-        d_lat: float = 39.7579,
-        d_lon: float = -104.978,
-        h3_res: int = 15,
-        road_network: RoadNetwork = mock_network(),
-        departure_time: SimTime = 0,
-        passengers: int = 1,
-        fleet_id: Optional[MembershipId] = None,
-        allows_pooling: bool = False
-) -> Request:
-    return Request.build(
-        request_id=request_id,
-        origin=h3.geo_to_h3(o_lat, o_lon, h3_res),
-        destination=h3.geo_to_h3(d_lat, d_lon, h3_res),
-        road_network=road_network,
-        departure_time=departure_time,
-        passengers=passengers,
-        fleet_id=fleet_id,
-        allows_pooling=allows_pooling
-    )
+def mock_request(request_id: RequestId = DefaultIds.mock_request_id(),
+                 o_lat: float = 39.7539,
+                 o_lon: float = -104.974,
+                 d_lat: float = 39.7579,
+                 d_lon: float = -104.978,
+                 h3_res: int = 15,
+                 road_network: RoadNetwork = mock_network(),
+                 departure_time: SimTime = 0,
+                 passengers: int = 1,
+                 fleet_id: Optional[MembershipId] = None,
+                 allows_pooling: bool = False) -> Request:
+    return Request.build(request_id=request_id,
+                         origin=h3.geo_to_h3(o_lat, o_lon, h3_res),
+                         destination=h3.geo_to_h3(d_lat, d_lon, h3_res),
+                         road_network=road_network,
+                         departure_time=departure_time,
+                         passengers=passengers,
+                         fleet_id=fleet_id,
+                         allows_pooling=allows_pooling)
 
 
-def mock_request_from_geoids(
-        request_id: RequestId = DefaultIds.mock_request_id(),
-        origin: GeoId = h3.geo_to_h3(39.7539, -104.974, 15),
-        destination: GeoId = h3.geo_to_h3(39.7579, -104.978, 15),
-        road_network: RoadNetwork = mock_network(),
-        departure_time: SimTime = SimTime(0),
-        passengers: int = 1,
-        value: Currency = 0,
-        fleet_id: Optional[MembershipId] = None,
-        allows_pooling: bool = False
-) -> Request:
-    return Request.build(
-        request_id=request_id,
-        origin=origin,
-        destination=destination,
-        road_network=road_network,
-        departure_time=departure_time,
-        passengers=passengers,
-        value=value,
-        fleet_id=fleet_id,
-        allows_pooling=allows_pooling
-    )
+def mock_request_from_geoids(request_id: RequestId = DefaultIds.mock_request_id(),
+                             origin: GeoId = h3.geo_to_h3(39.7539, -104.974, 15),
+                             destination: GeoId = h3.geo_to_h3(39.7579, -104.978, 15),
+                             road_network: RoadNetwork = mock_network(),
+                             departure_time: SimTime = SimTime(0),
+                             passengers: int = 1,
+                             value: Currency = 0,
+                             fleet_id: Optional[MembershipId] = None,
+                             allows_pooling: bool = False) -> Request:
+    return Request.build(request_id=request_id,
+                         origin=origin,
+                         destination=destination,
+                         road_network=road_network,
+                         departure_time=departure_time,
+                         passengers=passengers,
+                         value=value,
+                         fleet_id=fleet_id,
+                         allows_pooling=allows_pooling)
 
 
 def mock_ev_powertrain(nominal_watt_hour_per_mile) -> TabularPowertrain:
@@ -267,8 +265,8 @@ def mock_ev_powertrain(nominal_watt_hour_per_mile) -> TabularPowertrain:
 
 
 def mock_powercurve(
-        nominal_max_charge_kw=50,
-        battery_capacity_kwh=50,
+    nominal_max_charge_kw=50,
+    battery_capacity_kwh=50,
 ) -> TabularPowercurve:
     powercurve_file = resource_filename("hive.resources.powercurve", "normalized.yaml")
     with Path(powercurve_file).open() as f:
@@ -281,11 +279,11 @@ def mock_powercurve(
 
 
 def mock_bev(
-        battery_capacity_kwh=50,
-        idle_kwh_per_hour=0.8,
-        nominal_watt_hour_per_mile=225,
-        nominal_max_charge_kw=50,
-        charge_taper_cutoff_kw=10,
+    battery_capacity_kwh=50,
+    idle_kwh_per_hour=0.8,
+    nominal_watt_hour_per_mile=225,
+    nominal_max_charge_kw=50,
+    charge_taper_cutoff_kw=10,
 ) -> BEV:
     return BEV(
         mechatronics_id='bev',
@@ -307,9 +305,9 @@ def mock_ice_powertrain(nominal_miles_per_gallon) -> TabularPowertrain:
 
 
 def mock_ice(
-        tank_capacity_gallons=15,
-        idle_gallons_per_hour=0.2,
-        nominal_miles_per_gallon=30,
+    tank_capacity_gallons=15,
+    idle_gallons_per_hour=0.2,
+    nominal_miles_per_gallon=30,
 ) -> ICE:
     # source: https://www.energy.gov/eere/vehicles/
     #   fact-861-february-23-2015-idle-fuel-consumption-selected-gasoline-and-diesel-vehicles
@@ -322,68 +320,62 @@ def mock_ice(
     )
 
 
-def mock_vehicle(
-        vehicle_id: VehicleId = DefaultIds.mock_vehicle_id(),
-        lat: float = 39.7539,
-        lon: float = -104.974,
-        h3_res: int = 15,
-        mechatronics: MechatronicsInterface = mock_bev(),
-        vehicle_state: Optional[VehicleState] = None,
-        soc: Ratio = 1,
-        driver_state: Optional[DriverState] = None,
-        membership: Membership = Membership(),
-        total_seats: int = 999
-) -> Vehicle:
+def mock_vehicle(vehicle_id: VehicleId = DefaultIds.mock_vehicle_id(),
+                 lat: float = 39.7539,
+                 lon: float = -104.974,
+                 h3_res: int = 15,
+                 mechatronics: MechatronicsInterface = mock_bev(),
+                 vehicle_state: Optional[VehicleState] = None,
+                 soc: Ratio = 1,
+                 driver_state: Optional[DriverState] = None,
+                 membership: Membership = Membership(),
+                 total_seats: int = 999) -> Vehicle:
     v_state = vehicle_state if vehicle_state else Idle(vehicle_id)
     road_network = mock_network(h3_res)
     initial_energy = mechatronics.initial_energy(soc)
     geoid = h3.geo_to_h3(lat, lon, road_network.sim_h3_resolution)
-    d_state = driver_state if driver_state else AutonomousAvailable(AutonomousDriverAttributes(vehicle_id))
+    d_state = driver_state if driver_state else AutonomousAvailable(
+        AutonomousDriverAttributes(vehicle_id))
     position = road_network.position_from_geoid(geoid)
-    return Vehicle(
-        id=vehicle_id,
-        mechatronics_id=mechatronics.mechatronics_id,
-        energy=initial_energy,
-        position=position,
-        vehicle_state=v_state,
-        driver_state=d_state,
-        membership=membership,
-        total_seats=total_seats
-    )
+    return Vehicle(id=vehicle_id,
+                   mechatronics_id=mechatronics.mechatronics_id,
+                   energy=initial_energy,
+                   position=position,
+                   vehicle_state=v_state,
+                   driver_state=d_state,
+                   membership=membership,
+                   total_seats=total_seats)
 
 
-def mock_vehicle_from_geoid(
-        vehicle_id: VehicleId = DefaultIds.mock_vehicle_id(),
-        geoid: GeoId = h3.geo_to_h3(39.7539, -104.974, 15),
-        mechatronics: MechatronicsInterface = mock_bev(),
-        vehicle_state: Optional[VehicleState] = None,
-        soc: Ratio = 1,
-        driver_state: Optional[DriverState] = None,
-        membership: Membership = Membership(),
-        total_seats: int = 999
-) -> Vehicle:
+def mock_vehicle_from_geoid(vehicle_id: VehicleId = DefaultIds.mock_vehicle_id(),
+                            geoid: GeoId = h3.geo_to_h3(39.7539, -104.974, 15),
+                            mechatronics: MechatronicsInterface = mock_bev(),
+                            vehicle_state: Optional[VehicleState] = None,
+                            soc: Ratio = 1,
+                            driver_state: Optional[DriverState] = None,
+                            membership: Membership = Membership(),
+                            total_seats: int = 999) -> Vehicle:
     state = vehicle_state if vehicle_state else Idle(vehicle_id)
     initial_energy = mechatronics.initial_energy(soc)
-    d_state = driver_state if driver_state else AutonomousAvailable(AutonomousDriverAttributes(vehicle_id))
+    d_state = driver_state if driver_state else AutonomousAvailable(
+        AutonomousDriverAttributes(vehicle_id))
     position = mock_network().position_from_geoid(geoid)
-    return Vehicle(
-        id=vehicle_id,
-        mechatronics_id=mechatronics.mechatronics_id,
-        energy=initial_energy,
-        position=position,
-        vehicle_state=state,
-        driver_state=d_state,
-        membership=membership,
-        total_seats=total_seats
-    )
+    return Vehicle(id=vehicle_id,
+                   mechatronics_id=mechatronics.mechatronics_id,
+                   energy=initial_energy,
+                   position=position,
+                   vehicle_state=state,
+                   driver_state=d_state,
+                   membership=membership,
+                   total_seats=total_seats)
 
 
 def mock_human_driver(available: bool = True,
                       schedule_id: ScheduleId = DefaultIds.mock_schedule_id(),
                       home_base_id: BaseId = DefaultIds.mock_base_id(),
-                      allows_pooling: bool = True
-                      ):
-    attr = HumanDriverAttributes(DefaultIds.mock_vehicle_id(), schedule_id, home_base_id, allows_pooling)
+                      allows_pooling: bool = True):
+    attr = HumanDriverAttributes(DefaultIds.mock_vehicle_id(), schedule_id, home_base_id,
+                                 allows_pooling)
     state = HumanAvailable(attr) if available else HumanUnavailable(attr)
     return state
 
@@ -414,7 +406,6 @@ def mock_sim(
         :return: the updated sim
         ;raises: Exception when an add fails
         """
-
         def _inner(s: SimulationState, to_add):
             error, result = fn(s, to_add)
             if error:
@@ -424,20 +415,22 @@ def mock_sim(
 
         return _inner
 
-    sim_v = ft.reduce(add_or_throw(simulation_state_ops.add_vehicle), vehicles, sim) if vehicles else sim
-    sim_s = ft.reduce(add_or_throw(simulation_state_ops.add_station), stations, sim_v) if stations else sim_v
+    sim_v = ft.reduce(add_or_throw(simulation_state_ops.add_vehicle), vehicles,
+                      sim) if vehicles else sim
+    sim_s = ft.reduce(add_or_throw(simulation_state_ops.add_station), stations,
+                      sim_v) if stations else sim_v
     sim_b = ft.reduce(add_or_throw(simulation_state_ops.add_base), bases, sim_s) if bases else sim_s
 
     return sim_b
 
 
 def mock_config(
-        start_time: Union[str, int] = 0,
-        end_time: Union[str, int] = 100,
-        timestep_duration_seconds: Seconds = 1,
-        sim_h3_location_resolution: int = 15,
-        sim_h3_search_resolution: int = 9,
-        input: Dict = None,
+    start_time: Union[str, int] = 0,
+    end_time: Union[str, int] = 100,
+    timestep_duration_seconds: Seconds = 1,
+    sim_h3_location_resolution: int = 15,
+    sim_h3_search_resolution: int = 9,
+    input: Dict = None,
 ) -> HiveConfig:
     if not input:
         input = {
@@ -467,17 +460,18 @@ def mock_config(
             "network": {},
             "dispatcher": {}
         })
-    updated_global = conf_without_temp_dir.global_config._replace(output_base_directory=test_output_directory.name)
+    updated_global = conf_without_temp_dir.global_config._replace(
+        output_base_directory=test_output_directory.name)
 
     return conf_without_temp_dir._replace(global_config=updated_global)
 
 
 def mock_env(
-        config: HiveConfig = mock_config(),
-        mechatronics: Optional[Dict[MechatronicsId, MechatronicsInterface]] = None,
-        chargers: Optional[Dict[ChargerId, Charger]] = None,
-        schedules: Optional[Dict[ScheduleId, Callable[['SimulationState', VehicleId], bool]]] = None,
-        fleet_ids: FrozenSet[MembershipId] = frozenset([DefaultIds.mock_membership_id()])
+    config: HiveConfig = mock_config(),
+    mechatronics: Optional[Dict[MechatronicsId, MechatronicsInterface]] = None,
+    chargers: Optional[Dict[ChargerId, Charger]] = None,
+    schedules: Optional[Dict[ScheduleId, Callable[['SimulationState', VehicleId], bool]]] = None,
+    fleet_ids: FrozenSet[MembershipId] = frozenset([DefaultIds.mock_membership_id()])
 ) -> Environment:
     if mechatronics is None:
         mechatronics = {
@@ -492,21 +486,18 @@ def mock_env(
         }
 
     if schedules is None:
+
         def always_on_schedule(a, b):
             return True
 
-        schedules = {
-            DefaultIds.mock_schedule_id(): always_on_schedule
-        }
+        schedules = {DefaultIds.mock_schedule_id(): always_on_schedule}
 
-    initial_env = Environment(
-        config=config,
-        reporter=mock_reporter(),
-        mechatronics=immutables.Map(mechatronics),
-        chargers=immutables.Map(chargers),
-        schedules=immutables.Map(schedules),
-        fleet_ids=fleet_ids
-    )
+    initial_env = Environment(config=config,
+                              reporter=mock_reporter(),
+                              mechatronics=immutables.Map(mechatronics),
+                              chargers=immutables.Map(chargers),
+                              schedules=immutables.Map(schedules),
+                              fleet_ids=fleet_ids)
 
     return initial_env
 
@@ -528,13 +519,11 @@ def mock_reporter() -> Reporter:
     return MockReporter()
 
 
-def mock_haversine_zigzag_route(
-        n: int = 3,
-        lat_step_size: int = 5,
-        lon_step_size: int = 5,
-        speed_kmph: Kmph = 40,
-        h3_res: int = 15
-) -> Route:
+def mock_haversine_zigzag_route(n: int = 3,
+                                lat_step_size: int = 5,
+                                lon_step_size: int = 5,
+                                speed_kmph: Kmph = 40,
+                                h3_res: int = 15) -> Route:
     """
     "zigs" lat steps and "zags" lon steps. all your base belong to us.
 
@@ -549,7 +538,6 @@ def mock_haversine_zigzag_route(
     :param h3_res: h3 resolution
     :return: a route
     """
-
     def step(acc: Tuple[Link, ...], i: int) -> Tuple[Link, ...]:
         """
         constructs the next Link
@@ -559,8 +547,10 @@ def mock_haversine_zigzag_route(
         :param i: what link we are making
         :return: the route with another link added
         """
-        lat_pos, lon_pos = math.floor(i / 2.0) * lat_step_size, math.floor((i + 1) / 2.0) * lon_step_size
-        lat_dest, lon_dest = math.floor((i + 1) / 2.0) * lat_step_size, math.floor((i + 2) / 2.0) * lon_step_size
+        lat_pos, lon_pos = math.floor(i / 2.0) * lat_step_size, math.floor(
+            (i + 1) / 2.0) * lon_step_size
+        lat_dest, lon_dest = math.floor((i + 1) / 2.0) * lat_step_size, math.floor(
+            (i + 2) / 2.0) * lon_step_size
         start = h3.geo_to_h3(lat_pos, lon_pos, h3_res)
         end = h3.geo_to_h3(lat_dest, lon_dest, h3_res)
         distance_km = H3Ops.great_circle_distance(start, end)
@@ -571,15 +561,12 @@ def mock_haversine_zigzag_route(
             distance_km=distance_km,
             speed_kmph=speed_kmph,
         )
-        return acc + (link,)
+        return acc + (link, )
 
     return ft.reduce(step, range(0, n), ())
 
 
-def mock_route_from_geoids(
-        src: GeoId,
-        dst: GeoId,
-        speed_kmph: Kmph = 1) -> Tuple[Link, ...]:
+def mock_route_from_geoids(src: GeoId, dst: GeoId, speed_kmph: Kmph = 1) -> Tuple[Link, ...]:
     link = Link.build("1", src, dst, speed_kmph=speed_kmph)
     return link,
 
@@ -591,19 +578,23 @@ def mock_graph_links(h3_res: int = 15, speed_kmph: Kmph = 1) -> Dict[str, Link]:
     """
 
     links = {
-        "1": Link.build("1",
-                        h3.geo_to_h3(37, 122, h3_res),
-                        h3.geo_to_h3(37.008994, 122, h3_res),
-                        speed_kmph=speed_kmph,
-                        ),
-        "2": Link.build("2",
-                        h3.geo_to_h3(37.008994, 122, h3_res),
-                        h3.geo_to_h3(37.017998, 122, h3_res),
-                        speed_kmph=speed_kmph),
-        "3": Link.build("3",
-                        h3.geo_to_h3(37.017998, 122, h3_res),
-                        h3.geo_to_h3(37.026992, 122, h3_res),
-                        speed_kmph=speed_kmph),
+        "1":
+        Link.build(
+            "1",
+            h3.geo_to_h3(37, 122, h3_res),
+            h3.geo_to_h3(37.008994, 122, h3_res),
+            speed_kmph=speed_kmph,
+        ),
+        "2":
+        Link.build("2",
+                   h3.geo_to_h3(37.008994, 122, h3_res),
+                   h3.geo_to_h3(37.017998, 122, h3_res),
+                   speed_kmph=speed_kmph),
+        "3":
+        Link.build("3",
+                   h3.geo_to_h3(37.017998, 122, h3_res),
+                   h3.geo_to_h3(37.026992, 122, h3_res),
+                   speed_kmph=speed_kmph),
     }
 
     return links
@@ -616,9 +607,7 @@ def mock_route(h3_res: int = 15, speed_kmph: Kmph = 1) -> Tuple[Link, ...]:
 def mock_forecaster(forecast: int = 1) -> ForecasterInterface:
     class MockForecaster(NamedTuple, ForecasterInterface):
         def generate_forecast(
-                self,
-                simulation_state: SimulationState
-        ) -> Tuple[ForecasterInterface, Forecast]:
+                self, simulation_state: SimulationState) -> Tuple[ForecasterInterface, Forecast]:
             f = Forecast(type=ForecastType.DEMAND, value=forecast)
             return self, f
 
@@ -626,16 +615,16 @@ def mock_forecaster(forecast: int = 1) -> ForecasterInterface:
 
 
 def mock_instruction_generators(
-        config: HiveConfig = mock_config(),
-) -> Tuple[InstructionGenerator, ...]:
+        config: HiveConfig = mock_config(), ) -> Tuple[InstructionGenerator, ...]:
     return (
         ChargingFleetManager(config.dispatcher),
         Dispatcher(config.dispatcher),
     )
 
 
-def mock_update(config: Optional[HiveConfig] = None,
-                instruction_generators: Optional[Tuple[InstructionGenerator, ...]] = None) -> Update:
+def mock_update(
+        config: Optional[HiveConfig] = None,
+        instruction_generators: Optional[Tuple[InstructionGenerator, ...]] = None) -> Update:
     if config and instruction_generators:
         return Update.build(config, instruction_generators)
     elif config:
@@ -663,19 +652,31 @@ def mock_dcfc_charger_id():
 
 
 def mock_l1_charger():
-    return Charger(mock_l1_charger_id(), energy_type=EnergyType.ELECTRIC, rate=3.3, units='kilowatts')
+    return Charger(mock_l1_charger_id(),
+                   energy_type=EnergyType.ELECTRIC,
+                   rate=3.3,
+                   units='kilowatts')
 
 
 def mock_l2_charger():
-    return Charger(mock_l2_charger_id(), energy_type=EnergyType.ELECTRIC, rate=7.2, units='kilowatts')
+    return Charger(mock_l2_charger_id(),
+                   energy_type=EnergyType.ELECTRIC,
+                   rate=7.2,
+                   units='kilowatts')
 
 
 def mock_dcfc_charger():
-    return Charger(mock_dcfc_charger_id(), energy_type=EnergyType.ELECTRIC, rate=50.0, units='kilowatts')
+    return Charger(mock_dcfc_charger_id(),
+                   energy_type=EnergyType.ELECTRIC,
+                   rate=50.0,
+                   units='kilowatts')
 
 
 def mock_gasoline_pump():
     gal_per_minute = 10  # source: https://en.wikipedia.org/wiki/Gasoline_pump
     gal_per_second = gal_per_minute / 60
 
-    return Charger("gas_pump", energy_type=EnergyType.GASOLINE, rate=gal_per_second, units='gal_gasoline')
+    return Charger("gas_pump",
+                   energy_type=EnergyType.GASOLINE,
+                   rate=gal_per_second,
+                   units='gal_gasoline')

--- a/hive/runner/local_simulation_runner.py
+++ b/hive/runner/local_simulation_runner.py
@@ -18,12 +18,12 @@ class LocalSimulationRunner(NamedTuple):
     """
     The local simulation runner.
     """
-
     @classmethod
-    def run(cls,
-            runner_payload: RunnerPayload,
-            position: int = 0,
-            ) -> RunnerPayload:
+    def run(
+        cls,
+        runner_payload: RunnerPayload,
+        position: int = 0,
+    ) -> RunnerPayload:
         """
         steps through time, running a simulation, and producing a simulation result
 
@@ -36,13 +36,11 @@ class LocalSimulationRunner(NamedTuple):
             int(runner_payload.e.config.sim.start_time),
             int(runner_payload.e.config.sim.end_time),
             runner_payload.e.config.sim.timestep_duration_seconds,
-        ), position=position)
+        ),
+                          position=position)
 
-        final_payload = ft.reduce(
-            _run_step_in_context(runner_payload.e),
-            time_steps,
-            runner_payload
-        )
+        final_payload = ft.reduce(_run_step_in_context(runner_payload.e), time_steps,
+                                  runner_payload)
 
         return final_payload
 

--- a/hive/state/driver_state/autonomous_driver_state/autonomous_available.py
+++ b/hive/state/driver_state/autonomous_driver_state/autonomous_available.py
@@ -47,10 +47,10 @@ class AutonomousAvailable(NamedTuple, DriverState):
         return None
 
     def generate_instruction(
-            self,
-            sim: SimulationState,
-            env: Environment,
-            previous_instructions: Optional[Tuple[Instruction, ...]] = None,
+        self,
+        sim: SimulationState,
+        env: Environment,
+        previous_instructions: Optional[Tuple[Instruction, ...]] = None,
     ) -> Optional[Instruction]:
 
         my_vehicle = sim.vehicles.get(self.attributes.vehicle_id)
@@ -64,6 +64,7 @@ class AutonomousAvailable(NamedTuple, DriverState):
         else:
             return None
 
-    def update(self, sim: SimulationState, env: Environment) -> Tuple[Optional[Exception], Optional[SimulationState]]:
+    def update(self, sim: SimulationState,
+               env: Environment) -> Tuple[Optional[Exception], Optional[SimulationState]]:
         # there is no other state for an autonomous driver, so, this is a noop
         return None, sim

--- a/hive/state/driver_state/autonomous_driver_state/autonomous_driver_attributes.py
+++ b/hive/state/driver_state/autonomous_driver_state/autonomous_driver_attributes.py
@@ -9,7 +9,3 @@ class AutonomousDriverAttributes(NamedTuple):
     """
     vehicle_id: VehicleId
     # agencies we can use?
-
-
-
-

--- a/hive/state/driver_state/driver_instruction_ops.py
+++ b/hive/state/driver_state/driver_instruction_ops.py
@@ -32,10 +32,10 @@ log = logging.getLogger(__name__)
 
 
 def human_charge_at_home(
-        veh: Vehicle,
-        home_base: Base,
-        sim: SimulationState,
-        env: Environment,
+    veh: Vehicle,
+    home_base: Base,
+    sim: SimulationState,
+    env: Environment,
 ) -> Optional[ChargeBaseInstruction]:
     """
     Attempts to charge at home using the lowest power charger
@@ -56,10 +56,9 @@ def human_charge_at_home(
     elif my_mechatronics.is_full(veh):
         return None
 
-    chargers = tuple(filter(
-        lambda c: my_mechatronics.valid_charger(c),
-        [env.chargers[cid] for cid in my_station.total_chargers.keys()]
-    ))
+    chargers = tuple(
+        filter(lambda c: my_mechatronics.valid_charger(c),
+               [env.chargers[cid] for cid in my_station.total_chargers.keys()]))
     if not chargers:
         return None
     else:
@@ -69,10 +68,10 @@ def human_charge_at_home(
 
 
 def human_go_home(
-        veh: Vehicle,
-        home_base: Base,
-        sim: SimulationState,
-        env: Environment,
+    veh: Vehicle,
+    home_base: Base,
+    sim: SimulationState,
+    env: Environment,
 ) -> Optional[Instruction]:
     """
     human drivers go home at the end of their shift.
@@ -100,11 +99,10 @@ def human_go_home(
                 simulation_state=sim,
                 environment=env,
                 target_soc=env.config.dispatcher.ideal_fastcharge_soc_limit,
-                charging_search_type=env.config.dispatcher.charging_search_type
-            )
+                charging_search_type=env.config.dispatcher.charging_search_type)
 
-            target_soc = mechatronics.calc_required_soc(required_range +
-                                                        env.config.dispatcher.charging_range_km_threshold)
+            target_soc = mechatronics.calc_required_soc(
+                required_range + env.config.dispatcher.charging_range_km_threshold)
         else:
             target_soc = env.config.dispatcher.ideal_fastcharge_soc_limit
 
@@ -117,19 +115,18 @@ def human_go_home(
             charge_instructions = instruct_vehicles_to_dispatch_to_station(
                 n=1,
                 max_search_radius_km=env.config.dispatcher.max_search_radius_km,
-                vehicles=(veh,),
+                vehicles=(veh, ),
                 simulation_state=sim,
                 environment=env,
                 target_soc=target_soc,
-                charging_search_type=env.config.dispatcher.charging_search_type
-            )
+                charging_search_type=env.config.dispatcher.charging_search_type)
 
             return TupleOps.head_optional(charge_instructions)
 
 
 def human_look_for_requests(
-        veh: Vehicle,
-        sim: SimulationState,
+    veh: Vehicle,
+    sim: SimulationState,
 ) -> Optional[RepositionInstruction]:
     """
     Human driver relocates in search of greener request pastures.
@@ -138,7 +135,6 @@ def human_look_for_requests(
     :param sim:
     :return:
     """
-
     def _get_reposition_location() -> Optional[Link]:
         """
         takes the most dense request search hex as a proxy for high demand areas
@@ -149,10 +145,9 @@ def human_look_for_requests(
             return None
         else:
             # find the most dense request search hex and sends vehicles to the center
-            best_search_hex = sorted(
-                [(k, len(v)) for k, v in sim.r_search.items()], key=lambda t: t[1],
-                reverse=True
-            )[0][0]
+            best_search_hex = sorted([(k, len(v)) for k, v in sim.r_search.items()],
+                                     key=lambda t: t[1],
+                                     reverse=True)[0][0]
         destination = h3.h3_to_center_child(best_search_hex, sim.sim_h3_location_resolution)
         destination_link = sim.road_network.position_from_geoid(destination)
         return destination_link
@@ -165,8 +160,8 @@ def human_look_for_requests(
 
 
 def idle_if_at_soc_limit(
-        veh: Vehicle,
-        env: Environment,
+    veh: Vehicle,
+    env: Environment,
 ) -> Optional[IdleInstruction]:
     """
     Generates an IdleInstruction if the vehicle soc is above the limit set by 
@@ -183,9 +178,9 @@ def idle_if_at_soc_limit(
 
 
 def av_charge_base_instruction(
-        veh: Vehicle,
-        sim: SimulationState,
-        env: Environment,
+    veh: Vehicle,
+    sim: SimulationState,
+    env: Environment,
 ) -> Optional[ChargeBaseInstruction]:
     """
     Autonomous vehicles will attempt to charge at the base until they reach full energy capacity
@@ -209,10 +204,9 @@ def av_charge_base_instruction(
         return None
     my_mechatronics = env.mechatronics.get(veh.mechatronics_id)
 
-    chargers = tuple(filter(
-        lambda c: my_mechatronics.valid_charger(c),
-        [env.chargers[cid] for cid in my_station.total_chargers.keys()]
-    ))
+    chargers = tuple(
+        filter(lambda c: my_mechatronics.valid_charger(c),
+               [env.chargers[cid] for cid in my_station.total_chargers.keys()]))
 
     if not chargers:
         return None
@@ -223,9 +217,9 @@ def av_charge_base_instruction(
 
 
 def av_dispatch_base_instruction(
-        veh: Vehicle,
-        sim: SimulationState,
-        env: Environment,
+    veh: Vehicle,
+    sim: SimulationState,
+    env: Environment,
 ) -> Optional[DispatchBaseInstruction]:
     """
     Autonomous vehicles will return to a base after 10 minutes of being idle;

--- a/hive/state/driver_state/driver_state.py
+++ b/hive/state/driver_state/driver_state.py
@@ -18,7 +18,6 @@ class DriverState(ABCMeta, NamedTupleMeta, EntityState):
     """
     superclass for all driver state instances
     """
-
     @property
     @abstractmethod
     def schedule_id(cls) -> Optional[ScheduleId]:
@@ -45,10 +44,10 @@ class DriverState(ABCMeta, NamedTupleMeta, EntityState):
 
     @abstractmethod
     def generate_instruction(
-            self,
-            sim: SimulationState,
-            env: Environment,
-            previous_instructions: Optional[Tuple[Instruction, ...]] = None,
+        self,
+        sim: SimulationState,
+        env: Environment,
+        previous_instructions: Optional[Tuple[Instruction, ...]] = None,
     ) -> Optional[Instruction]:
         """
         allows the driver state to issue an optional instruction for the vehicle considering all the
@@ -62,8 +61,8 @@ class DriverState(ABCMeta, NamedTupleMeta, EntityState):
         """
         return None
 
-    def enter(self, sim: SimulationState, env: Environment) -> Tuple[
-        Optional[Exception], Optional[SimulationState]]:
+    def enter(self, sim: SimulationState,
+              env: Environment) -> Tuple[Optional[Exception], Optional[SimulationState]]:
         """
         there are no operations associated with entering a DriverState
 
@@ -73,8 +72,8 @@ class DriverState(ABCMeta, NamedTupleMeta, EntityState):
         """
         return None, sim
 
-    def exit(self, sim: SimulationState, env: Environment) -> Tuple[
-        Optional[Exception], Optional[SimulationState]]:
+    def exit(self, sim: SimulationState,
+             env: Environment) -> Tuple[Optional[Exception], Optional[SimulationState]]:
         """
         there are no operations associated with exiting a DriverState
 
@@ -85,11 +84,9 @@ class DriverState(ABCMeta, NamedTupleMeta, EntityState):
         return None, sim
 
     @classmethod
-    def apply_new_driver_state(mcs,
-                               sim: SimulationState,
-                               vehicle_id: VehicleId,
-                               new_state: DriverState
-                               ) -> Tuple[Optional[Exception], Optional[SimulationState]]:
+    def apply_new_driver_state(
+            mcs, sim: SimulationState, vehicle_id: VehicleId,
+            new_state: DriverState) -> Tuple[Optional[Exception], Optional[SimulationState]]:
         """
         helper for updating a Vehicle with a new DriverState
 
@@ -101,18 +98,16 @@ class DriverState(ABCMeta, NamedTupleMeta, EntityState):
         vehicle = sim.vehicles.get(vehicle_id)
         if not vehicle:
             state_name = new_state.__class__.__name__
-            return SimulationStateError(f"vehicle {vehicle_id} not found; context: applying new {state_name} driver state"), None
+            return SimulationStateError(
+                f"vehicle {vehicle_id} not found; context: applying new {state_name} driver state"
+            ), None
         else:
             updated_vehicle = vehicle.modify_driver_state(new_state)
             return simulation_state_ops.modify_vehicle(sim, updated_vehicle)
 
     @classmethod
-    def build(mcs,
-              vehicle_id: VehicleId,
-              schedule_id: Optional[ScheduleId],
-              base_id: Optional[BaseId],
-              allows_pooling: bool
-              ) -> DriverState:
+    def build(mcs, vehicle_id: VehicleId, schedule_id: Optional[ScheduleId],
+              base_id: Optional[BaseId], allows_pooling: bool) -> DriverState:
         """
         constructs a new DriverState based on the provided arguments
 
@@ -132,5 +127,6 @@ class DriverState(ABCMeta, NamedTupleMeta, EntityState):
         else:
             if not base_id:
                 raise Exception("cannot build a vehicle with schedule but not a home base id")
-            driver_state = HumanUnavailable(HumanDriverAttributes(vehicle_id, schedule_id, base_id, allows_pooling))
+            driver_state = HumanUnavailable(
+                HumanDriverAttributes(vehicle_id, schedule_id, base_id, allows_pooling))
             return driver_state

--- a/hive/state/driver_state/human_driver_state/human_driver_attributes.py
+++ b/hive/state/driver_state/human_driver_state/human_driver_attributes.py
@@ -13,7 +13,3 @@ class HumanDriverAttributes(NamedTuple):
     allows_pooling: bool
     # start_time: SimTime ?
     # agency_ids: frozenset[AgencyId] ?
-
-
-
-

--- a/hive/state/driver_state/human_driver_state/human_driver_state.py
+++ b/hive/state/driver_state/human_driver_state/human_driver_state.py
@@ -5,14 +5,13 @@ from typing import NamedTuple, Tuple, Optional, TYPE_CHECKING
 
 from hive.dispatcher.instruction.instruction import Instruction
 from hive.dispatcher.instruction.instructions import (
-    DispatchBaseInstruction, ReserveBaseInstruction,
+    DispatchBaseInstruction,
+    ReserveBaseInstruction,
 )
 from hive.reporting.driver_event_ops import driver_schedule_event, ScheduleEventType
-from hive.state.driver_state.driver_instruction_ops import (
-    human_charge_at_home,
-    idle_if_at_soc_limit,
-    human_look_for_requests,
-    human_go_home)
+from hive.state.driver_state.driver_instruction_ops import (human_charge_at_home,
+                                                            idle_if_at_soc_limit,
+                                                            human_look_for_requests, human_go_home)
 from hive.state.driver_state.driver_state import DriverState
 from hive.state.driver_state.human_driver_state.human_driver_attributes import HumanDriverAttributes
 from hive.state.driver_state.human_driver_state.human_unavailable_charge_parameters import HumanUnavailableChargeParameters
@@ -30,7 +29,6 @@ if TYPE_CHECKING:
     from hive.util.typealiases import ScheduleId
 
 log = logging.getLogger(__name__)
-
 
 # these two classes (HumanAvailable, HumanUnavailable) are in the same file in order to avoid circular references
 
@@ -59,10 +57,10 @@ class HumanAvailable(NamedTuple, DriverState):
         return cls.attributes.home_base_id
 
     def generate_instruction(
-            self,
-            sim: SimulationState,
-            env: Environment,
-            previous_instructions: Optional[Tuple[Instruction, ...]] = None,
+        self,
+        sim: SimulationState,
+        env: Environment,
+        previous_instructions: Optional[Tuple[Instruction, ...]] = None,
     ) -> Optional[Instruction]:
 
         my_vehicle = sim.vehicles.get(self.attributes.vehicle_id)
@@ -86,10 +84,8 @@ class HumanAvailable(NamedTuple, DriverState):
         else:
             return None
 
-    def update(self,
-               sim: SimulationState,
-               env: Environment
-               ) -> Tuple[Optional[Exception], Optional[SimulationState]]:
+    def update(self, sim: SimulationState,
+               env: Environment) -> Tuple[Optional[Exception], Optional[SimulationState]]:
         """
         test that the agent is available to work. if unavailable, transition to an unavailable state.
 
@@ -106,7 +102,9 @@ class HumanAvailable(NamedTuple, DriverState):
             return None, sim
         elif not vehicle:
             state_name = self.__class__.__name__
-            error = SimulationStateError(f"vehicle {self.attributes.vehicle_id} not found; context: update {state_name} driver state")
+            error = SimulationStateError(
+                f"vehicle {self.attributes.vehicle_id} not found; context: update {state_name} driver state"
+            )
             return error, None
         else:
             # log transition
@@ -114,11 +112,11 @@ class HumanAvailable(NamedTuple, DriverState):
             env.reporter.file_report(report)
 
             # transition to unavailable
-            charge_params = HumanUnavailableChargeParameters.build(vehicle, self.attributes.home_base_id, sim, env)
+            charge_params = HumanUnavailableChargeParameters.build(vehicle,
+                                                                   self.attributes.home_base_id,
+                                                                   sim, env)
             next_state = HumanUnavailable(self.attributes, charge_params)
-            result = DriverState.apply_new_driver_state(sim,
-                                                        self.attributes.vehicle_id,
-                                                        next_state)
+            result = DriverState.apply_new_driver_state(sim, self.attributes.vehicle_id, next_state)
             return result
 
 
@@ -146,10 +144,10 @@ class HumanUnavailable(NamedTuple, DriverState):
         return cls.attributes.home_base_id
 
     def generate_instruction(
-            self,
-            sim: SimulationState,
-            env: Environment,
-            previous_instructions: Optional[Tuple[Instruction, ...]] = None,
+        self,
+        sim: SimulationState,
+        env: Environment,
+        previous_instructions: Optional[Tuple[Instruction, ...]] = None,
     ) -> Optional[Instruction]:
         """
         while in this state, the driver checks the vehicle location; if the vehicle is not at the home base,
@@ -180,31 +178,35 @@ class HumanUnavailable(NamedTuple, DriverState):
                 if isinstance(my_vehicle.vehicle_state, DispatchBase):
                     # stick with the plan
                     return None
-                if isinstance(my_vehicle.vehicle_state, DispatchStation) or isinstance(my_vehicle.vehicle_state, ChargingStation):
+                if isinstance(my_vehicle.vehicle_state, DispatchStation) or isinstance(
+                        my_vehicle.vehicle_state, ChargingStation):
                     remaining_range = my_mechatronics.range_remaining_km(my_vehicle)
                     if self.charge_params.remaining_range_target and remaining_range < self.charge_params.remaining_range_target:
                         # stick with the plan (charging)
                         return None
                     else:
                         # we have charged to our charge target, or, have no charging target
-                        instruction = DispatchBaseInstruction(self.attributes.vehicle_id, self.attributes.home_base_id)
+                        instruction = DispatchBaseInstruction(self.attributes.vehicle_id,
+                                                              self.attributes.home_base_id)
                         return instruction
                 else:
                     # go home or charge on the way home if you need to
                     return human_go_home(my_vehicle, my_base, sim, env)
             else:
-                not_full = my_mechatronics.fuel_source_soc(my_vehicle) < env.config.dispatcher.ideal_fastcharge_soc_limit
-                if not_full and my_base.station_id and not isinstance(my_vehicle.vehicle_state, ChargingBase):
+                not_full = my_mechatronics.fuel_source_soc(
+                    my_vehicle) < env.config.dispatcher.ideal_fastcharge_soc_limit
+                if not_full and my_base.station_id and not isinstance(my_vehicle.vehicle_state,
+                                                                      ChargingBase):
                     # otherwise, if we're at home and we have a plug, we try to charge to full
                     return human_charge_at_home(my_vehicle, my_base, sim, env)
                 elif isinstance(my_vehicle.vehicle_state, Idle):
                     # finally, if we're at home and idling, we turn the vehicle off
-                    return ReserveBaseInstruction(self.attributes.vehicle_id, self.attributes.home_base_id)
+                    return ReserveBaseInstruction(self.attributes.vehicle_id,
+                                                  self.attributes.home_base_id)
                 else:
                     return None
 
-    def update(self,
-               sim: 'SimulationState',
+    def update(self, sim: 'SimulationState',
                env: 'Environment') -> Tuple[Optional[Exception], Optional['SimulationState']]:
         """
         test that the agent is unavailable to work. if not, transition to an available state.
@@ -219,7 +221,9 @@ class HumanUnavailable(NamedTuple, DriverState):
 
         if not vehicle:
             state_name = self.__class__.__name__
-            error = SimulationStateError(f"vehicle {self.attributes.vehicle_id} not found; context: update {state_name} driver state")
+            error = SimulationStateError(
+                f"vehicle {self.attributes.vehicle_id} not found; context: update {state_name} driver state"
+            )
             return error, None
         elif schedule_function and schedule_function(sim, self.attributes.vehicle_id):
             # log transition
@@ -230,9 +234,7 @@ class HumanUnavailable(NamedTuple, DriverState):
             #   being unavailable but not having a schedule is invalid.
             #   the schedule function returns true, so, we should be activated
             next_state = HumanAvailable(self.attributes)
-            result = DriverState.apply_new_driver_state(sim,
-                                                        self.attributes.vehicle_id,
-                                                        next_state)
+            result = DriverState.apply_new_driver_state(sim, self.attributes.vehicle_id, next_state)
             return result
         else:
             # stay unavailable

--- a/hive/state/driver_state/human_driver_state/human_unavailable_charge_parameters.py
+++ b/hive/state/driver_state/human_driver_state/human_unavailable_charge_parameters.py
@@ -19,10 +19,7 @@ class HumanUnavailableChargeParameters(NamedTuple):
     remaining_range_target: Optional[Kilometers] = None
 
     @classmethod
-    def build(cls,
-              vehicle: Vehicle,
-              home_base_id: BaseId,
-              sim: SimulationState,
+    def build(cls, vehicle: Vehicle, home_base_id: BaseId, sim: SimulationState,
               env: Environment) -> HumanUnavailableChargeParameters:
         """
         builds the parameters used to track our vehicle's need for charging. captures
@@ -61,6 +58,7 @@ class HumanUnavailableChargeParameters(NamedTuple):
             # determine if we have a charge target
             total_range_required = range_to_get_home + range_to_charger_tomorrow + buffer
             charge_target = total_range_required if total_range_required > remaining_range else None
-            charge_params = HumanUnavailableChargeParameters() if charge_target is None else HumanUnavailableChargeParameters(charge_target)
+            charge_params = HumanUnavailableChargeParameters(
+            ) if charge_target is None else HumanUnavailableChargeParameters(charge_target)
 
             return charge_params

--- a/hive/state/entity_state/entity_state.py
+++ b/hive/state/entity_state/entity_state.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 from abc import abstractmethod
 from typing import Tuple, Optional
 
-
 # if TYPE_CHECKING:
 #     from hive.state.simulation_state import SimulationState
 #     from hive.runner.environment import Environment
@@ -12,12 +11,12 @@ class EntityState:
     """
     a state representation along with methods for state transitions and discrete time step updates
     """
-
     @abstractmethod
-    def update(self,
-               sim: 'SimulationState',
-               env: 'Environment',
-               ) -> Tuple[Optional[Exception], Optional['SimulationState']]:
+    def update(
+        self,
+        sim: 'SimulationState',
+        env: 'Environment',
+    ) -> Tuple[Optional[Exception], Optional['SimulationState']]:
         """
         apply any effects due to an entity being advanced one discrete time unit in this EntityState
 
@@ -28,8 +27,7 @@ class EntityState:
         pass
 
     @abstractmethod
-    def enter(self,
-              sim: 'SimulationState',
+    def enter(self, sim: 'SimulationState',
               env: 'Environment') -> Tuple[Optional[Exception], Optional['SimulationState']]:
         """
         apply any effects due to an entity transitioning into this state
@@ -41,9 +39,7 @@ class EntityState:
         pass
 
     @abstractmethod
-    def exit(self,
-             next_state: EntityState,
-             sim: 'SimulationState',
+    def exit(self, next_state: EntityState, sim: 'SimulationState',
              env: 'Environment') -> Tuple[Optional[Exception], Optional['SimulationState']]:
         """
         apply any effects due to an entity transitioning out of this state

--- a/hive/state/entity_state/entity_state_ops.py
+++ b/hive/state/entity_state/entity_state_ops.py
@@ -34,9 +34,7 @@ def transition_previous_to_next(
         if enter_error:
             prev_state_name = prev_state.__class__.__name__
             next_state_name = next_state.__class__.__name__
-            error = StateTransitionError(
-                repr(enter_error), prev_state_name, next_state_name
-            )
+            error = StateTransitionError(repr(enter_error), prev_state_name, next_state_name)
             return error, None
         elif not enter_sim:
             return None, None

--- a/hive/state/simulation_state/simulation_state.py
+++ b/hive/state/simulation_state/simulation_state.py
@@ -58,11 +58,11 @@ class SimulationState(NamedTuple):
     b_search: immutables.Map[GeoId, FrozenSet[BaseId]] = immutables.Map()
 
     def get_stations(
-            self,
-            filter_function: Optional[Callable[[Station], bool]] = None,
-            sort: bool = False,
-            sort_key: Callable = lambda k: k,
-            sort_reversed: bool = False,
+        self,
+        filter_function: Optional[Callable[[Station], bool]] = None,
+        sort: bool = False,
+        sort_key: Callable = lambda k: k,
+        sort_reversed: bool = False,
     ) -> Tuple[Station, ...]:
         """
         returns a tuple of stations.
@@ -77,7 +77,8 @@ class SimulationState(NamedTuple):
         """
         stations = self.stations.values()
         if filter_function and sort:
-            return tuple(filter(filter_function, sorted(stations, key=sort_key, reverse=sort_reversed)))
+            return tuple(
+                filter(filter_function, sorted(stations, key=sort_key, reverse=sort_reversed)))
         elif filter_function:
             return tuple(filter(filter_function, stations))
         elif sort:
@@ -86,11 +87,11 @@ class SimulationState(NamedTuple):
             return tuple(stations)
 
     def get_bases(
-            self,
-            filter_function: Optional[Callable[[Base], bool]] = None,
-            sort: bool = False,
-            sort_key: Callable = lambda k: k,
-            sort_reversed: bool = False,
+        self,
+        filter_function: Optional[Callable[[Base], bool]] = None,
+        sort: bool = False,
+        sort_key: Callable = lambda k: k,
+        sort_reversed: bool = False,
     ) -> Tuple[Base, ...]:
         """
         returns a tuple of bases.
@@ -106,7 +107,8 @@ class SimulationState(NamedTuple):
         bases = self.bases.values()
 
         if filter_function and sort:
-            return tuple(filter(filter_function, sorted(bases, key=sort_key, reverse=sort_reversed)))
+            return tuple(filter(filter_function, sorted(bases, key=sort_key,
+                                                        reverse=sort_reversed)))
         elif filter_function:
             return tuple(filter(filter_function, bases))
         elif sort:
@@ -115,11 +117,11 @@ class SimulationState(NamedTuple):
             return tuple(bases)
 
     def get_vehicles(
-            self,
-            filter_function: Optional[Callable[[Vehicle], bool]] = None,
-            sort: bool = False,
-            sort_key: Callable = lambda k: k,
-            sort_reversed: bool = False,
+        self,
+        filter_function: Optional[Callable[[Vehicle], bool]] = None,
+        sort: bool = False,
+        sort_key: Callable = lambda k: k,
+        sort_reversed: bool = False,
     ) -> Tuple[Vehicle, ...]:
         """
         returns a tuple of vehicles.
@@ -135,7 +137,8 @@ class SimulationState(NamedTuple):
         vehicles = self.vehicles.values()
 
         if filter_function and sort:
-            return tuple(sorted(filter(filter_function, vehicles), key=sort_key, reverse=sort_reversed))
+            return tuple(
+                sorted(filter(filter_function, vehicles), key=sort_key, reverse=sort_reversed))
         elif filter_function:
             return tuple(filter(filter_function, vehicles))
         elif sort:
@@ -144,11 +147,11 @@ class SimulationState(NamedTuple):
             return tuple(vehicles)
 
     def get_requests(
-            self,
-            filter_function: Optional[Callable[[Request], bool]] = None,
-            sort: bool = False,
-            sort_key: Callable = lambda k: k,
-            sort_reversed: bool = False,
+        self,
+        filter_function: Optional[Callable[[Request], bool]] = None,
+        sort: bool = False,
+        sort_key: Callable = lambda k: k,
+        sort_reversed: bool = False,
     ) -> Tuple[Request, ...]:
         """
         returns a tuple of requests.
@@ -163,7 +166,8 @@ class SimulationState(NamedTuple):
         """
         requests = self.requests.values()
         if filter_function and sort:
-            return tuple(filter(filter_function, sorted(requests, key=sort_key, reverse=sort_reversed)))
+            return tuple(
+                filter(filter_function, sorted(requests, key=sort_key, reverse=sort_reversed)))
         elif filter_function:
             return tuple(filter(filter_function, requests))
         elif sort:
@@ -209,8 +213,7 @@ class SimulationState(NamedTuple):
         if not vehicle or not request:
             return False
         else:
-            return geo.same_simulation_location(vehicle.geoid,
-                                                request.origin,
+            return geo.same_simulation_location(vehicle.geoid, request.origin,
                                                 self.sim_h3_location_resolution,
                                                 override_resolution)
 
@@ -232,8 +235,7 @@ class SimulationState(NamedTuple):
         if not vehicle or not station:
             return False
         else:
-            return geo.same_simulation_location(vehicle.geoid,
-                                                station.geoid,
+            return geo.same_simulation_location(vehicle.geoid, station.geoid,
                                                 self.sim_h3_location_resolution,
                                                 override_resolution)
 
@@ -255,7 +257,6 @@ class SimulationState(NamedTuple):
         if not vehicle or not base:
             return False
         else:
-            return geo.same_simulation_location(vehicle.geoid,
-                                                base.geoid,
+            return geo.same_simulation_location(vehicle.geoid, base.geoid,
                                                 self.sim_h3_location_resolution,
                                                 override_resolution)

--- a/hive/state/simulation_state/update/cancel_requests.py
+++ b/hive/state/simulation_state/update/cancel_requests.py
@@ -16,11 +16,8 @@ log = logging.getLogger(__name__)
 
 
 class CancelRequests(NamedTuple, SimulationUpdateFunction):
-
-    def update(
-            self,
-            simulation_state: SimulationState,
-            env: Environment) -> Tuple[SimulationState, Optional[CancelRequests]]:
+    def update(self, simulation_state: SimulationState,
+               env: Environment) -> Tuple[SimulationState, Optional[CancelRequests]]:
         """
         cancels requests whose cancel time has been exceeded
 
@@ -29,9 +26,7 @@ class CancelRequests(NamedTuple, SimulationUpdateFunction):
         :param env: the scenario environment
         :return: state without cancelled requests, along with this update function
         """
-
-        def _remove_from_sim(sim: SimulationState,
-                             request_id: RequestId) -> SimulationState:
+        def _remove_from_sim(sim: SimulationState, request_id: RequestId) -> SimulationState:
             """
             inner function that removes each canceled request from the sim
 
@@ -40,7 +35,7 @@ class CancelRequests(NamedTuple, SimulationUpdateFunction):
             :return: the sim without the request
             """
             this_request_cancel_time = sim.requests[
-                                           request_id].departure_time + env.config.sim.request_cancel_time_seconds
+                request_id].departure_time + env.config.sim.request_cancel_time_seconds
             if sim.sim_time < this_request_cancel_time:
                 return sim
             else:
@@ -55,11 +50,7 @@ class CancelRequests(NamedTuple, SimulationUpdateFunction):
                     env.reporter.file_report(_gen_report(request_id, sim))
                     return updated_sim
 
-        updated = ft.reduce(
-            _remove_from_sim,
-            simulation_state.requests.keys(),
-            simulation_state
-        )
+        updated = ft.reduce(_remove_from_sim, simulation_state.requests.keys(), simulation_state)
 
         return updated, None
 

--- a/hive/state/simulation_state/update/charging_price_update.py
+++ b/hive/state/simulation_state/update/charging_price_update.py
@@ -31,11 +31,12 @@ class ChargingPriceUpdate(NamedTuple, SimulationUpdateFunction):
     use_defaults: bool
 
     @classmethod
-    def build(cls,
-              charging_price_file: Optional[str],
-              chargers_file: str,
-              lazy_file_reading: bool = False,
-              ) -> ChargingPriceUpdate:
+    def build(
+        cls,
+        charging_price_file: Optional[str],
+        chargers_file: str,
+        lazy_file_reading: bool = False,
+    ) -> ChargingPriceUpdate:
         """
         reads a requests file and builds a ChargingPriceUpdate SimulationUpdateFunction
         if no charging_file is specified, builds a price update which sets all
@@ -53,17 +54,20 @@ class ChargingPriceUpdate(NamedTuple, SimulationUpdateFunction):
             # assign default price of $0.00 for any charger types
             table = build_chargers_table(chargers_file)
 
-            def create_default_price(acc: Tuple[Dict, ...], charger_id: ChargerId) -> Tuple[Dict, ...]:
+            def create_default_price(acc: Tuple[Dict, ...],
+                                     charger_id: ChargerId) -> Tuple[Dict, ...]:
                 default_price = {
                     "time": "0",
                     "station_id": "default",
                     "charger_id": charger_id,
                     "price_kwh": "0.0"
                 }
-                return acc + (default_price,)
+                return acc + (default_price, )
 
             fallback_values = ft.reduce(create_default_price, table.keys(), ())
-            stepper = DictReaderStepper.from_iterator(iter(fallback_values), "time", parser=SimTime.build)
+            stepper = DictReaderStepper.from_iterator(iter(fallback_values),
+                                                      "time",
+                                                      parser=SimTime.build)
             return ChargingPriceUpdate(stepper, True)
         else:
             charging_path = Path(charging_price_file)
@@ -71,7 +75,9 @@ class ChargingPriceUpdate(NamedTuple, SimulationUpdateFunction):
                 raise IOError(f"{charging_price_file} is not a valid path to a request file")
             else:
                 if lazy_file_reading:
-                    error, stepper = DictReaderStepper.build(charging_path, "time", parser=SimTime.build)
+                    error, stepper = DictReaderStepper.build(charging_path,
+                                                             "time",
+                                                             parser=SimTime.build)
                     if error:
                         raise error
                 else:
@@ -81,8 +87,7 @@ class ChargingPriceUpdate(NamedTuple, SimulationUpdateFunction):
 
                 return ChargingPriceUpdate(stepper, False)
 
-    def update(self,
-               sim_state: SimulationState,
+    def update(self, sim_state: SimulationState,
                env: Environment) -> Tuple[SimulationState, Optional[ChargingPriceUpdate]]:
         """
         update charging price when the simulation reaches the update's time
@@ -99,11 +104,9 @@ class ChargingPriceUpdate(NamedTuple, SimulationUpdateFunction):
             return value < current_sim_time
 
         # parse the most recently available charger_id price data up to the current sim time
-        charger_update = ft.reduce(
-            _add_row_to_this_update,
-            self.reader.read_until_stop_condition(stop_condition),
-            immutables.Map()
-        )
+        charger_update = ft.reduce(_add_row_to_this_update,
+                                   self.reader.read_until_stop_condition(stop_condition),
+                                   immutables.Map())
 
         if len(charger_update) == 0:
             # no update
@@ -115,9 +118,7 @@ class ChargingPriceUpdate(NamedTuple, SimulationUpdateFunction):
             # apply it to every station here.
             result = ft.reduce(
                 lambda sim, s_id: _update_station_prices(sim, s_id, charger_update['default']),
-                sim_state.stations.keys(),
-                sim_state
-            )
+                sim_state.stations.keys(), sim_state)
             return result, self
 
         else:
@@ -129,15 +130,13 @@ class ChargingPriceUpdate(NamedTuple, SimulationUpdateFunction):
             # we are applying only the updates related to valid StationIds with updates
             result = ft.reduce(
                 lambda sim, s_id: _update_station_prices(sim, s_id, as_station_updates[s_id]),
-                station_ids_to_update,
-                sim_state
-            )
+                station_ids_to_update, sim_state)
             return result, self
 
 
-def _add_row_to_this_update(acc: immutables.Map[str, immutables.Map[Charger, Currency]],
-                            row: Dict[str, str]
-                            ) -> immutables.Map[str, immutables.Map[Charger, Currency]]:
+def _add_row_to_this_update(
+        acc: immutables.Map[str, immutables.Map[Charger, Currency]],
+        row: Dict[str, str]) -> immutables.Map[str, immutables.Map[Charger, Currency]]:
     """
     adds a single row to an accumulator that is storing only the most recently
     observed {StationId|GeoId}/charger_id/currency combinations
@@ -170,8 +169,7 @@ def _add_row_to_this_update(acc: immutables.Map[str, immutables.Map[Charger, Cur
         return rows
 
 
-def _update_station_prices(simulation_state: SimulationState,
-                           station_id: StationId,
+def _update_station_prices(simulation_state: SimulationState, station_id: StationId,
                            prices_update: immutables.Map[Charger, Currency]) -> SimulationState:
     """
     updates a simulation state with prices for a station by station id
@@ -194,8 +192,9 @@ def _update_station_prices(simulation_state: SimulationState,
             return updated_sim
 
 
-def _map_to_station_ids(this_update: immutables.Map[str, immutables.Map[Charger, Currency]],
-                        sim: SimulationState) -> immutables.Map[StationId, immutables.Map[Charger, Currency]]:
+def _map_to_station_ids(
+        this_update: immutables.Map[str, immutables.Map[Charger, Currency]],
+        sim: SimulationState) -> immutables.Map[StationId, immutables.Map[Charger, Currency]]:
     """
     in the case that updates are written by GeoId, map those to StationIds
 
@@ -215,13 +214,14 @@ def _map_to_station_ids(this_update: immutables.Map[str, immutables.Map[Charger,
 
                 # find the set of all station search geoids corresponding with the
                 # provided station charge price geoid
-                search_geoids = (k,)
+                search_geoids = (k, )
                 if res > sim.sim_h3_search_resolution:
-                    search_geoids = (h3.h3_to_parent(k, sim.sim_h3_search_resolution),)
+                    search_geoids = (h3.h3_to_parent(k, sim.sim_h3_search_resolution), )
                 elif res < sim.sim_h3_search_resolution:
                     search_geoids = tuple(h3.h3_to_children(k, sim.sim_h3_search_resolution))
 
-                station_ids = (station_id for search_geoid in search_geoids if sim.s_search.get(search_geoid)
+                station_ids = (station_id for search_geoid in search_geoids
+                               if sim.s_search.get(search_geoid)
                                for station_id in sim.s_search.get(search_geoid))
 
                 # all of these station ids should get entries managers the provided geoid

--- a/hive/state/simulation_state/update/simulation_update.py
+++ b/hive/state/simulation_state/update/simulation_update.py
@@ -11,10 +11,8 @@ if TYPE_CHECKING:
 
 
 class SimulationUpdateFunction(metaclass=ABCNamedTupleMeta):
-
     @abstractmethod
-    def update(self,
-               simulation_state: SimulationState,
+    def update(self, simulation_state: SimulationState,
                env: Environment) -> Tuple[SimulationState, Optional[SimulationUpdateFunction]]:
         """
         takes a simulation state and modifies it, returning the updated simulation state
@@ -25,4 +23,3 @@ class SimulationUpdateFunction(metaclass=ABCNamedTupleMeta):
         :return: the updated sim state, along with any reporting;
         as well, an Optionally-updated SimulationUpdate function
         """
-

--- a/hive/state/simulation_state/update/update_requests_from_file.py
+++ b/hive/state/simulation_state/update/update_requests_from_file.py
@@ -27,10 +27,10 @@ class UpdateRequestsFromFile(NamedTuple, SimulationUpdateFunction):
 
     @classmethod
     def build(
-            cls,
-            request_file: str,
-            rate_structure_file: Optional[str] = None,
-            lazy_file_reading: bool = False,
+        cls,
+        request_file: str,
+        rate_structure_file: Optional[str] = None,
+        lazy_file_reading: bool = False,
     ):
         """
         reads a requests file and builds a UpdateRequestsFromFile SimulationUpdateFunction
@@ -56,7 +56,9 @@ class UpdateRequestsFromFile(NamedTuple, SimulationUpdateFunction):
             raise IOError(f"{request_file} is not a valid path to a request file")
 
         if lazy_file_reading:
-            error, stepper = DictReaderStepper.build(request_file, "departure_time", parser=SimTime.build)
+            error, stepper = DictReaderStepper.build(request_file,
+                                                     "departure_time",
+                                                     parser=SimTime.build)
             if error:
                 raise error
         else:
@@ -64,12 +66,13 @@ class UpdateRequestsFromFile(NamedTuple, SimulationUpdateFunction):
                 # converting to tuple then back to iterator should bring the whole file into memory
                 reader = iter(tuple(DictReader(f)))
 
-            stepper = DictReaderStepper.from_iterator(reader, "departure_time", parser=SimTime.build)
+            stepper = DictReaderStepper.from_iterator(reader,
+                                                      "departure_time",
+                                                      parser=SimTime.build)
 
         return UpdateRequestsFromFile(stepper, rate_structure)
 
-    def update(self,
-               sim_state: SimulationState,
+    def update(self, sim_state: SimulationState,
                env: Environment) -> Tuple[SimulationState, Optional[UpdateRequestsFromFile]]:
         """
         add requests from file when the simulation reaches the request's time
@@ -96,11 +99,12 @@ class UpdateRequestsFromFile(NamedTuple, SimulationUpdateFunction):
         return result, None
 
 
-def update_requests_from_iterator(it: Iterator[Dict[str, str]],
-                                  initial_sim_state: SimulationState,
-                                  env: Environment,
-                                  rate_structure: RequestRateStructure,
-                                  ) -> SimulationState:
+def update_requests_from_iterator(
+    it: Iterator[Dict[str, str]],
+    initial_sim_state: SimulationState,
+    env: Environment,
+    rate_structure: RequestRateStructure,
+) -> SimulationState:
     """
     add requests from file when the simulation reaches the request's time
 
@@ -111,12 +115,12 @@ def update_requests_from_iterator(it: Iterator[Dict[str, str]],
     :param env:
     :return: sim state plus new requests
     """
-
-    def _update(sim: SimulationState,
-                row: Dict[str, str],
-                env: Environment,
-                rate_structure: RequestRateStructure,
-                ) -> SimulationState:
+    def _update(
+        sim: SimulationState,
+        row: Dict[str, str],
+        env: Environment,
+        rate_structure: RequestRateStructure,
+    ) -> SimulationState:
         """
         takes one row, attempts to parse it as a Request, and attempts to add it to the simulation
 
@@ -173,10 +177,7 @@ def update_requests_from_iterator(it: Iterator[Dict[str, str]],
                     return sim_updated
 
     # stream in all Requests that occur before the sim time of the provided SimulationState
-    updated_sim = ft.reduce(
-        ft.partial(_update, env=env, rate_structure=rate_structure),
-        it,
-        initial_sim_state
-    )
+    updated_sim = ft.reduce(ft.partial(_update, env=env, rate_structure=rate_structure), it,
+                            initial_sim_state)
 
     return updated_sim

--- a/hive/state/simulation_state/update/update_requests_sampling.py
+++ b/hive/state/simulation_state/update/update_requests_sampling.py
@@ -27,9 +27,9 @@ class UpdateRequestsSampling(NamedTuple, SimulationUpdateFunction):
 
     @classmethod
     def build(
-            cls,
-            sampled_requests: Tuple[Request, ...],
-            rate_structure_file: Optional[str] = None,
+        cls,
+        sampled_requests: Tuple[Request, ...],
+        rate_structure_file: Optional[str] = None,
     ):
         """
         reads an optional rate_structure_file and builds a UpdateRequestsFromFile SimulationUpdateFunction
@@ -59,8 +59,7 @@ class UpdateRequestsSampling(NamedTuple, SimulationUpdateFunction):
 
         return UpdateRequestsSampling(stepper, rate_structure)
 
-    def update(self,
-               sim_state: SimulationState,
+    def update(self, sim_state: SimulationState,
                env: Environment) -> Tuple[SimulationState, Optional[UpdateRequestsSampling]]:
         """
         add requests based on a sampling function
@@ -80,7 +79,8 @@ class UpdateRequestsSampling(NamedTuple, SimulationUpdateFunction):
         self.request_iterator.update_stop_condition(stop_condition)
 
         priced_requests = tuple(
-            r.assign_value(self.rate_structure, sim_state.road_network) for r in self.request_iterator)
+            r.assign_value(self.rate_structure, sim_state.road_network)
+            for r in self.request_iterator)
 
         def _add_request(sim: SimulationState, request: Request) -> SimulationState:
             # add request and handle any errors
@@ -98,10 +98,6 @@ class UpdateRequestsSampling(NamedTuple, SimulationUpdateFunction):
                 env.reporter.file_report(Report(ReportType.ADD_REQUEST_EVENT, report_data))
             return new_sim
 
-        updated_sim = ft.reduce(
-            _add_request,
-            priced_requests,
-            sim_state
-        )
+        updated_sim = ft.reduce(_add_request, priced_requests, sim_state)
 
         return updated_sim, self

--- a/hive/state/vehicle_state/charge_queueing.py
+++ b/hive/state/vehicle_state/charge_queueing.py
@@ -28,8 +28,8 @@ class ChargeQueueing(NamedTuple, VehicleState):
     def vehicle_state_type(cls) -> VehicleStateType:
         return VehicleStateType.CHARGE_QUEUEING
 
-    def enter(self, sim: 'SimulationState', env: 'Environment') -> Tuple[
-        Optional[Exception], Optional['SimulationState']]:
+    def enter(self, sim: 'SimulationState',
+              env: 'Environment') -> Tuple[Optional[Exception], Optional['SimulationState']]:
         """
                 entering a charge queueing state requires being at that station
 
@@ -39,7 +39,8 @@ class ChargeQueueing(NamedTuple, VehicleState):
                 """
         vehicle = sim.vehicles.get(self.vehicle_id)
         station = sim.stations.get(self.station_id)
-        has_available_charger = station.available_chargers.get(self.charger_id, 0) > 0 if station else False
+        has_available_charger = station.available_chargers.get(self.charger_id,
+                                                               0) > 0 if station else False
         context = f"vehicle {self.vehicle_id} entering queueing at station {self.station_id}"
         if not vehicle:
             return SimulationStateError(f"vehicle not found; context: {context}"), None
@@ -64,15 +65,12 @@ class ChargeQueueing(NamedTuple, VehicleState):
             else:
                 return VehicleState.apply_new_vehicle_state(updated_sim, self.vehicle_id, self)
 
-    def update(self, sim: 'SimulationState', env: 'Environment') -> Tuple[
-        Optional[Exception], Optional['SimulationState']]:
+    def update(self, sim: 'SimulationState',
+               env: 'Environment') -> Tuple[Optional[Exception], Optional['SimulationState']]:
         return VehicleState.default_update(sim, env, self)
 
-    def exit(self,
-             next_state: VehicleState,
-             sim: 'SimulationState',
-             env: 'Environment'
-             ) -> Tuple[Optional[Exception], Optional['SimulationState']]:
+    def exit(self, next_state: VehicleState, sim: 'SimulationState',
+             env: 'Environment') -> Tuple[Optional[Exception], Optional['SimulationState']]:
         """
         remove agent from queue before exiting this state
 
@@ -95,7 +93,8 @@ class ChargeQueueing(NamedTuple, VehicleState):
                 return response, None
             return None, updated_sim
 
-    def _has_reached_terminal_state_condition(self, sim: 'SimulationState', env: Environment) -> bool:
+    def _has_reached_terminal_state_condition(self, sim: 'SimulationState',
+                                              env: Environment) -> bool:
         """
         vehicle has reached a terminal state if the station disappeared
         or if it has at least one charger_id of the correct type
@@ -110,9 +109,9 @@ class ChargeQueueing(NamedTuple, VehicleState):
         else:
             return station.available_chargers.get(self.charger_id, 0) > 0
 
-    def _default_terminal_state(self,
-                                sim: 'SimulationState',
-                                env: Environment) -> Tuple[Optional[Exception], Optional[VehicleState]]:
+    def _default_terminal_state(
+            self, sim: 'SimulationState',
+            env: Environment) -> Tuple[Optional[Exception], Optional[VehicleState]]:
         """
         gets the default terminal state for this state which should be transitioned to
         once it reaches the end of the current task.
@@ -122,7 +121,8 @@ class ChargeQueueing(NamedTuple, VehicleState):
         """
         vehicle = sim.vehicles.get(self.vehicle_id)
         station = sim.stations.get(self.station_id)
-        has_no_charger = station.available_chargers.get(self.charger_id, 0) == 0 if station else False
+        has_no_charger = station.available_chargers.get(self.charger_id,
+                                                        0) == 0 if station else False
         context = f"vehicle {self.vehicle_id} entering default terminal state for charge queueing at station {self.station_id}"
         if not vehicle:
             return SimulationStateError(f"vehicle not found; context: {context}"), None
@@ -134,8 +134,9 @@ class ChargeQueueing(NamedTuple, VehicleState):
             next_state = ChargingStation(self.vehicle_id, self.station_id, self.charger_id)
             return next_state
 
-    def _perform_update(self, sim: 'SimulationState', env: Environment) -> Tuple[
-        Optional[Exception], Optional['SimulationState']]:
+    def _perform_update(
+            self, sim: 'SimulationState',
+            env: Environment) -> Tuple[Optional[Exception], Optional['SimulationState']]:
         """
         similarly to the idle state, we incur an idling penalty here
 
@@ -146,11 +147,14 @@ class ChargeQueueing(NamedTuple, VehicleState):
         vehicle = sim.vehicles.get(self.vehicle_id)
         context = f"vehicle {self.vehicle_id} performing update for charge queueing at station {self.station_id}"
         if not vehicle:
-            return SimulationStateError(f"vehicle {self.vehicle_id} not found; context: {context}"), None
+            return SimulationStateError(
+                f"vehicle {self.vehicle_id} not found; context: {context}"), None
         else:
             mechatronics = env.mechatronics.get(vehicle.mechatronics_id)
             if not mechatronics:
-                return SimulationStateError(f"cannot find {vehicle.mechatronics_id} in environment; context: {context}"), None
+                return SimulationStateError(
+                    f"cannot find {vehicle.mechatronics_id} in environment; context: {context}"
+                ), None
             less_energy_vehicle = mechatronics.idle(vehicle, sim.sim_timestep_duration_seconds)
 
             return simulation_state_ops.modify_vehicle(sim, less_energy_vehicle)

--- a/hive/state/vehicle_state/charging_base.py
+++ b/hive/state/vehicle_state/charging_base.py
@@ -31,9 +31,8 @@ class ChargingBase(NamedTuple, VehicleState):
     def vehicle_state_type(cls) -> VehicleStateType:
         return VehicleStateType.CHARGING_BASE
 
-    def enter(
-            self, sim: SimulationState, env: Environment
-    ) -> Tuple[Optional[Exception], Optional[SimulationState]]:
+    def enter(self, sim: SimulationState,
+              env: Environment) -> Tuple[Optional[Exception], Optional[SimulationState]]:
         """
         entering a charge event requires attaining a charger_id from the station situated at the base
 
@@ -70,7 +69,8 @@ class ChargingBase(NamedTuple, VehicleState):
             else:
                 err1, sim2 = simulation_state_ops.modify_base(sim, updated_base)
                 if err1:
-                    response = SimulationStateError(f"failure during ChargingBase.enter for vehicle {self.vehicle_id}")
+                    response = SimulationStateError(
+                        f"failure during ChargingBase.enter for vehicle {self.vehicle_id}")
                     response.__cause__ = err1
                     return response, None
                 else:
@@ -86,29 +86,23 @@ class ChargingBase(NamedTuple, VehicleState):
                             )
                             return None, None
                         else:
-                            err2, sim3 = simulation_state_ops.modify_station(
-                                sim2, updated_station
-                            )
+                            err2, sim3 = simulation_state_ops.modify_station(sim2, updated_station)
                             if err2:
                                 response = SimulationStateError(
-                                    f"failure during ChargingBase.enter for vehicle {self.vehicle_id}")
+                                    f"failure during ChargingBase.enter for vehicle {self.vehicle_id}"
+                                )
                                 response.__cause__ = err2
                                 return response, None
                             else:
                                 return VehicleState.apply_new_vehicle_state(
-                                    sim3, self.vehicle_id, self
-                                )
+                                    sim3, self.vehicle_id, self)
 
-    def update(
-            self, sim: SimulationState, env: Environment
-    ) -> Tuple[Optional[Exception], Optional[SimulationState]]:
+    def update(self, sim: SimulationState,
+               env: Environment) -> Tuple[Optional[Exception], Optional[SimulationState]]:
         return VehicleState.default_update(sim, env, self)
 
-    def exit(self,
-             next_state: VehicleState,
-             sim: SimulationState,
-             env: Environment
-             ) -> Tuple[Optional[Exception], Optional[SimulationState]]:
+    def exit(self, next_state: VehicleState, sim: SimulationState,
+             env: Environment) -> Tuple[Optional[Exception], Optional[SimulationState]]:
         """
         exiting a charge event requires returning the charger_id to the station at the base
 
@@ -131,13 +125,15 @@ class ChargingBase(NamedTuple, VehicleState):
         else:
             err1, updated_base = base.return_stall()
             if err1:
-                response = SimulationStateError(f"failure during ChargingBase.exit for vehicle {self.vehicle_id}")
+                response = SimulationStateError(
+                    f"failure during ChargingBase.exit for vehicle {self.vehicle_id}")
                 response.__cause__ = err1
                 return response, None
             else:
                 err2, sim2 = simulation_state_ops.modify_base(sim, updated_base)
                 if err2:
-                    response = SimulationStateError(f"failure during ChargingBase.exit for vehicle {self.vehicle_id}")
+                    response = SimulationStateError(
+                        f"failure during ChargingBase.exit for vehicle {self.vehicle_id}")
                     response.__cause__ = err2
                     return response, None
                 else:
@@ -149,9 +145,7 @@ class ChargingBase(NamedTuple, VehicleState):
                         return response, None
                     return simulation_state_ops.modify_station(sim2, updated_station)
 
-    def _has_reached_terminal_state_condition(
-            self, sim: SimulationState, env: Environment
-    ) -> bool:
+    def _has_reached_terminal_state_condition(self, sim: SimulationState, env: Environment) -> bool:
         """
         test if charging is finished
 
@@ -166,8 +160,9 @@ class ChargingBase(NamedTuple, VehicleState):
         else:
             return mechatronics.is_full(vehicle)
 
-    def _default_terminal_state(self, sim: SimulationState, env: Environment) -> Tuple[
-        Optional[Exception], Optional[VehicleState]]:
+    def _default_terminal_state(
+            self, sim: SimulationState,
+            env: Environment) -> Tuple[Optional[Exception], Optional[VehicleState]]:
         """
         give the default state to transition to after having met a terminal condition
 
@@ -178,9 +173,8 @@ class ChargingBase(NamedTuple, VehicleState):
         next_state = ReserveBase(self.vehicle_id, self.base_id)
         return None, next_state
 
-    def _perform_update(
-            self, sim: SimulationState, env: Environment
-    ) -> Tuple[Optional[Exception], Optional[SimulationState]]:
+    def _perform_update(self, sim: SimulationState,
+                        env: Environment) -> Tuple[Optional[Exception], Optional[SimulationState]]:
         """
         apply any effects due to a vehicle being advanced one discrete time unit in this VehicleState
 

--- a/hive/state/vehicle_state/charging_station.py
+++ b/hive/state/vehicle_state/charging_station.py
@@ -25,8 +25,7 @@ class ChargingStation(NamedTuple, VehicleState):
     def vehicle_state_type(cls) -> VehicleStateType:
         return VehicleStateType.CHARGING_STATION
 
-    def enter(self,
-              sim: 'SimulationState',
+    def enter(self, sim: 'SimulationState',
               env: Environment) -> Tuple[Optional[Exception], Optional['SimulationState']]:
         """
         entering a charge event requires attaining a charger_id from the station
@@ -70,15 +69,12 @@ class ChargingStation(NamedTuple, VehicleState):
                 else:
                     return VehicleState.apply_new_vehicle_state(updated_sim, self.vehicle_id, self)
 
-    def update(self, sim: 'SimulationState', env: Environment) -> Tuple[
-        Optional[Exception], Optional['SimulationState']]:
+    def update(self, sim: 'SimulationState',
+               env: Environment) -> Tuple[Optional[Exception], Optional['SimulationState']]:
         return VehicleState.default_update(sim, env, self)
 
-    def exit(self,
-             next_state: VehicleState,
-             sim: 'SimulationState',
-             env: 'Environment'
-             ) -> Tuple[Optional[Exception], Optional['SimulationState']]:
+    def exit(self, next_state: VehicleState, sim: 'SimulationState',
+             env: 'Environment') -> Tuple[Optional[Exception], Optional['SimulationState']]:
         """
         exiting a charge event requires returning the charger_id to the station
 
@@ -103,8 +99,7 @@ class ChargingStation(NamedTuple, VehicleState):
                 return response, None
             return simulation_state_ops.modify_station(sim, updated_station)
 
-    def _has_reached_terminal_state_condition(self,
-                                              sim: 'SimulationState',
+    def _has_reached_terminal_state_condition(self, sim: 'SimulationState',
                                               env: Environment) -> bool:
         """
         test if charging is finished
@@ -121,8 +116,8 @@ class ChargingStation(NamedTuple, VehicleState):
             return mechatronics.is_full(vehicle)
 
     def _default_terminal_state(
-        self, sim: 'SimulationState', env: Environment
-    ) -> Tuple[Optional[Exception], Optional[VehicleState]]:
+            self, sim: 'SimulationState',
+            env: Environment) -> Tuple[Optional[Exception], Optional[VehicleState]]:
         """
         give the default state to transition to after having met a terminal condition
 
@@ -133,9 +128,9 @@ class ChargingStation(NamedTuple, VehicleState):
         next_state = Idle(self.vehicle_id)
         return None, next_state
 
-    def _perform_update(self,
-                        sim: 'SimulationState',
-                        env: Environment) -> Tuple[Optional[Exception], Optional['SimulationState']]:
+    def _perform_update(
+            self, sim: 'SimulationState',
+            env: Environment) -> Tuple[Optional[Exception], Optional['SimulationState']]:
         """
         apply any effects due to a vehicle being advanced one discrete time unit in this VehicleState
 

--- a/hive/state/vehicle_state/dispatch_base.py
+++ b/hive/state/vehicle_state/dispatch_base.py
@@ -28,13 +28,16 @@ class DispatchBase(NamedTuple, VehicleState):
     def vehicle_state_type(cls) -> VehicleStateType:
         return VehicleStateType.DISPATCH_BASE
 
-    def update(self, sim: SimulationState, env: Environment) -> Tuple[Optional[Exception], Optional[SimulationState]]:
+    def update(self, sim: SimulationState,
+               env: Environment) -> Tuple[Optional[Exception], Optional[SimulationState]]:
         return VehicleState.default_update(sim, env, self)
 
-    def enter(self, sim: SimulationState, env: Environment) -> Tuple[Optional[Exception], Optional[SimulationState]]:
+    def enter(self, sim: SimulationState,
+              env: Environment) -> Tuple[Optional[Exception], Optional[SimulationState]]:
         base = sim.bases.get(self.base_id)
         vehicle = sim.vehicles.get(self.vehicle_id)
-        is_valid = route_cooresponds_with_entities(self.route, vehicle.position, base.position) if vehicle and base else False
+        is_valid = route_cooresponds_with_entities(self.route, vehicle.position,
+                                                   base.position) if vehicle and base else False
         context = f"vehicle {self.vehicle_id} entering dispatch base state at base {self.base_id}"
         if not base:
             msg = f"base not found; context: {context}"
@@ -51,11 +54,8 @@ class DispatchBase(NamedTuple, VehicleState):
             result = VehicleState.apply_new_vehicle_state(sim, self.vehicle_id, self)
             return result
 
-    def exit(self,
-             next_state: VehicleState,
-             sim: SimulationState,
-             env: Environment
-             ) -> Tuple[Optional[Exception], Optional[SimulationState]]:
+    def exit(self, next_state: VehicleState, sim: SimulationState,
+             env: Environment) -> Tuple[Optional[Exception], Optional[SimulationState]]:
         return None, sim
 
     def _has_reached_terminal_state_condition(self, sim: SimulationState, env: Environment) -> bool:
@@ -69,8 +69,8 @@ class DispatchBase(NamedTuple, VehicleState):
         return len(self.route) == 0
 
     def _default_terminal_state(
-        self, sim: SimulationState, env: Environment
-    ) -> Tuple[Optional[Exception], Optional[VehicleState]]:
+            self, sim: SimulationState,
+            env: Environment) -> Tuple[Optional[Exception], Optional[VehicleState]]:
         """
         give the default state to transition to after having met a terminal condition
 
@@ -95,8 +95,7 @@ class DispatchBase(NamedTuple, VehicleState):
                 next_state = Idle(self.vehicle_id)
             return None, next_state
 
-    def _perform_update(self,
-                        sim: SimulationState,
+    def _perform_update(self, sim: SimulationState,
                         env: Environment) -> Tuple[Optional[Exception], Optional[SimulationState]]:
         """
         take a step along the route to the base

--- a/hive/state/vehicle_state/dispatch_pooling_trip.py
+++ b/hive/state/vehicle_state/dispatch_pooling_trip.py
@@ -41,10 +41,12 @@ class DispatchPoolingTrip(NamedTuple, VehicleState):
     def vehicle_state_type(cls) -> VehicleStateType:
         return VehicleStateType.DISPATCH_POOLING_TRIP
 
-    def update(self, sim: SimulationState, env: Environment) -> Tuple[Optional[Exception], Optional[SimulationState]]:
+    def update(self, sim: SimulationState,
+               env: Environment) -> Tuple[Optional[Exception], Optional[SimulationState]]:
         return VehicleState.default_update(sim, env, self)
 
-    def enter(self, sim: 'SimulationState', env: 'Environment') -> Tuple[Optional[Exception], Optional['SimulationState']]:
+    def enter(self, sim: 'SimulationState',
+              env: 'Environment') -> Tuple[Optional[Exception], Optional['SimulationState']]:
         """
         checks that all requests exist. updates all requests to know that this vehicle is on it's way
 
@@ -59,10 +61,13 @@ class DispatchPoolingTrip(NamedTuple, VehicleState):
         else:
             req_ids, _ = tuple(zip(*self.trip_plan))
             vehicle = sim.vehicles.get(self.vehicle_id)
-            reqs_exist_and_match_membership = dispatch_ops.requests_exist_and_match_membership(sim, vehicle, req_ids)
+            reqs_exist_and_match_membership = dispatch_ops.requests_exist_and_match_membership(
+                sim, vehicle, req_ids)
             first_req_id, first_phase = first_stop
             first_req = sim.requests.get(first_req_id)
-            is_valid = route_cooresponds_with_entities(self.route, vehicle.position, first_req.origin_position) if vehicle and first_req else False
+            is_valid = route_cooresponds_with_entities(
+                self.route, vehicle.position,
+                first_req.origin_position) if vehicle and first_req else False
 
             context = f"vehicle {self.vehicle_id} entering dispatch pooling state"
             if not vehicle:
@@ -75,21 +80,20 @@ class DispatchPoolingTrip(NamedTuple, VehicleState):
                 log.debug(f"bad route to connect vehicle {vehicle.id} to request {first_req.id}")
                 return None, None
             else:
-                error, updated_sim = dispatch_ops.modify_vehicle_assignment(sim, self.vehicle_id, req_ids)
+                error, updated_sim = dispatch_ops.modify_vehicle_assignment(
+                    sim, self.vehicle_id, req_ids)
                 if error:
                     response = SimulationStateError(
                         f"failure during DispatchPoolingTrip.enter for vehicle {self.vehicle_id}")
                     response.__cause__ = error
                     return response, None
                 else:
-                    result = VehicleState.apply_new_vehicle_state(updated_sim, self.vehicle_id, self)
+                    result = VehicleState.apply_new_vehicle_state(updated_sim, self.vehicle_id,
+                                                                  self)
                     return result
 
-    def exit(self,
-             next_state: VehicleState,
-             sim: SimulationState,
-             env: Environment
-             ) -> Tuple[Optional[Exception], Optional[SimulationState]]:
+    def exit(self, next_state: VehicleState, sim: SimulationState,
+             env: Environment) -> Tuple[Optional[Exception], Optional[SimulationState]]:
         """
         release the vehicle from the requests it was dispatched to
 
@@ -98,7 +102,10 @@ class DispatchPoolingTrip(NamedTuple, VehicleState):
         :return: an error, or, the updated simulation state, where the requests are no longer awaiting this vehicle
         """
         req_ids, _ = tuple(zip(*self.trip_plan))
-        result = dispatch_ops.modify_vehicle_assignment(sim, self.vehicle_id, req_ids, unassign=True)
+        result = dispatch_ops.modify_vehicle_assignment(sim,
+                                                        self.vehicle_id,
+                                                        req_ids,
+                                                        unassign=True)
         return result
 
     def _has_reached_terminal_state_condition(self, sim: SimulationState, env: Environment) -> bool:
@@ -112,8 +119,8 @@ class DispatchPoolingTrip(NamedTuple, VehicleState):
         return len(self.route) == 0
 
     def _default_terminal_state(
-        self, sim: SimulationState, env: Environment
-    ) -> Tuple[Optional[Exception], Optional[VehicleState]]:
+            self, sim: SimulationState,
+            env: Environment) -> Tuple[Optional[Exception], Optional[VehicleState]]:
         """
         give the default state to transition to after having met a terminal condition
 
@@ -125,18 +132,15 @@ class DispatchPoolingTrip(NamedTuple, VehicleState):
         # create servicing state, with first request PICKUP event consumed
         routes = dispatch_ops.create_routes(sim, self.trip_plan)
 
-        servicing_pooling_state = ServicingPoolingTrip(
-            vehicle_id=self.vehicle_id,
-            trip_plan=self.trip_plan,
-            routes=routes,
-            boarded_requests=self.boarded_requests,
-            departure_times=self.departure_times,
-            num_passengers=self.num_passengers
-        )
+        servicing_pooling_state = ServicingPoolingTrip(vehicle_id=self.vehicle_id,
+                                                       trip_plan=self.trip_plan,
+                                                       routes=routes,
+                                                       boarded_requests=self.boarded_requests,
+                                                       departure_times=self.departure_times,
+                                                       num_passengers=self.num_passengers)
         return None, servicing_pooling_state
 
-    def _perform_update(self,
-                        sim: SimulationState,
+    def _perform_update(self, sim: SimulationState,
                         env: Environment) -> Tuple[Optional[Exception], Optional[SimulationState]]:
         """
         take a step along the route to the first request

--- a/hive/state/vehicle_state/dispatch_station.py
+++ b/hive/state/vehicle_state/dispatch_station.py
@@ -30,14 +30,16 @@ class DispatchStation(NamedTuple, VehicleState):
     def vehicle_state_type(cls) -> VehicleStateType:
         return VehicleStateType.DISPATCH_STATION
 
-    def update(self, sim: SimulationState, env: Environment) -> Tuple[
-        Optional[Exception], Optional[SimulationState]]:
+    def update(self, sim: SimulationState,
+               env: Environment) -> Tuple[Optional[Exception], Optional[SimulationState]]:
         return VehicleState.default_update(sim, env, self)
 
-    def enter(self, sim: SimulationState, env: Environment) -> Tuple[Optional[Exception], Optional[SimulationState]]:
+    def enter(self, sim: SimulationState,
+              env: Environment) -> Tuple[Optional[Exception], Optional[SimulationState]]:
         station = sim.stations.get(self.station_id)
         vehicle = sim.vehicles.get(self.vehicle_id)
-        is_valid = route_cooresponds_with_entities(self.route, vehicle.position, station.position) if vehicle and station else False
+        is_valid = route_cooresponds_with_entities(
+            self.route, vehicle.position, station.position) if vehicle and station else False
         context = f"vehicle {self.vehicle_id} entering dispatch station state for station {self.station_id} with charger {self.charger_id}"
         if not vehicle:
             return SimulationStateError(f"vehicle not found; context: {context}"), None
@@ -56,11 +58,8 @@ class DispatchStation(NamedTuple, VehicleState):
             result = VehicleState.apply_new_vehicle_state(sim, self.vehicle_id, self)
             return result
 
-    def exit(self,
-             next_state: VehicleState,
-             sim: SimulationState,
-             env: Environment
-             ) -> Tuple[Optional[Exception], Optional[SimulationState]]:
+    def exit(self, next_state: VehicleState, sim: SimulationState,
+             env: Environment) -> Tuple[Optional[Exception], Optional[SimulationState]]:
         return None, sim
 
     def _has_reached_terminal_state_condition(self, sim: SimulationState, env: Environment) -> bool:
@@ -74,8 +73,8 @@ class DispatchStation(NamedTuple, VehicleState):
         return len(self.route) == 0
 
     def _default_terminal_state(
-        self, sim: SimulationState, env: Environment
-    ) -> Tuple[Optional[Exception], Optional[VehicleState]]:
+            self, sim: SimulationState,
+            env: Environment) -> Tuple[Optional[Exception], Optional[VehicleState]]:
         """
         give the default state to transition to after having met a terminal condition
 
@@ -97,16 +96,13 @@ class DispatchStation(NamedTuple, VehicleState):
             return SimulationStateError(message), None
         else:
             has_chargers = available_chargers > 0
-            next_state = ChargingStation(self.vehicle_id,
-                                         self.station_id,
-                                         self.charger_id) if has_chargers else ChargeQueueing(self.vehicle_id,
-                                                                                              self.station_id,
-                                                                                              self.charger_id,
-                                                                                              sim.sim_time)
+            next_state = ChargingStation(self.vehicle_id, self.station_id,
+                                         self.charger_id) if has_chargers else ChargeQueueing(
+                                             self.vehicle_id, self.station_id, self.charger_id,
+                                             sim.sim_time)
             return None, next_state
 
-    def _perform_update(self,
-                        sim: SimulationState,
+    def _perform_update(self, sim: SimulationState,
                         env: Environment) -> Tuple[Optional[Exception], Optional[SimulationState]]:
         """
         take a step along the route to the station

--- a/hive/state/vehicle_state/dispatch_trip.py
+++ b/hive/state/vehicle_state/dispatch_trip.py
@@ -34,11 +34,12 @@ class DispatchTrip(NamedTuple, VehicleState):
     def vehicle_state_type(cls) -> VehicleStateType:
         return VehicleStateType.DISPATCH_TRIP
 
-    def update(self, sim: SimulationState, env: Environment) -> Tuple[Optional[Exception], Optional[SimulationState]]:
+    def update(self, sim: SimulationState,
+               env: Environment) -> Tuple[Optional[Exception], Optional[SimulationState]]:
         return VehicleState.default_update(sim, env, self)
 
-    def enter(self, sim: SimulationState, env: Environment) -> Tuple[
-        Optional[Exception], Optional[SimulationState]]:
+    def enter(self, sim: SimulationState,
+              env: Environment) -> Tuple[Optional[Exception], Optional[SimulationState]]:
         """
         checks that the request exists and if so, updates the request to know that this vehicle is on it's way
 
@@ -48,7 +49,8 @@ class DispatchTrip(NamedTuple, VehicleState):
         """
         vehicle = sim.vehicles.get(self.vehicle_id)
         request = sim.requests.get(self.request_id)
-        is_valid = route_cooresponds_with_entities(self.route, vehicle.position, request.origin_position) if vehicle and request else False
+        is_valid = route_cooresponds_with_entities(
+            self.route, vehicle.position, request.origin_position) if vehicle and request else False
         context = f"vehicle {self.vehicle_id} entering dispatch trip for request {self.request_id}"
         if not vehicle:
             return SimulationStateError(f"vehicle not found; context: {context}"), None
@@ -72,11 +74,8 @@ class DispatchTrip(NamedTuple, VehicleState):
                 result = VehicleState.apply_new_vehicle_state(updated_sim, self.vehicle_id, self)
                 return result
 
-    def exit(self,
-             next_state: VehicleState,
-             sim: SimulationState,
-             env: Environment
-             ) -> Tuple[Optional[Exception], Optional[SimulationState]]:
+    def exit(self, next_state: VehicleState, sim: SimulationState,
+             env: Environment) -> Tuple[Optional[Exception], Optional[SimulationState]]:
         """
         release the vehicle from the request it was dispatched to
 
@@ -105,8 +104,8 @@ class DispatchTrip(NamedTuple, VehicleState):
         return len(self.route) == 0
 
     def _default_terminal_state(
-        self, sim: SimulationState, env: Environment
-    ) -> Tuple[Optional[Exception], Optional[VehicleState]]:
+            self, sim: SimulationState,
+            env: Environment) -> Tuple[Optional[Exception], Optional[VehicleState]]:
         """
         give the default state to transition to after having met a terminal condition
 
@@ -130,7 +129,7 @@ class DispatchTrip(NamedTuple, VehicleState):
             # apply next state
             # generate the data to describe the trip for this request
             # where the pickup phase is currently happening + doesn't need to be added to the trip plan
-            trip_plan: Tuple[Tuple[RequestId, TripPhase], ...] = ((request.id, TripPhase.DROPOFF),)
+            trip_plan: Tuple[Tuple[RequestId, TripPhase], ...] = ((request.id, TripPhase.DROPOFF), )
             departure_time = sim.sim_time
 
             # create the state (pooling, or, standard servicing trip, depending on the sitch)
@@ -140,18 +139,15 @@ class DispatchTrip(NamedTuple, VehicleState):
                 trip_plan=trip_plan,
                 boarded_requests=immutables.Map({request.id: request}),
                 departure_times=immutables.Map({request.id, departure_time}),
-                routes=(route,),
-                num_passengers=len(request.passengers)
-            ) if pooling_trip else ServicingTrip(
-                vehicle_id=vehicle.id,
-                request=request,
-                departure_time=departure_time,
-                route=route
-            )
+                routes=(route, ),
+                num_passengers=len(request.passengers)) if pooling_trip else ServicingTrip(
+                    vehicle_id=vehicle.id,
+                    request=request,
+                    departure_time=departure_time,
+                    route=route)
             return None, next_state
 
-    def _perform_update(self,
-                        sim: SimulationState,
+    def _perform_update(self, sim: SimulationState,
                         env: Environment) -> Tuple[Optional[Exception], Optional[SimulationState]]:
         """
         take a step along the route to the request

--- a/hive/state/vehicle_state/idle.py
+++ b/hive/state/vehicle_state/idle.py
@@ -18,20 +18,20 @@ class Idle(NamedTuple, VehicleState):
     def vehicle_state_type(cls) -> VehicleStateType:
         return VehicleStateType.IDLE
 
-    def update(self, sim: 'SimulationState', env: Environment) -> Tuple[Optional[Exception], Optional['SimulationState']]:
+    def update(self, sim: 'SimulationState',
+               env: Environment) -> Tuple[Optional[Exception], Optional['SimulationState']]:
         return VehicleState.default_update(sim, env, self)
 
-    def enter(self, sim: 'SimulationState', env: Environment) -> Tuple[Optional[Exception], Optional['SimulationState']]:
+    def enter(self, sim: 'SimulationState',
+              env: Environment) -> Tuple[Optional[Exception], Optional['SimulationState']]:
         return VehicleState.apply_new_vehicle_state(sim, self.vehicle_id, self)
 
-    def exit(self,
-             next_state: VehicleState,
-             sim: 'SimulationState',
-             env: Environment
-             ) -> Tuple[Optional[Exception], Optional['SimulationState']]:
+    def exit(self, next_state: VehicleState, sim: 'SimulationState',
+             env: Environment) -> Tuple[Optional[Exception], Optional['SimulationState']]:
         return None, sim
 
-    def _has_reached_terminal_state_condition(self, sim: 'SimulationState', env: Environment) -> bool:
+    def _has_reached_terminal_state_condition(self, sim: 'SimulationState',
+                                              env: Environment) -> bool:
         """
         If energy has run out, we will move to OutOfService
 
@@ -44,8 +44,8 @@ class Idle(NamedTuple, VehicleState):
         return not vehicle or mechatronics.is_empty(vehicle)
 
     def _default_terminal_state(
-        self, sim: 'SimulationState', env: Environment
-    ) -> Tuple[Optional[Exception], Optional[VehicleState]]:
+            self, sim: 'SimulationState',
+            env: Environment) -> Tuple[Optional[Exception], Optional[VehicleState]]:
         """
         give the default state to transition to after having met a terminal condition
 
@@ -56,9 +56,9 @@ class Idle(NamedTuple, VehicleState):
         next_state = OutOfService(self.vehicle_id)
         return None, next_state
 
-    def _perform_update(self,
-                        sim: 'SimulationState',
-                        env: Environment) -> Tuple[Optional[Exception], Optional['SimulationState']]:
+    def _perform_update(
+            self, sim: 'SimulationState',
+            env: Environment) -> Tuple[Optional[Exception], Optional['SimulationState']]:
         """
         incur an idling cost
 
@@ -72,7 +72,8 @@ class Idle(NamedTuple, VehicleState):
         if not vehicle:
             return SimulationStateError(f"vehicle not found; context: {context}"), None
         elif not mechatronics:
-            return SimulationStateError(f"cannot find {vehicle.mechatronics_id} in environment"), None
+            return SimulationStateError(
+                f"cannot find {vehicle.mechatronics_id} in environment"), None
         else:
             less_energy_vehicle = mechatronics.idle(vehicle, sim.sim_timestep_duration_seconds)
 

--- a/hive/state/vehicle_state/out_of_service.py
+++ b/hive/state/vehicle_state/out_of_service.py
@@ -13,20 +13,20 @@ class OutOfService(NamedTuple, VehicleState):
     def vehicle_state_type(cls) -> VehicleStateType:
         return VehicleStateType.OUT_OF_SERVICE
 
-    def update(self, sim: 'SimulationState', env: Environment) -> Tuple[Optional[Exception], Optional['SimulationState']]:
+    def update(self, sim: 'SimulationState',
+               env: Environment) -> Tuple[Optional[Exception], Optional['SimulationState']]:
         return VehicleState.default_update(sim, env, self)
 
-    def enter(self, sim: 'SimulationState', env: Environment) -> Tuple[Optional[Exception], Optional['SimulationState']]:
+    def enter(self, sim: 'SimulationState',
+              env: Environment) -> Tuple[Optional[Exception], Optional['SimulationState']]:
         return VehicleState.apply_new_vehicle_state(sim, self.vehicle_id, self)
 
-    def exit(self,
-             next_state: VehicleState,
-             sim: 'SimulationState',
-             env: Environment
-             ) -> Tuple[Optional[Exception], Optional['SimulationState']]:
+    def exit(self, next_state: VehicleState, sim: 'SimulationState',
+             env: Environment) -> Tuple[Optional[Exception], Optional['SimulationState']]:
         return None, sim
 
-    def _has_reached_terminal_state_condition(self, sim: 'SimulationState', env: Environment) -> bool:
+    def _has_reached_terminal_state_condition(self, sim: 'SimulationState',
+                                              env: Environment) -> bool:
         """
         There is no terminal state for OutOfService
 
@@ -37,8 +37,8 @@ class OutOfService(NamedTuple, VehicleState):
         return False
 
     def _default_terminal_state(
-        self, sim: 'SimulationState', env: Environment
-    ) -> Tuple[Optional[Exception], Optional[VehicleState]]:
+            self, sim: 'SimulationState',
+            env: Environment) -> Tuple[Optional[Exception], Optional[VehicleState]]:
         """
         give the default state to transition to after having met a terminal condition
 
@@ -48,9 +48,9 @@ class OutOfService(NamedTuple, VehicleState):
         """
         return None, self
 
-    def _perform_update(self,
-                        sim: 'SimulationState',
-                        env: Environment) -> Tuple[Optional[Exception], Optional['SimulationState']]:
+    def _perform_update(
+            self, sim: 'SimulationState',
+            env: Environment) -> Tuple[Optional[Exception], Optional['SimulationState']]:
         """
         as of now, there is no update for being OutOfService
 

--- a/hive/state/vehicle_state/repositioning.py
+++ b/hive/state/vehicle_state/repositioning.py
@@ -19,12 +19,15 @@ class Repositioning(NamedTuple, VehicleState):
     def vehicle_state_type(cls) -> VehicleStateType:
         return VehicleStateType.REPOSITIONING
 
-    def update(self, sim: 'SimulationState', env: Environment) -> Tuple[Optional[Exception], Optional['SimulationState']]:
+    def update(self, sim: 'SimulationState',
+               env: Environment) -> Tuple[Optional[Exception], Optional['SimulationState']]:
         return VehicleState.default_update(sim, env, self)
 
-    def enter(self, sim: 'SimulationState', env: Environment) -> Tuple[Optional[Exception], Optional['SimulationState']]:
+    def enter(self, sim: 'SimulationState',
+              env: Environment) -> Tuple[Optional[Exception], Optional['SimulationState']]:
         vehicle = sim.vehicles.get(self.vehicle_id)
-        is_valid = route_cooresponds_with_entities(self.route, vehicle.position) if vehicle else False
+        is_valid = route_cooresponds_with_entities(self.route,
+                                                   vehicle.position) if vehicle else False
         context = f"vehicle {self.vehicle_id} entering repositioning state"
         if not vehicle:
             return SimulationStateError(f"vehicle not found; context: {context}"), None
@@ -34,14 +37,12 @@ class Repositioning(NamedTuple, VehicleState):
             result = VehicleState.apply_new_vehicle_state(sim, self.vehicle_id, self)
             return result
 
-    def exit(self,
-             next_state: VehicleState,
-             sim: 'SimulationState',
-             env: Environment
-             ) -> Tuple[Optional[Exception], Optional['SimulationState']]:
+    def exit(self, next_state: VehicleState, sim: 'SimulationState',
+             env: Environment) -> Tuple[Optional[Exception], Optional['SimulationState']]:
         return None, sim
 
-    def _has_reached_terminal_state_condition(self, sim: 'SimulationState', env: Environment) -> bool:
+    def _has_reached_terminal_state_condition(self, sim: 'SimulationState',
+                                              env: Environment) -> bool:
         """
         this terminates when we reach a base
 
@@ -52,8 +53,8 @@ class Repositioning(NamedTuple, VehicleState):
         return len(self.route) == 0
 
     def _default_terminal_state(
-        self, sim: 'SimulationState', env: Environment
-    ) -> Tuple[Optional[Exception], Optional[VehicleState]]:
+            self, sim: 'SimulationState',
+            env: Environment) -> Tuple[Optional[Exception], Optional[VehicleState]]:
         """
         give the default state to transition to after having met a terminal condition
 
@@ -64,9 +65,9 @@ class Repositioning(NamedTuple, VehicleState):
         next_state = Idle(self.vehicle_id)
         return None, next_state
 
-    def _perform_update(self,
-                        sim: 'SimulationState',
-                        env: Environment) -> Tuple[Optional[Exception], Optional['SimulationState']]:
+    def _perform_update(
+            self, sim: 'SimulationState',
+            env: Environment) -> Tuple[Optional[Exception], Optional['SimulationState']]:
         """
         take a step along the route to the base
 
@@ -85,7 +86,8 @@ class Repositioning(NamedTuple, VehicleState):
             response.__cause__ = move_error
             return response, None
         elif not moved_vehicle:
-            return SimulationStateError(f"vehicle {self.vehicle_id} not found; context: {context}"), None
+            return SimulationStateError(
+                f"vehicle {self.vehicle_id} not found; context: {context}"), None
         elif moved_vehicle.vehicle_state.vehicle_state_type == VehicleStateType.OUT_OF_SERVICE:
             return None, move_result.sim
         else:

--- a/hive/state/vehicle_state/reserve_base.py
+++ b/hive/state/vehicle_state/reserve_base.py
@@ -24,12 +24,12 @@ class ReserveBase(NamedTuple, VehicleState):
     def vehicle_state_type(cls) -> VehicleStateType:
         return VehicleStateType.RESERVE_BASE
 
-    def update(self, sim: SimulationState, env: Environment) -> Tuple[
-        Optional[Exception], Optional[SimulationState]]:
+    def update(self, sim: SimulationState,
+               env: Environment) -> Tuple[Optional[Exception], Optional[SimulationState]]:
         return VehicleState.default_update(sim, env, self)
 
-    def enter(self, sim: SimulationState, env: Environment) -> Tuple[
-        Optional[Exception], Optional[SimulationState]]:
+    def enter(self, sim: SimulationState,
+              env: Environment) -> Tuple[Optional[Exception], Optional[SimulationState]]:
         """
         to enter this state, the base must have a stall for the vehicle
 
@@ -45,7 +45,8 @@ class ReserveBase(NamedTuple, VehicleState):
         elif not base:
             return SimulationStateError(f"{context}; base not found"), None
         elif base.geoid != vehicle.geoid:
-            log.warning(f"ReserveBase.enter(): vehicle {vehicle.id} not at same location as {base.id}")
+            log.warning(
+                f"ReserveBase.enter(): vehicle {vehicle.id} not at same location as {base.id}")
             return None, None
         elif not base.membership.grant_access_to_membership(vehicle.membership):
             msg = f"ReserveBase.enter(): vehicle {vehicle.id} does not have access to base {base.id}"
@@ -65,11 +66,8 @@ class ReserveBase(NamedTuple, VehicleState):
                 else:
                     return VehicleState.apply_new_vehicle_state(updated_sim, self.vehicle_id, self)
 
-    def exit(self,
-             next_state: VehicleState,
-             sim: SimulationState,
-             env: Environment
-             ) -> Tuple[Optional[Exception], Optional[SimulationState]]:
+    def exit(self, next_state: VehicleState, sim: SimulationState,
+             env: Environment) -> Tuple[Optional[Exception], Optional[SimulationState]]:
         """
         releases the stall that this vehicle occupied
 
@@ -101,8 +99,8 @@ class ReserveBase(NamedTuple, VehicleState):
         return False
 
     def _default_terminal_state(
-        self, sim: SimulationState, env: Environment
-    ) -> Tuple[Optional[Exception], Optional[VehicleState]]:
+            self, sim: SimulationState,
+            env: Environment) -> Tuple[Optional[Exception], Optional[VehicleState]]:
         """
         give the default state to transition to after having met a terminal condition
 
@@ -112,8 +110,7 @@ class ReserveBase(NamedTuple, VehicleState):
         """
         return None, self
 
-    def _perform_update(self,
-                        sim: SimulationState,
+    def _perform_update(self, sim: SimulationState,
                         env: Environment) -> Tuple[Optional[Exception], Optional[SimulationState]]:
         """
         as of now, there is no update for being ReserveBase

--- a/hive/state/vehicle_state/servicing_pooling_trip.py
+++ b/hive/state/vehicle_state/servicing_pooling_trip.py
@@ -49,10 +49,12 @@ class ServicingPoolingTrip(NamedTuple, VehicleState):
         """
         return cls.routes[0] if len(cls.routes) > 0 else ()
 
-    def update(self, sim: SimulationState, env: Environment) -> Tuple[Optional[Exception], Optional[SimulationState]]:
+    def update(self, sim: SimulationState,
+               env: Environment) -> Tuple[Optional[Exception], Optional[SimulationState]]:
         return VehicleState.default_update(sim, env, self)
 
-    def enter(self, sim: SimulationState, env: Environment) -> Tuple[Optional[Exception], Optional[SimulationState]]:
+    def enter(self, sim: SimulationState,
+              env: Environment) -> Tuple[Optional[Exception], Optional[SimulationState]]:
         """
         transition from DispatchTrip into a pooling trip service leg. this first frame of servicing
         a pooling trip should be happening at the start location of the first request in the pool,
@@ -72,7 +74,8 @@ class ServicingPoolingTrip(NamedTuple, VehicleState):
         if vehicle is None:
             return SimulationStateError(f"vehicle note found; context: {context}"), None
         if first_req is None:
-            return SimulationStateError(f"request {first_req_id} not found; context: {context}"), None
+            return SimulationStateError(
+                f"request {first_req_id} not found; context: {context}"), None
         elif not vehicle.vehicle_state.vehicle_state_type == VehicleStateType.DISPATCH_POOLING_TRIP:
             # the only supported transition into ServicingPoolingTrip comes from DispatchTrip
             prev_state = vehicle.vehicle_state.__class__.__name__
@@ -86,9 +89,11 @@ class ServicingPoolingTrip(NamedTuple, VehicleState):
         else:
 
             # pick up first request
-            pickup_error, pickup_sim = servicing_ops.pick_up_trip(sim, env, self.vehicle_id, first_req_id)
+            pickup_error, pickup_sim = servicing_ops.pick_up_trip(sim, env, self.vehicle_id,
+                                                                  first_req_id)
             if pickup_error:
-                result = SimulationStateError(f"failed to pick up first trip in ServicingPoolingTrip {self}")
+                result = SimulationStateError(
+                    f"failed to pick up first trip in ServicingPoolingTrip {self}")
                 result.__cause__ = pickup_error
                 return result, None
             else:
@@ -97,18 +102,13 @@ class ServicingPoolingTrip(NamedTuple, VehicleState):
                     boarded_requests=immutables.Map({first_req_id: first_req}),
                     departure_times=immutables.Map({first_req_id: sim.sim_time}),
                     num_passengers=len(first_req.passengers),
-                    trip_plan=remaining_trip_plan
-                )
-                result = VehicleState.apply_new_vehicle_state(pickup_sim,
-                                                              self.vehicle_id,
+                    trip_plan=remaining_trip_plan)
+                result = VehicleState.apply_new_vehicle_state(pickup_sim, self.vehicle_id,
                                                               vehicle_state_with_first_trip)
                 return result
 
-    def exit(self,
-             next_state: VehicleState,
-             sim: SimulationState,
-             env: Environment
-             ) -> Tuple[Optional[Exception], Optional[SimulationState]]:
+    def exit(self, next_state: VehicleState, sim: SimulationState,
+             env: Environment) -> Tuple[Optional[Exception], Optional[SimulationState]]:
         """
         exit when there is no remaining trip_phase to complete
 
@@ -135,8 +135,8 @@ class ServicingPoolingTrip(NamedTuple, VehicleState):
         return len(self.trip_plan) == 0
 
     def _default_terminal_state(
-            self, sim: SimulationState, env: Environment
-    ) -> Tuple[Optional[Exception], Optional[VehicleState]]:
+            self, sim: SimulationState,
+            env: Environment) -> Tuple[Optional[Exception], Optional[VehicleState]]:
         """
         give the default state to transition to after having met a terminal condition
 
@@ -147,8 +147,8 @@ class ServicingPoolingTrip(NamedTuple, VehicleState):
         next_state = Idle(self.vehicle_id)
         return None, next_state
 
-    def _perform_update(self, sim: SimulationState, env: Environment) -> Tuple[
-        Optional[Exception], Optional[SimulationState]]:
+    def _perform_update(self, sim: SimulationState,
+                        env: Environment) -> Tuple[Optional[Exception], Optional[SimulationState]]:
         """
         move forward on our trip, making pickups and dropoffs as needed
 
@@ -161,7 +161,8 @@ class ServicingPoolingTrip(NamedTuple, VehicleState):
         err1, active_trip = get_active_pooling_trip(self)
         if err1 is not None:
             response = SimulationStateError(
-                f"failure during ServicingPoolingTrip._perform_update for vehicle {self.vehicle_id}")
+                f"failure during ServicingPoolingTrip._perform_update for vehicle {self.vehicle_id}"
+            )
             response.__cause__ = err1
             return response, None
         else:
@@ -171,7 +172,8 @@ class ServicingPoolingTrip(NamedTuple, VehicleState):
 
             if move_error:
                 response = SimulationStateError(
-                    f"failure during ServicingPoolingTrip._perform_update for vehicle {self.vehicle_id}")
+                    f"failure during ServicingPoolingTrip._perform_update for vehicle {self.vehicle_id}"
+                )
                 response.__cause__ = move_error
                 return response, None
             elif not moved_vehicle:

--- a/hive/state/vehicle_state/servicing_trip.py
+++ b/hive/state/vehicle_state/servicing_trip.py
@@ -32,13 +32,11 @@ class ServicingTrip(NamedTuple, VehicleState):
     def vehicle_state_type(cls) -> VehicleStateType:
         return VehicleStateType.SERVICING_TRIP
 
-    def update(self,
-               sim: SimulationState,
+    def update(self, sim: SimulationState,
                env: Environment) -> Tuple[Optional[Exception], Optional[SimulationState]]:
         return VehicleState.default_update(sim, env, self)
 
-    def enter(self,
-              sim: SimulationState,
+    def enter(self, sim: SimulationState,
               env: Environment) -> Tuple[Optional[Exception], Optional[SimulationState]]:
         """
         transition from DispatchTrip into a non-pooling trip service leg
@@ -49,7 +47,9 @@ class ServicingTrip(NamedTuple, VehicleState):
         """
         vehicle = sim.vehicles.get(self.vehicle_id)
         request = sim.requests.get(self.request.id)
-        is_valid = route_cooresponds_with_entities(self.route, request.origin_position, request.destination_position) if vehicle and request else False
+        is_valid = route_cooresponds_with_entities(
+            self.route, request.origin_position,
+            request.destination_position) if vehicle and request else False
         context = f"vehicle {self.vehicle_id} entering servicing trip state for request {self.request.id}"
         if vehicle is None:
             return SimulationStateError(f"vehicle not found; context: {context}"), None
@@ -72,7 +72,8 @@ class ServicingTrip(NamedTuple, VehicleState):
             msg = f"vehicle {vehicle.id} attempting to service request {self.request.id} invalid route (doesn't match location of vehicle)"
             log.warning(msg)
             return None, None
-        elif not route_cooresponds_with_entities(self.route, request.origin_position, request.destination_position):
+        elif not route_cooresponds_with_entities(self.route, request.origin_position,
+                                                 request.destination_position):
             msg = f"vehicle {vehicle.id} attempting to service request {self.request.id} invalid route (doesn't match o/d of request)"
             log.warning(msg)
             return None, None
@@ -84,14 +85,12 @@ class ServicingTrip(NamedTuple, VehicleState):
                 response.__cause__ = pickup_error
                 return response, None
             else:
-                enter_result = VehicleState.apply_new_vehicle_state(pickup_sim, self.vehicle_id, self)
+                enter_result = VehicleState.apply_new_vehicle_state(pickup_sim, self.vehicle_id,
+                                                                    self)
                 return enter_result
 
-    def exit(self,
-             next_state: VehicleState,
-             sim: SimulationState,
-             env: Environment
-             ) -> Tuple[Optional[Exception], Optional[SimulationState]]:
+    def exit(self, next_state: VehicleState, sim: SimulationState,
+             env: Environment) -> Tuple[Optional[Exception], Optional[SimulationState]]:
         """
         leave this state when the route is completed
 
@@ -114,9 +113,9 @@ class ServicingTrip(NamedTuple, VehicleState):
         """
         return len(self.route) == 0
 
-    def _default_terminal_state(self,
-                                sim: SimulationState,
-                                env: Environment) -> Tuple[Optional[Exception], Optional[VehicleState]]:
+    def _default_terminal_state(
+            self, sim: SimulationState,
+            env: Environment) -> Tuple[Optional[Exception], Optional[VehicleState]]:
         """
         gets the default terminal state for this state which should be transitioned to
         once it reaches the end of the current task.
@@ -127,8 +126,7 @@ class ServicingTrip(NamedTuple, VehicleState):
         next_state = Idle(self.vehicle_id)
         return None, next_state
 
-    def _perform_update(self,
-                        sim: SimulationState,
+    def _perform_update(self, sim: SimulationState,
                         env: Environment) -> Tuple[Optional[Exception], Optional[SimulationState]]:
         """
         take a step along the route to the base

--- a/hive/state/vehicle_state/vehicle_state.py
+++ b/hive/state/vehicle_state/vehicle_state.py
@@ -25,7 +25,6 @@ class VehicleState(ABCMeta, NamedTupleMeta, EntityState):
     an enter or exit can return an exception, a SimulationState, or (None, None) signifying that the
     state cannot be entered/exited under this circumstance.
     """
-
     @abstractproperty
     def vehicle_id(self) -> VehicleId:
         """
@@ -48,8 +47,8 @@ class VehicleState(ABCMeta, NamedTupleMeta, EntityState):
 
     @classmethod
     def default_update(
-            mcs, sim: SimulationState, env: Environment, state: VehicleState
-    ) -> Tuple[Optional[Exception], Optional[SimulationState]]:
+            mcs, sim: SimulationState, env: Environment,
+            state: VehicleState) -> Tuple[Optional[Exception], Optional[SimulationState]]:
         """
         apply any effects due to a vehicle being advanced one discrete time unit in this VehicleState.
         under terminal conditions, exits the current state, enters a default transition state, and steps
@@ -66,15 +65,18 @@ class VehicleState(ABCMeta, NamedTupleMeta, EntityState):
             err1, next_state = state._default_terminal_state(sim, env)
             if err1 is not None:
                 state_type = state.vehicle_state_type
-                err_res = SimulationStateError(f"failure during default update of {state_type} state")
+                err_res = SimulationStateError(
+                    f"failure during default update of {state_type} state")
                 err_res.__cause__ = err1
                 return err_res, None
             else:
                 # perform default state transition
-                err2, updated_sim = entity_state_ops.transition_previous_to_next(sim, env, state, next_state)
+                err2, updated_sim = entity_state_ops.transition_previous_to_next(
+                    sim, env, state, next_state)
                 if err2 is not None:
                     state_type = state.vehicle_state_type
-                    err_res = SimulationStateError(f"failure during default update of {state_type} state")
+                    err_res = SimulationStateError(
+                        f"failure during default update of {state_type} state")
                     err_res.__cause__ = err2
                     return err_res, None
                 elif updated_sim is None:
@@ -95,8 +97,8 @@ class VehicleState(ABCMeta, NamedTupleMeta, EntityState):
 
     @classmethod
     def apply_new_vehicle_state(
-            mcs, sim: SimulationState, vehicle_id: VehicleId, new_state: VehicleState
-    ) -> Tuple[Optional[Exception], Optional[SimulationState]]:
+            mcs, sim: SimulationState, vehicle_id: VehicleId,
+            new_state: VehicleState) -> Tuple[Optional[Exception], Optional[SimulationState]]:
         """
         this default enter operation simply modifies the vehicle's stored state value
 
@@ -109,17 +111,14 @@ class VehicleState(ABCMeta, NamedTupleMeta, EntityState):
         if not vehicle:
             state_name = new_state.__class__.__name__
             error = StateTransitionError(
-                f"failed to apply state {state_name}; vehicle {vehicle_id} not found"
-            )
+                f"failed to apply state {state_name}; vehicle {vehicle_id} not found")
             return error, None
         else:
             updated_vehicle = vehicle.modify_vehicle_state(new_state)
             return simulation_state_ops.modify_vehicle(sim, updated_vehicle)
 
     @abstractmethod
-    def _has_reached_terminal_state_condition(
-            self, sim: SimulationState, env: Environment
-    ) -> bool:
+    def _has_reached_terminal_state_condition(self, sim: SimulationState, env: Environment) -> bool:
         """
         test if we have reached a terminal state and need to apply the default transition
 
@@ -131,8 +130,8 @@ class VehicleState(ABCMeta, NamedTupleMeta, EntityState):
 
     @abstractmethod
     def _default_terminal_state(
-            self, sim: SimulationState, env: Environment
-    ) -> Tuple[Optional[Exception], Optional[VehicleState]]:
+            self, sim: SimulationState,
+            env: Environment) -> Tuple[Optional[Exception], Optional[VehicleState]]:
         """
         give the default state to transition to after having met a terminal condition
 
@@ -143,9 +142,8 @@ class VehicleState(ABCMeta, NamedTupleMeta, EntityState):
         pass
 
     @abstractmethod
-    def _perform_update(
-            self, sim: SimulationState, env: Environment
-    ) -> Tuple[Optional[Exception], Optional[SimulationState]]:
+    def _perform_update(self, sim: SimulationState,
+                        env: Environment) -> Tuple[Optional[Exception], Optional[SimulationState]]:
         """
         perform a simulation state update for a vehicle in this state
 

--- a/hive/state/vehicle_state/vehicle_state_ops.py
+++ b/hive/state/vehicle_state/vehicle_state_ops.py
@@ -18,10 +18,7 @@ if TYPE_CHECKING:
     from hive.runner.environment import Environment
 
 
-def charge(sim: SimulationState,
-           env: Environment,
-           vehicle_id: VehicleId,
-           station_id: StationId,
+def charge(sim: SimulationState, env: Environment, vehicle_id: VehicleId, station_id: StationId,
            charger_id: ChargerId) -> Tuple[Optional[Exception], Optional[SimulationState]]:
     """
     apply any effects due to a vehicle being advanced one discrete time unit in this VehicleState
@@ -44,18 +41,22 @@ def charge(sim: SimulationState,
     if not vehicle:
         return SimulationStateError(f"vehicle not found; context: {context}"), None
     elif not mechatronics:
-        return SimulationStateError(f"invalid mechatronics_id {vehicle.mechatronics_id}; context: {context}"), None
+        return SimulationStateError(
+            f"invalid mechatronics_id {vehicle.mechatronics_id}; context: {context}"), None
     elif not charger:
         return SimulationStateError(f"invalid charger_id; context: {context}"), None
     elif not station:
         return SimulationStateError(f"station not found; context {context}"), None
     elif mechatronics.is_full(vehicle):
-        return SimulationStateError(f"vehicle is full but still attempting to charge; context {context}"), None
+        return SimulationStateError(
+            f"vehicle is full but still attempting to charge; context {context}"), None
     else:
-        charged_vehicle, _ = mechatronics.add_energy(vehicle, charger, sim.sim_timestep_duration_seconds)
+        charged_vehicle, _ = mechatronics.add_energy(vehicle, charger,
+                                                     sim.sim_timestep_duration_seconds)
 
         # determine price of charge event
-        kwh_transacted = charged_vehicle.energy[charger.energy_type] - vehicle.energy[charger.energy_type]  # kwh
+        kwh_transacted = charged_vehicle.energy[charger.energy_type] - vehicle.energy[
+            charger.energy_type]  # kwh
         charger_price = station.charger_prices_per_kwh.get(charger_id)  # Currency
         charging_price = kwh_transacted * charger_price if charger_price else 0.0
 
@@ -69,7 +70,8 @@ def charge(sim: SimulationState,
             response.__cause__ = veh_error
             return response, None
         else:
-            report = vehicle_charge_event(vehicle, updated_vehicle, sim_with_vehicle, updated_station, charger)
+            report = vehicle_charge_event(vehicle, updated_vehicle, sim_with_vehicle,
+                                          updated_station, charger)
             env.reporter.file_report(report)
 
             return simulation_state_ops.modify_station(sim_with_vehicle, updated_station)
@@ -82,9 +84,7 @@ class MoveResult(NamedTuple):
     route_traversal: RouteTraversal = RouteTraversal()
 
 
-def _apply_route_traversal(sim: SimulationState,
-                           env: Environment,
-                           vehicle_id: VehicleId,
+def _apply_route_traversal(sim: SimulationState, env: Environment, vehicle_id: VehicleId,
                            route: Route) -> Tuple[Optional[Exception], Optional[MoveResult]]:
     """
     Moves the vehicle and consumes energy.
@@ -125,13 +125,16 @@ def _apply_route_traversal(sim: SimulationState,
         step_distance_km = traverse_result.traversal_distance_km
 
         if not experienced_route:
-            return SimulationStateError(f"after traversal, no route was experienced for vehicle {vehicle_id} at time {sim.sim_time}"), None
+            return SimulationStateError(
+                f"after traversal, no route was experienced for vehicle {vehicle_id} at time {sim.sim_time}"
+            ), None
         else:
             last_link_traversed = experienced_route[-1]
             # quick trick here to turn the final traversed link into a Positional Link (where link.start == link.end)
             # used to represent the Vehicle's new position
             vehicle_position = EntityPosition(last_link_traversed.link_id, last_link_traversed.end)
-            updated_vehicle = less_energy_vehicle.modify_position(position=vehicle_position).tick_distance_traveled_km(step_distance_km)
+            updated_vehicle = less_energy_vehicle.modify_position(
+                position=vehicle_position).tick_distance_traveled_km(step_distance_km)
             error, updated_sim = simulation_state_ops.modify_vehicle(sim, updated_vehicle)
             if error:
                 response = SimulationStateError(
@@ -142,9 +145,9 @@ def _apply_route_traversal(sim: SimulationState,
                 return None, MoveResult(updated_sim, vehicle, updated_vehicle, traverse_result)
 
 
-def _go_out_of_service_on_empty(sim: SimulationState,
-                                env: Environment,
-                                vehicle_id: VehicleId) -> Tuple[Optional[Exception], Optional[SimulationState]]:
+def _go_out_of_service_on_empty(
+        sim: SimulationState, env: Environment,
+        vehicle_id: VehicleId) -> Tuple[Optional[Exception], Optional[SimulationState]]:
     """
     sets a vehicle to OutOfService if it is out of energy after a move event
 
@@ -156,9 +159,11 @@ def _go_out_of_service_on_empty(sim: SimulationState,
     moved_vehicle = sim.vehicles.get(vehicle_id)
     mechatronics = env.mechatronics.get(moved_vehicle.mechatronics_id)
     if not moved_vehicle:
-        return SimulationStateError(f"vehicle not found; context: vehicle {vehicle_id} going out of service"), None
+        return SimulationStateError(
+            f"vehicle not found; context: vehicle {vehicle_id} going out of service"), None
     elif not mechatronics:
-        return SimulationStateError(f"cannot find {moved_vehicle.mechatronics_id} in environment"), None
+        return SimulationStateError(
+            f"cannot find {moved_vehicle.mechatronics_id} in environment"), None
     elif mechatronics.is_empty(moved_vehicle):
         # todo: are we in ServicingTrip or ServicingPoolingTrip? report stranded passengers!!!
         # error, exit_sim = moved_vehicle.vehicle_state.exit(sim, env)
@@ -177,9 +182,7 @@ def _go_out_of_service_on_empty(sim: SimulationState,
         return None, None
 
 
-def move(sim: SimulationState,
-         env: Environment,
-         vehicle_id: VehicleId,
+def move(sim: SimulationState, env: Environment, vehicle_id: VehicleId,
          route: Route) -> Tuple[Optional[Exception], Optional[MoveResult]]:
     """
     moves the vehicle, and moves to OutOfService if resulting vehicle energy is empty
@@ -197,10 +200,10 @@ def move(sim: SimulationState,
     elif not move_result:
         return None, MoveResult(sim)
     else:
-        empty_check_error, empty_vehicle_sim = _go_out_of_service_on_empty(move_result.sim, env, vehicle_id)
+        empty_check_error, empty_vehicle_sim = _go_out_of_service_on_empty(
+            move_result.sim, env, vehicle_id)
         if empty_check_error:
-            response = SimulationStateError(
-                f"failure during move for vehicle {vehicle_id}")
+            response = SimulationStateError(f"failure during move for vehicle {vehicle_id}")
             response.__cause__ = empty_check_error
             return response, None
         elif empty_vehicle_sim:
@@ -209,5 +212,3 @@ def move(sim: SimulationState,
             report = vehicle_move_event(move_result, env)
             env.reporter.file_report(report)
             return None, move_result
-
-

--- a/hive/state/vehicle_state/vehicle_state_type.py
+++ b/hive/state/vehicle_state/vehicle_state_type.py
@@ -18,5 +18,3 @@ class VehicleStateType(Enum):
     DISPATCH_STATION = 30
     CHARGING_STATION = 31
     CHARGE_QUEUEING = 32
-
-

--- a/hive/util/__init__.py
+++ b/hive/util/__init__.py
@@ -1,33 +1,14 @@
 from hive.util.abc_named_tuple_meta import ABCNamedTupleMeta
 from hive.util.iterators import DictReaderStepper
-from hive.util.exception import (
-    StateOfChargeError,
-    StateTransitionError,
-    SimulationStateError,
-    RouteStepError,
-    EntityError,
-    UnitError,
-    H3Error)
+from hive.util.exception import (StateOfChargeError, StateTransitionError, SimulationStateError,
+                                 RouteStepError, EntityError, UnitError, H3Error)
 from hive.util.h3_ops import H3Ops
 from hive.util.switch_case import SwitchCase
 from hive.util.dict_ops import DictOps
 from hive.util.tuple_ops import TupleOps
-from hive.util.typealiases import (
-    RequestId,
-    VehicleId,
-    StationId,
-    BaseId,
-    PowertrainId,
-    PowercurveId,
-    PassengerId,
-    GeoId,
-    LinkId,
-    RouteStepPointer,
-    H3Line,
-    SimStep
-)
-from hive.util.units import (
-    KwH, J, Kw, Meters, Kilometers, Feet, Miles, Mph, Kmph, Seconds, Hours,
-    Currency, Percentage, Ratio, HOURS_TO_SECONDS, hours_to_seconds,
-    SECONDS_IN_HOUR, SECONDS_TO_HOURS, KMPH_TO_MPH, KM_TO_MILE, WH_TO_KWH
-)
+from hive.util.typealiases import (RequestId, VehicleId, StationId, BaseId, PowertrainId,
+                                   PowercurveId, PassengerId, GeoId, LinkId, RouteStepPointer,
+                                   H3Line, SimStep)
+from hive.util.units import (KwH, J, Kw, Meters, Kilometers, Feet, Miles, Mph, Kmph, Seconds, Hours,
+                             Currency, Percentage, Ratio, HOURS_TO_SECONDS, hours_to_seconds,
+                             SECONDS_IN_HOUR, SECONDS_TO_HOURS, KMPH_TO_MPH, KM_TO_MILE, WH_TO_KWH)

--- a/hive/util/abc_utils.py
+++ b/hive/util/abc_utils.py
@@ -13,7 +13,6 @@ def abstract_attribute(obj=None):
 
 
 class ABCMeta(NativeABCMeta):
-
     def __call__(cls, *args, **kwargs):
         instance = NativeABCMeta.__call__(cls, *args, **kwargs)
         abstract_attributes = {
@@ -22,11 +21,7 @@ class ABCMeta(NativeABCMeta):
             if getattr(getattr(instance, name), '__is_abstract_attribute__', False)
         }
         if abstract_attributes:
-            raise NotImplementedError(
-                "Can't instantiate abstract class {} with"
-                " abstract attributes: {}".format(
-                    cls.__name__,
-                    ', '.join(abstract_attributes)
-                )
-            )
+            raise NotImplementedError("Can't instantiate abstract class {} with"
+                                      " abstract attributes: {}".format(
+                                          cls.__name__, ', '.join(abstract_attributes)))
         return instance

--- a/hive/util/dict_ops.py
+++ b/hive/util/dict_ops.py
@@ -53,7 +53,8 @@ class DictOps:
         return xs.delete(obj_id)
 
     @classmethod
-    def merge_dicts(cls, old: immutables.Map[K, V], new: immutables.Map[K, V]) -> immutables.Map[K, V]:
+    def merge_dicts(cls, old: immutables.Map[K, V], new: immutables.Map[K,
+                                                                        V]) -> immutables.Map[K, V]:
         """
         merges two Dictionaries, replacing old kv pairs with new ones
 
@@ -68,9 +69,7 @@ class DictOps:
         return tmp
 
     @classmethod
-    def add_to_collection_dict(cls,
-                               xs: immutables.Map[str, FrozenSet[V]],
-                               collection_id: str,
+    def add_to_collection_dict(cls, xs: immutables.Map[str, FrozenSet[V]], collection_id: str,
                                obj_id: str) -> immutables.Map[str, FrozenSet[V]]:
         """
         updates Dicts that track collections of entities
@@ -87,9 +86,7 @@ class DictOps:
         return xs.set(collection_id, updated_ids)
 
     @classmethod
-    def add_to_stack_dict(cls,
-                          xs: immutables.Map[str, Tuple[V]],
-                          collection_id: str,
+    def add_to_stack_dict(cls, xs: immutables.Map[str, Tuple[V]], collection_id: str,
                           obj: V) -> immutables.Map[str, Tuple[V]]:
         """
         updates Dicts that hold a stack of entities;
@@ -103,14 +100,15 @@ class DictOps:
         :return:
         """
         stack = xs.get(collection_id, tuple())
-        updated_stack = (obj,) + stack
+        updated_stack = (obj, ) + stack
         return xs.set(collection_id, updated_stack)
 
     @classmethod
-    def pop_from_stack_dict(cls,
-                            xs: immutables.Map[str, Tuple[V]],
-                            collection_id: str,
-                            ) -> Tuple[Optional[V], immutables.Map[str, Tuple[V]]]:
+    def pop_from_stack_dict(
+        cls,
+        xs: immutables.Map[str, Tuple[V]],
+        collection_id: str,
+    ) -> Tuple[Optional[V], immutables.Map[str, Tuple[V]]]:
         """
         pops an element from the stack and returns it;
         note that the head of the tuple represents the top of the stack; popped elements come from the tuple head;
@@ -130,9 +128,7 @@ class DictOps:
         return obj, xs.set(collection_id, updated_stack)
 
     @classmethod
-    def remove_from_collection_dict(cls,
-                                    xs: immutables.Map[str, FrozenSet[V]],
-                                    collection_id: str,
+    def remove_from_collection_dict(cls, xs: immutables.Map[str, FrozenSet[V]], collection_id: str,
                                     obj_id: str) -> immutables.Map[str, FrozenSet[V]]:
         """
         updates Dicts that track collections of entities
@@ -147,12 +143,12 @@ class DictOps:
         """
         ids_at_loc = xs.get(collection_id, frozenset())
         updated_ids = ids_at_loc.difference([obj_id])
-        return xs.delete(collection_id) if len(updated_ids) == 0 else xs.set(collection_id, updated_ids)
+        return xs.delete(collection_id) if len(updated_ids) == 0 else xs.set(
+            collection_id, updated_ids)
 
     @classmethod
-    def update_entity_dictionaries(cls,
-                                   updated_entity: V,
-                                   entities: immutables.Map[K, Tuple[V, ...]],
+    def update_entity_dictionaries(cls, updated_entity: V, entities: immutables.Map[K, Tuple[V,
+                                                                                             ...]],
                                    locations: immutables.Map[GeoId, Tuple[K, ...]],
                                    search: immutables.Map[GeoId, Tuple[K, ...]],
                                    sim_h3_search_resolution: int) -> EntityUpdateResult:
@@ -170,15 +166,11 @@ class DictOps:
         entities_updated = DictOps.add_to_dict(entities, updated_entity.id, updated_entity)
 
         if old_entity.geoid == updated_entity.geoid:
-            return EntityUpdateResult(
-                entities=entities_updated
-            )
+            return EntityUpdateResult(entities=entities_updated)
         # unset from old geoid add add to new one
-        locations_removed = DictOps.remove_from_collection_dict(locations,
-                                                                old_entity.geoid,
+        locations_removed = DictOps.remove_from_collection_dict(locations, old_entity.geoid,
                                                                 old_entity.id)
-        locations_updated = DictOps.add_to_collection_dict(locations_removed,
-                                                           updated_entity.geoid,
+        locations_updated = DictOps.add_to_collection_dict(locations_removed, updated_entity.geoid,
                                                            updated_entity.id)
 
         old_search_geoid = h3.h3_to_parent(old_entity.geoid, sim_h3_search_resolution)
@@ -186,21 +178,14 @@ class DictOps:
 
         if old_search_geoid == updated_search_geoid:
             # no update to search location
-            return EntityUpdateResult(
-                entities=entities_updated,
-                locations=locations_updated
-            )
+            return EntityUpdateResult(entities=entities_updated, locations=locations_updated)
 
         # update request search dict location
-        search_removed = DictOps.remove_from_collection_dict(search,
-                                                             old_search_geoid,
+        search_removed = DictOps.remove_from_collection_dict(search, old_search_geoid,
                                                              old_entity.id)
-        search_updated = DictOps.add_to_collection_dict(search_removed,
-                                                        updated_search_geoid,
+        search_updated = DictOps.add_to_collection_dict(search_removed, updated_search_geoid,
                                                         updated_entity.id)
 
-        return EntityUpdateResult(
-            entities=entities_updated,
-            locations=locations_updated,
-            search=search_updated
-        )
+        return EntityUpdateResult(entities=entities_updated,
+                                  locations=locations_updated,
+                                  search=search_updated)

--- a/hive/util/exception.py
+++ b/hive/util/exception.py
@@ -9,10 +9,7 @@ def report_error(error: Exception) -> Dict:
     :param error: the error that occurred during simulation
     :return: packaged as a report
     """
-    data = {
-        'report_type': 'error',
-        'message': error.args
-    }
+    data = {'report_type': 'error', 'message': error.args}
     return data
 
 
@@ -20,7 +17,6 @@ class TimeParseError(Exception):
     """
     raised when time parsing fails
     """
-
     def __init__(self, msg):
         self.message = msg
 
@@ -33,12 +29,11 @@ class StateTransitionError(Exception):
     calls out a breach in the simulation's physics observed when
     a state transition's invariants are not met.
     """
-
     def __init__(
-            self,
-            msg: str,
-            this_state_name: Optional[str] = None,
-            next_state_name: Optional[str] = None,
+        self,
+        msg: str,
+        this_state_name: Optional[str] = None,
+        next_state_name: Optional[str] = None,
     ):
         """
         :param msg: any addition context information
@@ -61,7 +56,6 @@ class StateOfChargeError(Exception):
     """
     state of charge must exist in the range [0, 1]
     """
-
     def __init__(self, soc):
         self.message = "Illegal state of charge value {}".format(soc)
 
@@ -73,7 +67,6 @@ class RouteStepError(Exception):
     """
     errors related to stepping forward along a route
     """
-
     def __init__(self, msg):
         self.message = msg
 
@@ -85,7 +78,6 @@ class SimulationStateError(Exception):
     """
     errors related to SimulationState operations
     """
-
     def __init__(self, msg):
         self.message = msg
 
@@ -97,7 +89,6 @@ class UnitError(Exception):
     """
     errors related to units
     """
-
     def __init__(self, msg):
         self.message = msg
 
@@ -109,7 +100,6 @@ class EntityError(Exception):
     """
     errors related to methods on entities such as vehicles or stations.
     """
-
     def __init__(self, msg):
         self.message = msg
 
@@ -121,7 +111,6 @@ class H3Error(Exception):
     """
     errors related to H3 operations
     """
-
     def __init__(self, msg):
         self.message = msg
 
@@ -133,16 +122,11 @@ class CombinedException(Exception):
     """
     a bundle of errors which can be raised as a single Exception
     """
-
     def __init__(self, errors: Tuple[Exception, ...]):
         self.errors = errors
 
     def __str__(self):
-        combined = ft.reduce(
-            lambda acc, err: acc + f"{err.message}\n",
-            self.errors,
-            ""
-        )
+        combined = ft.reduce(lambda acc, err: acc + f"{err.message}\n", self.errors, "")
         return repr(combined)
 
 
@@ -150,7 +134,6 @@ class InstructionError(Exception):
     """
     reports that an instruction was erroneous
     """
-
     def __init__(self, msg):
         self.message = msg
 

--- a/hive/util/fs.py
+++ b/hive/util/fs.py
@@ -12,6 +12,7 @@ def global_hive_config_search() -> GlobalConfig:
     searches for the global hive config, and if found, loads it. if not, loads the default from hive.resources
     :return: global hive config
     """
+
     # this searches up the path to the root of the file system
     def _backprop_search(search_path: Path) -> Optional[Path]:
         search_file = search_path.joinpath(".hive.yaml")
@@ -25,7 +26,8 @@ def global_hive_config_search() -> GlobalConfig:
                 return _backprop_search(updated_search_path)
 
     # load the default file to be merged with any found files
-    default_global_config_file_path = pkg_resources.resource_filename("hive.resources.defaults", ".hive.yaml")
+    default_global_config_file_path = pkg_resources.resource_filename("hive.resources.defaults",
+                                                                      ".hive.yaml")
     with Path(default_global_config_file_path).open() as df:
         default = yaml.safe_load(df)
 
@@ -52,7 +54,8 @@ def global_hive_config_search() -> GlobalConfig:
         return GlobalConfig.from_dict(default, default_global_config_file_path)
 
 
-def construct_asset_path(file: str, scenario_directory: str, default_directory_name: str, resources_subdirectory: str) -> str:
+def construct_asset_path(file: str, scenario_directory: str, default_directory_name: str,
+                         resources_subdirectory: str) -> str:
     """
     constructs the path to a scenario asset relative to a scenario directory. attempts to load at both
     the user-provided relative path, and if that fails, attempts to load at the default directory; finally, checks
@@ -87,7 +90,8 @@ def construct_asset_path(file: str, scenario_directory: str, default_directory_n
             raise FileNotFoundError(msg)
 
 
-def construct_scenario_asset_path(file: str, scenario_directory: str, default_directory_name: str) -> str:
+def construct_scenario_asset_path(file: str, scenario_directory: str,
+                                  default_directory_name: str) -> str:
     """
     constructs the path to a scenario asset relative to a scenario directory. attempts to load at both
     the user-provided relative path, and if that fails, attempts to load at the default directory.
@@ -104,7 +108,8 @@ def construct_scenario_asset_path(file: str, scenario_directory: str, default_di
     :raises: FileNotFoundError if asset is not found
     """
     file_at_scenario_directory = Path(scenario_directory).joinpath(file)
-    file_at_default_directory = Path(scenario_directory).joinpath(default_directory_name).joinpath(file)
+    file_at_default_directory = Path(scenario_directory).joinpath(default_directory_name).joinpath(
+        file)
     if file_at_scenario_directory.is_file():
         return str(file_at_scenario_directory)
     elif file_at_default_directory.is_file():
@@ -125,8 +130,12 @@ def find_scenario(user_provided_scenario: str) -> Path:
     """
     absolute_path = Path(user_provided_scenario).absolute()
     relative_path = Path.cwd().joinpath(user_provided_scenario)
-    den_path = Path(pkg_resources.resource_filename("hive.resources.scenarios.denver_downtown", user_provided_scenario))
-    nyc_path = Path(pkg_resources.resource_filename("hive.resources.scenarios.manhattan", user_provided_scenario))
+    den_path = Path(
+        pkg_resources.resource_filename("hive.resources.scenarios.denver_downtown",
+                                        user_provided_scenario))
+    nyc_path = Path(
+        pkg_resources.resource_filename("hive.resources.scenarios.manhattan",
+                                        user_provided_scenario))
 
     if absolute_path.is_file():
         return absolute_path

--- a/hive/util/geo.py
+++ b/hive/util/geo.py
@@ -5,9 +5,7 @@ import h3
 from hive.util import GeoId, SimulationStateError
 
 
-def same_simulation_location(a: GeoId,
-                             b: GeoId,
-                             sim_h3_resolution: int,
+def same_simulation_location(a: GeoId, b: GeoId, sim_h3_resolution: int,
                              override_resolution: Optional[int]) -> bool:
     """
     tests if two geoids are at the same location in the simulation. allows for overriding test resolution to a parent level.

--- a/hive/util/h3_ops.py
+++ b/hive/util/h3_ops.py
@@ -16,14 +16,15 @@ if TYPE_CHECKING:
 
 class H3Ops:
     @classmethod
-    def nearest_entity_by_great_circle_distance(cls,
-                                                geoid: GeoId,
-                                                entities: immutables.Map[EntityId, Entity],
-                                                entity_search: immutables.Map[GeoId, Tuple[EntityId, ...]],
-                                                sim_h3_search_resolution: int,
-                                                is_valid: Callable[[Entity], bool] = lambda x: True,
-                                                max_search_distance_km: Kilometers = 10  # kilometers
-                                                ) -> Optional[Entity]:
+    def nearest_entity_by_great_circle_distance(
+            cls,
+            geoid: GeoId,
+            entities: immutables.Map[EntityId, Entity],
+            entity_search: immutables.Map[GeoId, Tuple[EntityId, ...]],
+            sim_h3_search_resolution: int,
+            is_valid: Callable[[Entity], bool] = lambda x: True,
+            max_search_distance_km: Kilometers = 10  # kilometers
+    ) -> Optional[Entity]:
         """
         returns the closest entity to the given geoid. In the case of a tie, the first entity encountered is returned.
         invariant: the Entity has a geoid field (Entity.geoid)
@@ -45,19 +46,19 @@ class H3Ops:
             sim_h3_search_resolution=sim_h3_search_resolution,
             is_valid=is_valid,
             distance_function=lambda e: cls.great_circle_distance(geoid, e.geoid),
-            max_search_distance_km=max_search_distance_km
-        )
+            max_search_distance_km=max_search_distance_km)
 
     @classmethod
-    def nearest_entity(cls,
-                       geoid: GeoId,
-                       entities: Tuple[Entity, ...],
-                       entity_search: immutables.Map[GeoId, Tuple[EntityId, ...]],
-                       sim_h3_search_resolution: int,
-                       distance_function: Callable[[Entity], float],
-                       is_valid: Callable[[Entity], bool] = lambda x: True,
-                       max_search_distance_km: Kilometers = 10  # kilometers
-                       ) -> Optional[Entity]:
+    def nearest_entity(
+            cls,
+            geoid: GeoId,
+            entities: Tuple[Entity, ...],
+            entity_search: immutables.Map[GeoId, Tuple[EntityId, ...]],
+            sim_h3_search_resolution: int,
+            distance_function: Callable[[Entity], float],
+            is_valid: Callable[[Entity], bool] = lambda x: True,
+            max_search_distance_km: Kilometers = 10  # kilometers
+    ) -> Optional[Entity]:
         """
         returns the closest entity to the given geoid. In the case of a tie, the first entity encountered is returned.
         invariant: the Entity has a geoid field (Entity.geoid)
@@ -115,8 +116,7 @@ class H3Ops:
         return _search()
 
     @classmethod
-    def get_entities_at_cell(cls,
-                             search_cell: GeoId,
+    def get_entities_at_cell(cls, search_cell: GeoId,
                              entity_search: immutables.Map[GeoId, Tuple[EntityId, ...]],
                              entities: Tuple[Entity, ...]) -> Tuple[Entity, ...]:
         """
@@ -136,12 +136,13 @@ class H3Ops:
             return found
 
     @classmethod
-    def nearest_entity_point_to_point(cls,
-                                      geoid: GeoId,
-                                      entities: Dict[EntityId, Entity],
-                                      entity_locations: Dict[GeoId, Tuple[EntityId, ...]],
-                                      is_valid: Callable = lambda x: True,
-                                      ) -> Optional[Entity]:
+    def nearest_entity_point_to_point(
+        cls,
+        geoid: GeoId,
+        entities: Dict[EntityId, Entity],
+        entity_locations: Dict[GeoId, Tuple[EntityId, ...]],
+        is_valid: Callable = lambda x: True,
+    ) -> Optional[Entity]:
         """
         A nearest neighbor search that scans all entities and returns the one with the lowest distance to the geoid.
 
@@ -188,7 +189,7 @@ class H3Ops:
         # calculate haversine
         lat = lat2 - lat1
         lon = lon2 - lon1
-        d = sin(lat * 0.5) ** 2 + cos(lat1) * cos(lat2) * sin(lon * 0.5) ** 2
+        d = sin(lat * 0.5)**2 + cos(lat1) * cos(lat2) * sin(lon * 0.5)**2
 
         return 2 * avg_earth_radius_km * asin(sqrt(d))
 

--- a/hive/util/iterators.py
+++ b/hive/util/iterators.py
@@ -5,6 +5,7 @@ import logging
 from typing import Iterator, Dict, TextIO, Optional, Callable, Tuple, NamedTuple, Iterable, Generator
 
 from itertools import islice, tee
+
 log = logging.getLogger(__name__)
 
 
@@ -12,8 +13,8 @@ class NamedTupleIterator:
     """
     iterator that deals with a set of named tuples
     """
-
-    def __init__(self, items: Tuple[NamedTuple, ...], step_attr_name: str, stop_condition: Callable):
+    def __init__(self, items: Tuple[NamedTuple, ...], step_attr_name: str,
+                 stop_condition: Callable):
         self._iterator = iter(items)
         self.step_attr_name = step_attr_name
         self.stop_condition = stop_condition
@@ -53,13 +54,13 @@ class DictReaderIterator:
     """
     iterator used internally by DictReaderStepper
     """
-
-    def __init__(self,
-                 reader: Iterator[Dict[str, str]],
-                 step_column_name: str,
-                 stop_condition: Callable,
-                 parser: Callable,
-                 ):
+    def __init__(
+        self,
+        reader: Iterator[Dict[str, str]],
+        step_column_name: str,
+        stop_condition: Callable,
+        parser: Callable,
+    ):
         self.reader = reader
         self.history = None
         self.step_column_name = step_column_name
@@ -111,14 +112,14 @@ class DictReaderStepper:
 
     destruction: should be explicitly closed via DictReaderStepper.close()
     """
-
-    def __init__(self,
-                 dict_reader: Iterator[Dict[str, str]],
-                 file_reference: Optional[TextIO],
-                 step_column_name: str,
-                 initial_stop_condition: Callable = lambda x: x < 0,
-                 parser: Callable = lambda x: x,
-                 ):
+    def __init__(
+        self,
+        dict_reader: Iterator[Dict[str, str]],
+        file_reference: Optional[TextIO],
+        step_column_name: str,
+        initial_stop_condition: Callable = lambda x: x < 0,
+        parser: Callable = lambda x: x,
+    ):
         """
         creates a DictReaderStepper with an internal DictReaderIterator
 
@@ -127,16 +128,18 @@ class DictReaderStepper:
         :param initial_stop_condition: the initial bounds - set low (zero) for ascending, high (inf) for descending
         :param parser: an optional parameter for parsing the input_config value
         """
-        self._iterator = DictReaderIterator(dict_reader, step_column_name, initial_stop_condition, parser)
+        self._iterator = DictReaderIterator(dict_reader, step_column_name, initial_stop_condition,
+                                            parser)
         self._file = file_reference
 
     @classmethod
-    def build(cls,
-              file: str,
-              step_column_name: str,
-              initial_stop_condition: Callable = lambda x: x < 0,
-              parser: Callable = lambda x: x,
-              ) -> Tuple[Optional[Exception], Optional[DictReaderStepper]]:
+    def build(
+        cls,
+        file: str,
+        step_column_name: str,
+        initial_stop_condition: Callable = lambda x: x < 0,
+        parser: Callable = lambda x: x,
+    ) -> Tuple[Optional[Exception], Optional[DictReaderStepper]]:
         """
         alternative constructor that takes a file path and returns a DictReaderStepper, or, a failure
 
@@ -154,12 +157,13 @@ class DictReaderStepper:
             return e, None
 
     @classmethod
-    def from_iterator(cls,
-                      data: Iterator[Dict[str, str]],
-                      step_column_name: str,
-                      initial_stop_condition: Callable = lambda x: x < 0,
-                      parser: Callable = lambda x: x,
-                      ) -> DictReaderStepper:
+    def from_iterator(
+        cls,
+        data: Iterator[Dict[str, str]],
+        step_column_name: str,
+        initial_stop_condition: Callable = lambda x: x < 0,
+        parser: Callable = lambda x: x,
+    ) -> DictReaderStepper:
         """
         allows for substituting a simple Dict Iterator in place of loading from
         a file, allowing for programmatic data loading (for debugging, or, for

--- a/hive/util/switch_case.py
+++ b/hive/util/switch_case.py
@@ -5,7 +5,6 @@ from typing import Dict
 
 from hive.util.typealiases import *
 
-
 Key = TypeVar('Key')
 """
 the type used to switch off of
@@ -23,7 +22,6 @@ the type returned from the SwitchCase (can be "Any")
 
 
 class SwitchCase(ABC):
-
     @abstractmethod
     def _default(self, arguments: Arguments) -> Result:
         """

--- a/hive/util/tuple_ops.py
+++ b/hive/util/tuple_ops.py
@@ -69,8 +69,7 @@ class TupleOps:
             return remaining
 
     @classmethod
-    def partition(cls,
-                  predicate: Callable[[T], bool],
+    def partition(cls, predicate: Callable[[T], bool],
                   t: Tuple[T, ...]) -> Tuple[Tuple[T, ...], Tuple[T, ...]]:
         """
         partitions a tuple into two tuples where members of the first tuple

--- a/hive/util/wkt.py
+++ b/hive/util/wkt.py
@@ -50,7 +50,8 @@ def linestring_2d(points: Tuple[Tuple[float, float], ...], x_y_ordering: bool) -
     elif len(points) == 1:
         return point_2d(points[0], x_y_ordering)
     else:
-        pts_strings = ft.reduce(lambda acc, pair: acc + (f"{_point_to_string(pair, x_y_ordering)}",), points, ())
+        pts_strings = ft.reduce(
+            lambda acc, pair: acc + (f"{_point_to_string(pair, x_y_ordering)}", ), points, ())
         inner_content = ", ".join(pts_strings)
         linestring = f"LINESTRING ({inner_content})"
         return linestring

--- a/setup.py
+++ b/setup.py
@@ -18,12 +18,9 @@ setup(
     long_description_content_type='text/markdown',
     url="https://github.nrel.gov/MBAP/hive",
     classifiers=[
-        "Development Status :: 3 - Alpha",
-        "Intended Audience :: Science/Research",
-        "License :: Other/Proprietary License",
-        "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3.7",
-        "Topic :: Scientific/Engineering"
+        "Development Status :: 3 - Alpha", "Intended Audience :: Science/Research",
+        "License :: Other/Proprietary License", "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3.7", "Topic :: Scientific/Engineering"
     ],
     packages=find_packages(),
     python_requires=">=3.7",
@@ -39,9 +36,7 @@ setup(
         "returns",
     ],
     include_package_data=True,
-    package_data={
-        "hive.resources": ["*"]
-    },
+    package_data={"hive.resources": ["*"]},
     entry_points={
         'console_scripts': [
             'hive=hive.app.run:run',
@@ -51,5 +46,4 @@ setup(
     author="National Renewable Energy Laboratory",
     author_email="Reinicke, Nicholas <Nicholas.Reinicke@nrel.gov>",
     license=notice,
-    keywords="transportation simulation ride-hail data-driven agent-based model ABM"
-)
+    keywords="transportation simulation ride-hail data-driven agent-based model ABM")

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+
 def test_dir() -> Path:
     """
     Returns the directory of the tests.

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -5,7 +5,6 @@ from hive.resources.mock_lobster import *
 
 
 class TestBase(TestCase):
-
     def test_from_row(self):
         source = """base_id,lat,lon,stall_count,station_id
                     b1,37,122,10,s1"""

--- a/tests/test_bev_mechatronics.py
+++ b/tests/test_bev_mechatronics.py
@@ -4,17 +4,15 @@ from hive.resources.mock_lobster import *
 
 
 class TestBEV(TestCase):
-
     def test_leaf_energy_gain_0_soc(self):
         bev = mock_bev(battery_capacity_kwh=50)
         vehicle = mock_vehicle(soc=0)
 
         charged_vehicle, _ = bev.add_energy(vehicle, mock_dcfc_charger(), hours_to_seconds(10))
-        self.assertAlmostEqual(
-            charged_vehicle.energy[EnergyType.ELECTRIC] / bev.battery_capacity_kwh,
-            1,
-            places=2
-        )
+        self.assertAlmostEqual(charged_vehicle.energy[EnergyType.ELECTRIC] /
+                               bev.battery_capacity_kwh,
+                               1,
+                               places=2)
 
     def test_leaf_energy_gain_full_soc(self):
         bev = mock_bev(battery_capacity_kwh=50)
@@ -28,14 +26,16 @@ class TestBEV(TestCase):
         vehicle = mock_vehicle(soc=0)
 
         charged_vehicle, _ = bev.add_energy(vehicle, mock_l2_charger(), hours_to_seconds(0.1))
-        self.assertLess(charged_vehicle.energy[EnergyType.ELECTRIC], 50, "Should not be fully charged")
+        self.assertLess(charged_vehicle.energy[EnergyType.ELECTRIC], 50,
+                        "Should not be fully charged")
 
     def test_leaf_energy_cost_empty_route(self):
         bev = mock_bev(battery_capacity_kwh=50)
         vehicle = mock_vehicle(soc=1)
 
         moved_vehicle = bev.move(vehicle, route=())
-        self.assertEqual(moved_vehicle.energy[EnergyType.ELECTRIC], 50, "empty route should yield zero energy cost")
+        self.assertEqual(moved_vehicle.energy[EnergyType.ELECTRIC], 50,
+                         "empty route should yield zero energy cost")
 
     def test_leaf_energy_cost_real_route(self):
         bev = mock_bev(battery_capacity_kwh=50, nominal_watt_hour_per_mile=1000)
@@ -47,10 +47,9 @@ class TestBEV(TestCase):
         expected_energy_kwh = vehicle.energy[EnergyType.ELECTRIC] - 1 * (3 * KM_TO_MILE)
 
         moved_vehicle = bev.move(vehicle, route=test_route)
-        self.assertAlmostEqual(
-            moved_vehicle.energy[EnergyType.ELECTRIC],
-            expected_energy_kwh,
-            places=0)
+        self.assertAlmostEqual(moved_vehicle.energy[EnergyType.ELECTRIC],
+                               expected_energy_kwh,
+                               places=0)
 
     def test_remaining_range(self):
         bev = mock_bev(battery_capacity_kwh=50, nominal_watt_hour_per_mile=1000)

--- a/tests/test_build_mechatronics_table.py
+++ b/tests/test_build_mechatronics_table.py
@@ -6,9 +6,7 @@ from hive.model.vehicle.mechatronics.__init__ import build_mechatronics_table
 test_dir = Path(__file__).parent
 
 
-
 class TestBuildMechatronicsTable(TestCase):
-
     def test_build_valid_table(self):
         try:
             build_mechatronics_table(test_dir / 'test_assets/mechatronics_valid.yaml',
@@ -17,43 +15,36 @@ class TestBuildMechatronicsTable(TestCase):
             self.fail("build_mechatronics_table threw KeyError unexpectedly!")
 
     def test_missing_type_field(self):
-        self.assertRaises(IOError,
-                          build_mechatronics_table,
+        self.assertRaises(IOError, build_mechatronics_table,
                           test_dir / 'test_assets/mechatronics_missing_type.yaml',
                           'hive.resources.scenarios.denver_downtown')
 
     def test_bad_type(self):
-        self.assertRaises(IOError,
-                          build_mechatronics_table,
+        self.assertRaises(IOError, build_mechatronics_table,
                           test_dir / 'test_assets/mechatronics_bad_type.yaml',
                           'hive.resources.scenarios.denver_downtown')
 
     def test_missing_power_curve_field(self):
-        self.assertRaises(FileNotFoundError,
-                          build_mechatronics_table,
+        self.assertRaises(FileNotFoundError, build_mechatronics_table,
                           test_dir / 'test_assets/mechatronics_missing_powercurve.yaml',
                           'hive.resources.scenarios.denver_downtown')
 
     def test_bad_power_curve(self):
-        self.assertRaises(FileNotFoundError,
-                          build_mechatronics_table,
+        self.assertRaises(FileNotFoundError, build_mechatronics_table,
                           test_dir / 'test_assets/mechatronics_bad_powercurve.yaml',
                           'hive.resources.scenarios.denver_downtown')
 
     def test_missing_power_train_field(self):
-        self.assertRaises(FileNotFoundError,
-                          build_mechatronics_table,
+        self.assertRaises(FileNotFoundError, build_mechatronics_table,
                           test_dir / 'test_assets/mechatronics_missing_powertrain.yaml',
                           'hive.resources.scenarios.denver_downtown')
 
     def test_bad_power_train_name(self):
-        self.assertRaises(FileNotFoundError,
-                          build_mechatronics_table,
+        self.assertRaises(FileNotFoundError, build_mechatronics_table,
                           test_dir / 'test_assets/mechatronics_bad_powertrain.yaml',
                           'hive.resources.scenarios.denver_downtown')
 
     def test_missing_mechatronics_file(self):
-        self.assertRaises(FileNotFoundError,
-                          build_mechatronics_table,
+        self.assertRaises(FileNotFoundError, build_mechatronics_table,
                           test_dir / 'test_assets/not_real_mechatronics.yaml',
                           'hive.resources.scenarios.denver_downtown')

--- a/tests/test_cancel_requests.py
+++ b/tests/test_cancel_requests.py
@@ -12,7 +12,8 @@ class TestCancelRequests(TestCase):
         cancel_requests = CancelRequests()
         result, _ = cancel_requests.update(sim, env)
         self.assertNotIn(req.id, result.requests, "request should have been removed")
-        self.assertNotIn(req.origin, result.r_locations, "request location should have been removed")
+        self.assertNotIn(req.origin, result.r_locations,
+                         "request location should have been removed")
 
     def test_update_not_cancellable(self):
         req = mock_request()
@@ -21,5 +22,5 @@ class TestCancelRequests(TestCase):
         cancel_requests = CancelRequests()
         result, _ = cancel_requests.update(sim, env)
         self.assertIn(req.id, result.requests, "request should not have been removed")
-        self.assertIn(req.origin, result.r_locations, "request location should not have been removed")
-
+        self.assertIn(req.origin, result.r_locations,
+                      "request location should not have been removed")

--- a/tests/test_charging_price_update.py
+++ b/tests/test_charging_price_update.py
@@ -5,54 +5,68 @@ from hive.resources.mock_lobster import *
 
 
 class TestChargingPriceUpdate(TestCase):
-
     def test_charge_price_update_from_station_id_file(self):
         # prices are set to bump at 28800 (8 am)
-        sim = mock_sim(
-            stations=(
-                mock_station_from_geoid("s1", '8f268cdac268430'),
-                mock_station_from_geoid("s2", '8f268cdac268589'),
-                mock_station_from_geoid("bs1", '8f268cdac268433')),
-            sim_time=28801)
+        sim = mock_sim(stations=(mock_station_from_geoid("s1", '8f268cdac268430'),
+                                 mock_station_from_geoid("s2", '8f268cdac268589'),
+                                 mock_station_from_geoid("bs1", '8f268cdac268433')),
+                       sim_time=28801)
         env = mock_env()
         s1, s2, bs1 = "s1", "s2", "bs1"  # StationIds in the Denver Downtown scenario
-        file = resource_filename("hive.resources.scenarios.denver_downtown.charging_prices", "denver_charging_prices_by_station_id.csv")
+        file = resource_filename("hive.resources.scenarios.denver_downtown.charging_prices",
+                                 "denver_charging_prices_by_station_id.csv")
         fn = ChargingPriceUpdate.build(file, env.config.input_config.chargers_file)
         result, _ = fn.update(sim, env)
         s1_prices = result.stations[s1].charger_prices_per_kwh
         s2_prices = result.stations[s2].charger_prices_per_kwh
         bs1_prices = result.stations[bs1].charger_prices_per_kwh
-        self.assertEqual(s1_prices.get(mock_dcfc_charger_id()), 0.5, "station s1 has a DCFC price of 0.5 per kwh")
-        self.assertEqual(s2_prices.get(mock_dcfc_charger_id()), 0.5, "station s1 has a DCFC price of 0.5 per kwh")
-        self.assertEqual(bs1_prices.get(mock_l2_charger_id()), 0.05, "station s1 has a LEVEL_2 price of 0.05 per kwh")
+        self.assertEqual(s1_prices.get(mock_dcfc_charger_id()), 0.5,
+                         "station s1 has a DCFC price of 0.5 per kwh")
+        self.assertEqual(s2_prices.get(mock_dcfc_charger_id()), 0.5,
+                         "station s1 has a DCFC price of 0.5 per kwh")
+        self.assertEqual(bs1_prices.get(mock_l2_charger_id()), 0.05,
+                         "station s1 has a LEVEL_2 price of 0.05 per kwh")
         fn.reader.close()
 
     def test_charge_price_update_from_geoid_file(self):
         # prices are set to bump at 28800 (8 am)
         stations = (
-            mock_station("s1", 39.752233, -104.976061, chargers=immutables.Map({mock_dcfc_charger_id(): 10})),
-            mock_station("s2", 39.759521,-104.97526, chargers=immutables.Map({mock_dcfc_charger_id(): 10})),
-            mock_station("bs1", 39.754695,-104.988116, chargers=immutables.Map({mock_l2_charger_id(): 10})),
+            mock_station("s1",
+                         39.752233,
+                         -104.976061,
+                         chargers=immutables.Map({mock_dcfc_charger_id(): 10})),
+            mock_station("s2",
+                         39.759521,
+                         -104.97526,
+                         chargers=immutables.Map({mock_dcfc_charger_id(): 10})),
+            mock_station("bs1",
+                         39.754695,
+                         -104.988116,
+                         chargers=immutables.Map({mock_l2_charger_id(): 10})),
         )
         sim = mock_sim(stations=stations, sim_time=36001)
         env = mock_env()
         s1, s2, bs1 = "s1", "s2", "bs1"  # StationIds in the Denver Downtown scenario
-        file = resource_filename("hive.resources.scenarios.denver_downtown.charging_prices", "denver_charging_prices_by_geoid.csv")
+        file = resource_filename("hive.resources.scenarios.denver_downtown.charging_prices",
+                                 "denver_charging_prices_by_geoid.csv")
         fn = ChargingPriceUpdate.build(file, env.config.input_config.chargers_file)
         result, _ = fn.update(sim, env)
         s1_prices = result.stations[s1].charger_prices_per_kwh
         s2_prices = result.stations[s2].charger_prices_per_kwh
         bs1_prices = result.stations[bs1].charger_prices_per_kwh
-        self.assertEqual(s1_prices.get(mock_dcfc_charger_id()), 0.3, "station s1 has a DCFC price of 0.3 per kwh")
-        self.assertEqual(s2_prices.get(mock_dcfc_charger_id()), 0.3, "station s1 has a DCFC price of 0.3 per kwh")
-        self.assertEqual(bs1_prices.get(mock_l2_charger_id()), 0.03, "station s1 has a LEVEL_2 price of 0.03 per kwh")
+        self.assertEqual(s1_prices.get(mock_dcfc_charger_id()), 0.3,
+                         "station s1 has a DCFC price of 0.3 per kwh")
+        self.assertEqual(s2_prices.get(mock_dcfc_charger_id()), 0.3,
+                         "station s1 has a DCFC price of 0.3 per kwh")
+        self.assertEqual(bs1_prices.get(mock_l2_charger_id()), 0.03,
+                         "station s1 has a LEVEL_2 price of 0.03 per kwh")
         fn.reader.close()
 
     def test_charge_price_default_price_is_zero(self):
         station = mock_station(chargers=immutables.Map({
-                mock_l1_charger_id(): 1,
-                mock_l2_charger_id(): 1,
-                mock_dcfc_charger_id(): 1
+            mock_l1_charger_id(): 1,
+            mock_l2_charger_id(): 1,
+            mock_dcfc_charger_id(): 1
         }))
         sim = mock_sim(
             stations=(station, ),
@@ -63,9 +77,9 @@ class TestChargingPriceUpdate(TestCase):
         fn = ChargingPriceUpdate.build(None, env.config.input_config.chargers_file)
         result, _ = fn.update(sim, env)
         prices = result.stations[DefaultIds.mock_station_id()].charger_prices_per_kwh
-        self.assertEqual(prices.get(mock_l1_charger_id()), 0.0, "LEVEL_1 charging should be free by default")
-        self.assertEqual(prices.get(mock_l2_charger_id()), 0.0, "LEVEL_2 charging should be free by default")
-        self.assertEqual(prices.get(mock_dcfc_charger_id()), 0.0, "DCFC charging should be free by default")
-
-
-
+        self.assertEqual(prices.get(mock_l1_charger_id()), 0.0,
+                         "LEVEL_1 charging should be free by default")
+        self.assertEqual(prices.get(mock_l2_charger_id()), 0.0,
+                         "LEVEL_2 charging should be free by default")
+        self.assertEqual(prices.get(mock_dcfc_charger_id()), 0.0,
+                         "DCFC charging should be free by default")

--- a/tests/test_config_builder.py
+++ b/tests/test_config_builder.py
@@ -11,12 +11,10 @@ class TestConfigBuilder(TestCase):
             'b': "string",
         }
 
-        test_class = ConfigBuilder.build(
-            default_config=defaults,
-            required_config=(),
-            config_constructor=TestConfigBuilderAssets.constructor,
-            config=None
-        )
+        test_class = ConfigBuilder.build(default_config=defaults,
+                                         required_config=(),
+                                         config_constructor=TestConfigBuilderAssets.constructor,
+                                         config=None)
 
         self.assertIsInstance(test_class, TestConfigBuilderAssets.TestClass)
         self.assertEqual(test_class.a, defaults['a'])
@@ -33,12 +31,10 @@ class TestConfigBuilder(TestCase):
             'b': 'foo',
         }
 
-        test_class = ConfigBuilder.build(
-            default_config={},
-            required_config=required,
-            config_constructor=TestConfigBuilderAssets.constructor,
-            config=config
-        )
+        test_class = ConfigBuilder.build(default_config={},
+                                         required_config=required,
+                                         config_constructor=TestConfigBuilderAssets.constructor,
+                                         config=config)
 
         self.assertIsInstance(test_class, TestConfigBuilderAssets.TestClass)
         self.assertEqual(test_class.a, config['a'])
@@ -55,29 +51,18 @@ class TestConfigBuilder(TestCase):
         }
 
         with self.assertRaises(AttributeError):
-            test_class = ConfigBuilder.build(
-                default_config={},
-                required_config=required,
-                config_constructor=TestConfigBuilderAssets.constructor,
-                config=config
-            )
+            test_class = ConfigBuilder.build(default_config={},
+                                             required_config=required,
+                                             config_constructor=TestConfigBuilderAssets.constructor,
+                                             config=config)
 
     def test_build_ignores_extra_fields(self):
-        config = {
-            'a': 6,
-            'b': 'foo',
-            'extra': "will be ignored",
-            'd': {
-                'e': 'bar'
-            }
-        }
+        config = {'a': 6, 'b': 'foo', 'extra': "will be ignored", 'd': {'e': 'bar'}}
 
-        test_class = ConfigBuilder.build(
-            default_config={},
-            required_config=(),
-            config_constructor=TestConfigBuilderAssets.constructor,
-            config=config
-        )
+        test_class = ConfigBuilder.build(default_config={},
+                                         required_config=(),
+                                         config_constructor=TestConfigBuilderAssets.constructor,
+                                         config=config)
 
         self.assertIsInstance(test_class, TestConfigBuilderAssets.TestClass)
         self.assertEqual(test_class.a, config['a'])

--- a/tests/test_dict_ops.py
+++ b/tests/test_dict_ops.py
@@ -30,18 +30,28 @@ class TestDictOps(TestCase):
         update_at_loc = DictOps.add_to_collection_dict(some_locs, '1234', 'v3')
         update_empty_loc = DictOps.add_to_collection_dict(some_locs, '5678', 'v4')
         self.assertIn('v3', update_at_loc.get('1234'), "v3 should be added at location 1234")
-        self.assertIn('v1', update_at_loc.get('1234'), "v1 should not have been removed at location 1234")
-        self.assertIn('v2', update_at_loc.get('1234'), "v2 should not have been removed at location 1234")
+        self.assertIn('v1', update_at_loc.get('1234'),
+                      "v1 should not have been removed at location 1234")
+        self.assertIn('v2', update_at_loc.get('1234'),
+                      "v2 should not have been removed at location 1234")
         self.assertIn('5678', update_empty_loc.keys(), "location 1234 should be added")
         self.assertIn('v4', update_empty_loc.get('5678'), "v4 should be added to new location 5678")
 
     def test_remove_from_collection_dict(self):
-        some_locs = immutables.Map({'1234': frozenset(['v1', 'v2']), '5678': frozenset(['v3',])})
+        some_locs = immutables.Map({
+            '1234': frozenset(['v1', 'v2']),
+            '5678': frozenset([
+                'v3',
+            ])
+        })
         update_at_loc = DictOps.remove_from_collection_dict(some_locs, '1234', 'v1')
         update_empties_loc = DictOps.remove_from_collection_dict(some_locs, '5678', 'v3')
-        self.assertNotIn('v1', update_at_loc.get('1234'), "v1 should have been removed at location 1234")
-        self.assertIn('v2', update_at_loc.get('1234'), "v2 should not have been removed at location 1234")
-        self.assertNotIn('5678', update_empties_loc.keys(), "location 5678 should have been emptied")
+        self.assertNotIn('v1', update_at_loc.get('1234'),
+                         "v1 should have been removed at location 1234")
+        self.assertIn('v2', update_at_loc.get('1234'),
+                      "v2 should not have been removed at location 1234")
+        self.assertNotIn('5678', update_empties_loc.keys(),
+                         "location 5678 should have been emptied")
 
         with self.assertRaises(KeyError) as raised:
             DictOps.remove_from_collection_dict(some_locs, '910_', 'v4')

--- a/tests/test_dict_reader_stepper.py
+++ b/tests/test_dict_reader_stepper.py
@@ -27,18 +27,13 @@ class TestDictReaderStepper(TestCase):
         stop_condition = self._generate_stop_condition(stop_time)
         _, stepper = DictReaderStepper.build(test_filename, "departure_time", parser=SimTime.build)
         result = tuple(stepper.read_until_stop_condition(stop_condition))
-        self.assertEqual(len(result), 20, f"should have found 20 rows with departure time earlier than {stop_time}")
-        self.assertEqual(
-            SimTime.build(stepper._iterator.history['departure_time']),
-            stop_time,
-            f"next has time {stop_time}"
-        )
+        self.assertEqual(len(result), 20,
+                         f"should have found 20 rows with departure time earlier than {stop_time}")
+        self.assertEqual(SimTime.build(stepper._iterator.history['departure_time']), stop_time,
+                         f"next has time {stop_time}")
         for row in result:
-            self.assertLess(
-                SimTime.build(row['departure_time']),
-                stop_time,
-                f"should be less than {stop_time}"
-            )
+            self.assertLess(SimTime.build(row['departure_time']), stop_time,
+                            f"should be less than {stop_time}")
         stepper.close()
 
     def test_reading_two_consecutive_times(self):
@@ -49,30 +44,30 @@ class TestDictReaderStepper(TestCase):
         stop2 = SimTime.build('1970-01-01T00:14:00')
         result1 = tuple(stepper.read_until_stop_condition(self._generate_stop_condition(stop1)))
         result2 = tuple(stepper.read_until_stop_condition(self._generate_stop_condition(stop2)))
-        self.assertEqual(len(result1), 20, f"should have found 20 rows with departure time [0, {stop1})")
-        self.assertEqual(len(result2), 5, f"should have found 5 rows with departure time [{stop1}, {stop2})")
+        self.assertEqual(len(result1), 20,
+                         f"should have found 20 rows with departure time [0, {stop1})")
+        self.assertEqual(len(result2), 5,
+                         f"should have found 5 rows with departure time [{stop1}, {stop2})")
         for row in result1:
-            self.assertLess(
-                SimTime.build(row['departure_time']),
-                stop1,
-                f"should be less than {stop1}")
+            self.assertLess(SimTime.build(row['departure_time']), stop1,
+                            f"should be less than {stop1}")
         for row in result2:
-            self.assertGreaterEqual(
-                SimTime.build(row['departure_time']),
-                stop1,
-                f"should be gte {stop1}")
-            self.assertLess(
-                SimTime.build(row['departure_time']),
-                stop2,
-                f"should be less than {stop2}")
+            self.assertGreaterEqual(SimTime.build(row['departure_time']), stop1,
+                                    f"should be gte {stop1}")
+            self.assertLess(SimTime.build(row['departure_time']), stop2,
+                            f"should be less than {stop2}")
         stepper.close()
 
     def test_no_agents_after_end_of_file(self):
         test_filename = resource_filename("hive.resources.scenarios.denver_downtown.requests",
                                           "denver_demo_requests.csv")
         _, stepper = DictReaderStepper.build(test_filename, "departure_time", parser=SimTime.build)
-        _ = tuple(stepper.read_until_stop_condition(self._generate_stop_condition(SimTime.build(9999998))))
-        result = tuple(stepper.read_until_stop_condition(self._generate_stop_condition(SimTime.build(9999999))))
+        _ = tuple(
+            stepper.read_until_stop_condition(self._generate_stop_condition(
+                SimTime.build(9999998))))
+        result = tuple(
+            stepper.read_until_stop_condition(self._generate_stop_condition(
+                SimTime.build(9999999))))
         self.assertEqual(len(result), 0, "should find no more agents after end of time")
 
     def test_no_second_file_reading_on_repeated_value(self):
@@ -82,8 +77,10 @@ class TestDictReaderStepper(TestCase):
         stop = SimTime.build('1970-01-01T00:12:00')
         result1 = tuple(stepper.read_until_stop_condition(self._generate_stop_condition(stop)))
         result2 = tuple(stepper.read_until_stop_condition(self._generate_stop_condition(stop)))
-        self.assertEqual(len(result1), 20, f"should have found 20 rows with departure time earlier than {stop}")
-        self.assertEqual(len(result2), 0, f"will not advance file by calling same stop value {stop}")
+        self.assertEqual(len(result1), 20,
+                         f"should have found 20 rows with departure time earlier than {stop}")
+        self.assertEqual(len(result2), 0,
+                         f"will not advance file by calling same stop value {stop}")
 
     def test_correct_management_of_stored_value_after_repeated_value(self):
         test_filename = resource_filename("hive.resources.scenarios.denver_downtown.requests",
@@ -96,19 +93,12 @@ class TestDictReaderStepper(TestCase):
         # show that second stop1 call means we should have done nothing since the first call
         stop2 = SimTime.build('1970-01-01T00:13:00')
         result = tuple(stepper.read_until_stop_condition(self._generate_stop_condition(stop2)))
-        self.assertEqual(len(result), 1, f"should have found 20 rows with departure time earlier than {stop2}")
-        self.assertEqual(
-            SimTime.build(stepper._iterator.history['departure_time']),
-            stop2,
-            f"next has time {stop2}"
-        )
+        self.assertEqual(len(result), 1,
+                         f"should have found 20 rows with departure time earlier than {stop2}")
+        self.assertEqual(SimTime.build(stepper._iterator.history['departure_time']), stop2,
+                         f"next has time {stop2}")
         for row in result:
-            self.assertGreaterEqual(
-                SimTime.build(row['departure_time']),
-                stop1,
-                f"should be gte {stop1}"
-            )
-            self.assertLess(
-                SimTime.build(row['departure_time']),
-                stop2,
-                f"should be less than {stop2}")
+            self.assertGreaterEqual(SimTime.build(row['departure_time']), stop1,
+                                    f"should be gte {stop1}")
+            self.assertLess(SimTime.build(row['departure_time']), stop2,
+                            f"should be less than {stop2}")

--- a/tests/test_driver_instruction_ops.py
+++ b/tests/test_driver_instruction_ops.py
@@ -1,4 +1,3 @@
-
 from unittest import TestCase
 
 from hive.state.driver_state.driver_instruction_ops import human_go_home
@@ -6,12 +5,11 @@ from hive.resources.mock_lobster import *
 
 
 class TestDriverInstructionOps(TestCase):
-
     def test_human_go_home_with_enough_range(self):
         veh = mock_vehicle(soc=0.8, lat=0, lon=0)
-        base = mock_base(lat=1, lon=1, station_id='hb1')              # 141-ish km away
+        base = mock_base(lat=1, lon=1, station_id='hb1')  # 141-ish km away
         station = mock_station(lat=0.01, lon=0.01)  # 1.41km-ish away
-        sim = mock_sim(vehicles=(veh,), bases=(base,), stations=(station,))
+        sim = mock_sim(vehicles=(veh, ), bases=(base, ), stations=(station, ))
         env = mock_env()
 
         result = human_go_home(veh, base, sim, env)
@@ -21,7 +19,7 @@ class TestDriverInstructionOps(TestCase):
         veh = mock_vehicle(soc=0.05, lat=0, lon=0)
         base = mock_base(lat=1, lon=1, station_id='hb1')
         station = mock_station(lat=0.01, lon=0.01)
-        sim = mock_sim(vehicles=(veh,), bases=(base,), stations=(station,))
+        sim = mock_sim(vehicles=(veh, ), bases=(base, ), stations=(station, ))
         env = mock_env()
 
         result = human_go_home(veh, base, sim, env)
@@ -33,7 +31,7 @@ class TestDriverInstructionOps(TestCase):
         veh = mock_vehicle(soc=0.02, lat=0, lon=0)
         base = mock_base(lat=0.04, lon=0.04, station_id=None)
         station = mock_station(lat=0.01, lon=0.01)
-        sim = mock_sim(vehicles=(veh,), bases=(base,), stations=(station,))
+        sim = mock_sim(vehicles=(veh, ), bases=(base, ), stations=(station, ))
         env = mock_env()
 
         result = human_go_home(veh, base, sim, env)

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -10,7 +10,6 @@ from hive.util.fs import global_hive_config_search
 
 
 class TestDictReaderStepper(TestCase):
-
     def test_global_hive_config_search_finds_default(self):
         result = global_hive_config_search()
         self.assertIsInstance(result, GlobalConfig, "should be a GlobalConfig class instance")
@@ -24,6 +23,9 @@ class TestDictReaderStepper(TestCase):
             with tempfile.TemporaryDirectory(dir=parent) as child:
                 os.chdir(child)
                 result = global_hive_config_search()
-                self.assertIsInstance(result, GlobalConfig, "should be a GlobalConfig class instance")
-                self.assertFalse(result.log_states, "should have found the modified config in the parent directory")  # default is "True"
+                self.assertIsInstance(result, GlobalConfig,
+                                      "should be a GlobalConfig class instance")
+                self.assertFalse(result.log_states,
+                                 "should have found the modified config in the parent directory"
+                                 )  # default is "True"
                 self.assertTrue(result.log_run, "should also contain keys from the default config")

--- a/tests/test_h3_ops.py
+++ b/tests/test_h3_ops.py
@@ -31,7 +31,10 @@ class TestH3Ops(TestCase):
         close_to_somewhere = h3.geo_to_h3(39.753600, -104.993369, 15)
         far_from_somewhere = h3.geo_to_h3(39.728882, -105.002792, 15)
         entities = immutables.Map({'1': 1, '2': 2, '3': 3, '4': 4})
-        entity_locations = immutables.Map({close_to_somewhere: ('1', '2'), far_from_somewhere: ('3', '4')})
+        entity_locations = immutables.Map({
+            close_to_somewhere: ('1', '2'),
+            far_from_somewhere: ('3', '4')
+        })
 
         nearest_entity = H3Ops.nearest_entity_point_to_point(somewhere, entities, entity_locations)
 
@@ -57,10 +60,11 @@ class TestH3Ops(TestCase):
         self.assertIsNone(e1, "test invariant failed")
         self.assertIsNone(e2, "test invariant failed")
 
-        nearest = H3Ops.nearest_entity_by_great_circle_distance(geoid=somewhere,
-                                                                entities=tuple(sim_with_reqs.requests.values()),
-                                                                entity_search=sim_with_reqs.r_search,
-                                                                sim_h3_search_resolution=sim_with_reqs.sim_h3_search_resolution)
+        nearest = H3Ops.nearest_entity_by_great_circle_distance(
+            geoid=somewhere,
+            entities=tuple(sim_with_reqs.requests.values()),
+            entity_search=sim_with_reqs.r_search,
+            sim_h3_search_resolution=sim_with_reqs.sim_h3_search_resolution)
 
         self.assertEqual(nearest.geoid, req_near.geoid)
 

--- a/tests/test_haversine_roadnetwork.py
+++ b/tests/test_haversine_roadnetwork.py
@@ -33,4 +33,7 @@ class TestHaversineRoadNetwork(TestCase):
         self.assertEqual(len(route), 1, "Route should have only one link")
         self.assertEqual(route[0].start, origin, "Route should start from origin")
         self.assertEqual(route[0].end, destination, "Route should end at destination")
-        self.assertAlmostEqual(route[0].distance_km, 1.1, places=1, msg="Route should be approx. 1.1km")
+        self.assertAlmostEqual(route[0].distance_km,
+                               1.1,
+                               places=1,
+                               msg="Route should be approx. 1.1km")

--- a/tests/test_human_driver_state.py
+++ b/tests/test_human_driver_state.py
@@ -11,18 +11,14 @@ def off_schedule(a, b):
     return False
 
 
-test_schedules = {
-    "on": on_schedule,
-    "off": off_schedule
-}
+test_schedules = {"on": on_schedule, "off": off_schedule}
 
 
 class TestHumanDriverState(TestCase):
-
     def test_stays_available(self):
         state = mock_human_driver(available=True, schedule_id="on")
         veh = mock_vehicle(driver_state=state)
-        sim = mock_sim(vehicles=(veh,))
+        sim = mock_sim(vehicles=(veh, ))
 
         env = mock_env(schedules=test_schedules)
         error, updated_sim = state.update(sim, env)
@@ -35,7 +31,7 @@ class TestHumanDriverState(TestCase):
     def test_becomes_unavailable(self):
         state = mock_human_driver(available=True, schedule_id="off")
         veh = mock_vehicle(driver_state=state)
-        sim = mock_sim(vehicles=(veh,))
+        sim = mock_sim(vehicles=(veh, ))
 
         env = mock_env(schedules=test_schedules)
         error, updated_sim = state.update(sim, env)
@@ -51,12 +47,19 @@ class TestHumanDriverState(TestCase):
         veh_state = ChargingStation(veh_id, "away_station", "DCFC")
 
         # vehicle is at away_station, but has a home_base with a home_station
-        veh = mock_vehicle(lat=39.7664622, lon=-105.0390823, vehicle_id=veh_id, driver_state=state, vehicle_state=veh_state)
+        veh = mock_vehicle(lat=39.7664622,
+                           lon=-105.0390823,
+                           vehicle_id=veh_id,
+                           driver_state=state,
+                           vehicle_state=veh_state)
         away_station = mock_station(lat=39.7664622, lon=-105.0390823, station_id="away_station")
-        home_base = mock_base(lat=39.7544977, lon=-104.9809168, base_id="home_base", station_id="home_station")
+        home_base = mock_base(lat=39.7544977,
+                              lon=-104.9809168,
+                              base_id="home_base",
+                              station_id="home_station")
         home_station = mock_station(lat=39.7544977, lon=-104.9809168, station_id="home_station")
 
-        sim = mock_sim(vehicles=(veh,), bases=(home_base,), stations=(home_station, away_station))
+        sim = mock_sim(vehicles=(veh, ), bases=(home_base, ), stations=(home_station, away_station))
         env = mock_env(schedules=test_schedules)
         error, updated_sim = state.update(sim, env)
         if error:
@@ -64,7 +67,8 @@ class TestHumanDriverState(TestCase):
         else:
             updated_veh = updated_sim.vehicles.get(veh_id)
             instruction = updated_veh.driver_state.generate_instruction(updated_sim, env, ())
-            self.assertEqual(instruction, DispatchBaseInstruction("v0", "home_base"), "should have been sent home where charging is cheaper")
+            self.assertEqual(instruction, DispatchBaseInstruction("v0", "home_base"),
+                             "should have been sent home where charging is cheaper")
 
     def test_becomes_unavailable_while_station_charging_no_home_charger(self):
         state = mock_human_driver(available=True, schedule_id="off", home_base_id="home_base")
@@ -72,11 +76,18 @@ class TestHumanDriverState(TestCase):
         veh_state = ChargingStation(veh_id, "away_station", "DCFC")
 
         # vehicle is at away_station, but has a home_base with a home_station
-        veh = mock_vehicle(lat=39.7664622, lon=-105.0390823, vehicle_id=veh_id, driver_state=state, vehicle_state=veh_state)
+        veh = mock_vehicle(lat=39.7664622,
+                           lon=-105.0390823,
+                           vehicle_id=veh_id,
+                           driver_state=state,
+                           vehicle_state=veh_state)
         away_station = mock_station(lat=39.7664622, lon=-105.0390823, station_id="away_station")
-        home_base = mock_base(lat=39.7544977, lon=-104.9809168, base_id="home_base", station_id=None)
+        home_base = mock_base(lat=39.7544977,
+                              lon=-104.9809168,
+                              base_id="home_base",
+                              station_id=None)
 
-        sim = mock_sim(vehicles=(veh,), bases=(home_base,), stations=(away_station,))
+        sim = mock_sim(vehicles=(veh, ), bases=(home_base, ), stations=(away_station, ))
         env = mock_env(schedules=test_schedules)
         error, updated_sim = state.update(sim, env)
         if error:
@@ -84,14 +95,16 @@ class TestHumanDriverState(TestCase):
         else:
             updated_veh = updated_sim.vehicles.get(veh_id)
             instruction = updated_veh.driver_state.generate_instruction(updated_sim, env, ())
-            self.assertEqual(instruction, DispatchBaseInstruction("v0", "home_base"), "should have been sent home, "
-                                                                                      "enough charge to get to "
-                                                                                      "station in the morning")
+            self.assertEqual(
+                instruction, DispatchBaseInstruction("v0", "home_base"),
+                "should have been sent home, "
+                "enough charge to get to "
+                "station in the morning")
 
     def test_stays_unavailable(self):
         state = mock_human_driver(available=False, schedule_id="off")
         veh = mock_vehicle(driver_state=state)
-        sim = mock_sim(vehicles=(veh,))
+        sim = mock_sim(vehicles=(veh, ))
 
         env = mock_env(schedules=test_schedules)
         error, updated_sim = state.update(sim, env)
@@ -104,7 +117,7 @@ class TestHumanDriverState(TestCase):
     def test_becomes_available(self):
         state = mock_human_driver(available=False, schedule_id="on")
         veh = mock_vehicle(driver_state=state)
-        sim = mock_sim(vehicles=(veh,))
+        sim = mock_sim(vehicles=(veh, ))
 
         env = mock_env(schedules=test_schedules)
         error, updated_sim = state.update(sim, env)
@@ -120,7 +133,7 @@ class TestHumanDriverState(TestCase):
         veh = mock_vehicle_from_geoid(driver_state=state, geoid=somewhere())
         station = mock_station_from_geoid(geoid=somewhere_else())
         base = mock_base_from_geoid(station_id=station.id, geoid=somewhere_else())
-        sim = mock_sim(vehicles=(veh,), bases=(base,), stations=(station,))
+        sim = mock_sim(vehicles=(veh, ), bases=(base, ), stations=(station, ))
         env = mock_env()
 
         i = veh.driver_state.generate_instruction(sim, env)
@@ -133,7 +146,7 @@ class TestHumanDriverState(TestCase):
         veh = mock_vehicle_from_geoid(driver_state=state, geoid=somewhere(), soc=0.5)
         station = mock_station_from_geoid(geoid=somewhere())
         base = mock_base_from_geoid(station_id=station.id, geoid=somewhere())
-        sim = mock_sim(vehicles=(veh,), bases=(base,), stations=(station,))
+        sim = mock_sim(vehicles=(veh, ), bases=(base, ), stations=(station, ))
         env = mock_env()
 
         i = veh.driver_state.generate_instruction(sim, env)
@@ -143,12 +156,13 @@ class TestHumanDriverState(TestCase):
     def test_reposition_instruction(self):
         # vehicle is at home but is available, should try to reposition
         state = mock_human_driver(available=True, schedule_id="on")
-        veh = mock_vehicle(driver_state=state, vehicle_state=ReserveBase(
-            DefaultIds.mock_vehicle_id(),
-            DefaultIds.mock_base_id(),
-        ))
+        veh = mock_vehicle(driver_state=state,
+                           vehicle_state=ReserveBase(
+                               DefaultIds.mock_vehicle_id(),
+                               DefaultIds.mock_base_id(),
+                           ))
         req = mock_request_from_geoids(origin=somewhere_else(), destination=somewhere())
-        sim = mock_sim(vehicles=(veh,))
+        sim = mock_sim(vehicles=(veh, ))
         _, sim_w_req = simulation_state_ops.add_request(sim, req)
         env = mock_env()
 
@@ -158,16 +172,14 @@ class TestHumanDriverState(TestCase):
 
     def test_stop_fast_charging_instruction(self):
         state = mock_human_driver(available=True, schedule_id="on")
-        veh = mock_vehicle(
-            driver_state=state,
-            vehicle_state=ChargingStation(
-                vehicle_id=DefaultIds.mock_vehicle_id(),
-                station_id=DefaultIds.mock_station_id(),
-                charger_id=mock_dcfc_charger_id(),
-            ),
-            soc=0.9
-        )
-        sim = mock_sim(vehicles=(veh,))
+        veh = mock_vehicle(driver_state=state,
+                           vehicle_state=ChargingStation(
+                               vehicle_id=DefaultIds.mock_vehicle_id(),
+                               station_id=DefaultIds.mock_station_id(),
+                               charger_id=mock_dcfc_charger_id(),
+                           ),
+                           soc=0.9)
+        sim = mock_sim(vehicles=(veh, ))
         env = mock_env()
 
         # the default soc limit for charging at a station is 0.8 so we should generate an idle instruction.
@@ -183,14 +195,10 @@ class TestHumanDriverState(TestCase):
             geoid=somewhere(),
         )
         base = mock_base_from_geoid(geoid=somewhere())
-        sim = mock_sim(vehicles=(veh,), bases=(base,))
+        sim = mock_sim(vehicles=(veh, ), bases=(base, ))
         env = mock_env()
 
         # the driver is at home and idle so it should try to turn off (i.e. transition to ReserveBase).
         i = veh.driver_state.generate_instruction(sim, env)
 
         self.assertIsInstance(i, ReserveBaseInstruction)
-
-
-
-

--- a/tests/test_ice_mechatronics.py
+++ b/tests/test_ice_mechatronics.py
@@ -4,17 +4,14 @@ from hive.resources.mock_lobster import *
 
 
 class TestICE(TestCase):
-
     def test_energy_gain(self):
         ice = mock_ice(tank_capacity_gallons=10)
         vehicle = mock_vehicle(soc=0, mechatronics=ice)
 
         full_vehicle, _ = ice.add_energy(vehicle, mock_gasoline_pump(), hours_to_seconds(10))
-        self.assertAlmostEqual(
-            full_vehicle.energy[EnergyType.GASOLINE] / ice.tank_capacity_gallons,
-            1,
-            places=2
-        )
+        self.assertAlmostEqual(full_vehicle.energy[EnergyType.GASOLINE] / ice.tank_capacity_gallons,
+                               1,
+                               places=2)
 
     def test_energy_gain_full_soc(self):
         ice = mock_ice(tank_capacity_gallons=10)
@@ -29,7 +26,8 @@ class TestICE(TestCase):
         vehicle = mock_vehicle(soc=1, mechatronics=ice)
 
         moved_vehicle = ice.move(vehicle, route=())
-        self.assertEqual(moved_vehicle.energy[EnergyType.GASOLINE], 10, "empty route should yield zero energy cost")
+        self.assertEqual(moved_vehicle.energy[EnergyType.GASOLINE], 10,
+                         "empty route should yield zero energy cost")
 
     def test_energy_cost_real_route(self):
         ice = mock_ice(tank_capacity_gallons=10, nominal_miles_per_gallon=10)
@@ -41,10 +39,9 @@ class TestICE(TestCase):
         expected_gal_gas = 3 * KM_TO_MILE / 10
 
         moved_vehicle = ice.move(vehicle, route=test_route)
-        self.assertAlmostEqual(
-            10 - moved_vehicle.energy[EnergyType.GASOLINE],
-            expected_gal_gas,
-            places=0)
+        self.assertAlmostEqual(10 - moved_vehicle.energy[EnergyType.GASOLINE],
+                               expected_gal_gas,
+                               places=0)
 
     def test_remaining_range(self):
         ice = mock_ice(tank_capacity_gallons=10, nominal_miles_per_gallon=10)

--- a/tests/test_initialize_ops.py
+++ b/tests/test_initialize_ops.py
@@ -5,21 +5,18 @@ from hive.initialization.initialize_ops import process_fleet_file
 
 
 class TestIntializeOps(TestCase):
-
     def test_process_fleet_file(self):
-        fleets_file_location = resource_filename("hive.resources.scenarios.denver_downtown.fleets", "denver_duel_fleets.yaml")
+        fleets_file_location = resource_filename("hive.resources.scenarios.denver_downtown.fleets",
+                                                 "denver_duel_fleets.yaml")
 
         veh_member_ids = process_fleet_file(fleets_file_location, 'vehicles')
         base_member_ids = process_fleet_file(fleets_file_location, 'bases')
         station_member_ids = process_fleet_file(fleets_file_location, 'stations')
 
-        self.assertEqual(len(veh_member_ids['v7']), 2,
-                         "v7 should be a member of two fleets")
-        self.assertEqual(len(veh_member_ids['v13']), 1,
-                         "v3 should be a member of only one fleet")
+        self.assertEqual(len(veh_member_ids['v7']), 2, "v7 should be a member of two fleets")
+        self.assertEqual(len(veh_member_ids['v13']), 1, "v3 should be a member of only one fleet")
 
-        self.assertEqual(len(base_member_ids['b1']), 1,
-                         "b1 should only be a member of one fleet")
+        self.assertEqual(len(base_member_ids['b1']), 1, "b1 should only be a member of one fleet")
 
         self.assertEqual(len(station_member_ids['s1']), 1,
                          "s1 should be only be a member of one fleet")

--- a/tests/test_initialize_simulation.py
+++ b/tests/test_initialize_simulation.py
@@ -20,15 +20,15 @@ class TestInitializeSimulation(TestCase):
 
         def filter_veh(v: Vehicle) -> bool:
             if v.id == 'v1':
-                return False 
+                return False
 
         def filter_base(b: Base) -> bool:
             if b.id == 'b1':
-                return False 
+                return False
 
         def filter_station(s: Station) -> bool:
             if s.id == 's1':
-                return False 
+                return False
 
         sim, env = initialize_simulation(
             conf,

--- a/tests/test_instruction_generator_ops.py
+++ b/tests/test_instruction_generator_ops.py
@@ -1,8 +1,7 @@
 from unittest import TestCase
 
 from hive.dispatcher.instruction_generator.instruction_generator_ops import (
-    instruct_vehicles_to_dispatch_to_station,
-)
+    instruct_vehicles_to_dispatch_to_station, )
 from hive.dispatcher.instruction_generator.charging_search_type import ChargingSearchType
 from hive.resources.mock_lobster import *
 
@@ -24,15 +23,15 @@ class TestInstructionGenerators(TestCase):
         )
 
         sim = mock_sim(
-            vehicles=(vehicle,),
-            stations=(station,),
+            vehicles=(vehicle, ),
+            stations=(station, ),
         )
         env = mock_env(mechatronics={ice_mechatronics.mechatronics_id: ice_mechatronics})
 
         instructions = instruct_vehicles_to_dispatch_to_station(
             n=1,
             max_search_radius_km=10,
-            vehicles=(vehicle,),
+            vehicles=(vehicle, ),
             simulation_state=sim,
             environment=env,
             target_soc=0.2,
@@ -57,15 +56,15 @@ class TestInstructionGenerators(TestCase):
         )
 
         sim = mock_sim(
-            vehicles=(vehicle,),
-            stations=(station,),
+            vehicles=(vehicle, ),
+            stations=(station, ),
         )
         env = mock_env(mechatronics={mechatronics.mechatronics_id: mechatronics})
 
         instructions = instruct_vehicles_to_dispatch_to_station(
             n=1,
             max_search_radius_km=10,
-            vehicles=(vehicle,),
+            vehicles=(vehicle, ),
             simulation_state=sim,
             environment=env,
             target_soc=0.2,

--- a/tests/test_instruction_generators.py
+++ b/tests/test_instruction_generators.py
@@ -12,8 +12,12 @@ class TestInstructionGenerators(TestCase):
         far_from_somewhere = h3.geo_to_h3(39.755, -104.976, 15)
 
         req = mock_request_from_geoids(origin=somewhere, fleet_id=DefaultIds.mock_membership_id())
-        close_veh = mock_vehicle_from_geoid(vehicle_id='close_veh', geoid=near_to_somewhere, membership=mock_membership())
-        far_veh = mock_vehicle_from_geoid(vehicle_id='far_veh', geoid=far_from_somewhere, membership=mock_membership())
+        close_veh = mock_vehicle_from_geoid(vehicle_id='close_veh',
+                                            geoid=near_to_somewhere,
+                                            membership=mock_membership())
+        far_veh = mock_vehicle_from_geoid(vehicle_id='far_veh',
+                                          geoid=far_from_somewhere,
+                                          membership=mock_membership())
         sim = mock_sim(
             h3_location_res=9,
             h3_search_res=9,
@@ -23,12 +27,11 @@ class TestInstructionGenerators(TestCase):
 
         dispatcher, instructions = dispatcher.generate_instructions(sim, mock_env())
 
-        self.assertGreaterEqual(len(instructions), 1, "Should have generated at least one instruction")
-        self.assertIsInstance(instructions[0],
-                              DispatchTripInstruction,
+        self.assertGreaterEqual(len(instructions), 1,
+                                "Should have generated at least one instruction")
+        self.assertIsInstance(instructions[0], DispatchTripInstruction,
                               "Should have instructed vehicle to dispatch")
-        self.assertEqual(instructions[0].vehicle_id,
-                         close_veh.id,
+        self.assertEqual(instructions[0].vehicle_id, close_veh.id,
                          "Should have picked closest vehicle")
 
     def test_dispatcher_no_vehicles(self):
@@ -53,13 +56,14 @@ class TestInstructionGenerators(TestCase):
         veh = mock_vehicle_from_geoid(geoid=somewhere, soc=0.01)
 
         station = mock_station_from_geoid(geoid=somewhere_else)
-        sim = mock_sim(h3_location_res=9, h3_search_res=9, vehicles=(veh,), stations=(station,))
+        sim = mock_sim(h3_location_res=9, h3_search_res=9, vehicles=(veh, ), stations=(station, ))
 
-        charging_fleet_manager, instructions = charging_fleet_manager.generate_instructions(sim, mock_env())
+        charging_fleet_manager, instructions = charging_fleet_manager.generate_instructions(
+            sim, mock_env())
 
-        self.assertGreaterEqual(len(instructions), 1, "Should have generated at least one instruction")
-        self.assertIsInstance(instructions[0],
-                              DispatchStationInstruction,
+        self.assertGreaterEqual(len(instructions), 1,
+                                "Should have generated at least one instruction")
+        self.assertIsInstance(instructions[0], DispatchStationInstruction,
                               "Should have instructed vehicle to dispatch to station")
 
     def test_charging_fleet_manager_queues(self):
@@ -73,19 +77,31 @@ class TestInstructionGenerators(TestCase):
 
         # invariant: a queue can be created even if plugs are available and
         # our dispatcher only considers the queue size in the distance metric
-        s1 = mock_station_from_geoid(station_id="s1", geoid=s1_geoid, chargers={mock_dcfc_charger_id(): 1})
+        s1 = mock_station_from_geoid(station_id="s1",
+                                     geoid=s1_geoid,
+                                     chargers={mock_dcfc_charger_id(): 1})
         s1 = s1.enqueue_for_charger(mock_dcfc_charger_id()).checkout_charger(mock_dcfc_charger_id())
-        s2 = mock_station_from_geoid(station_id="s2", geoid=s2_geoid, chargers={mock_dcfc_charger_id(): 1})
+        s2 = mock_station_from_geoid(station_id="s2",
+                                     geoid=s2_geoid,
+                                     chargers={mock_dcfc_charger_id(): 1})
 
         self.assertIsNotNone(s1, "test invariant failed (unable to checkout charger)")
 
-        sim = mock_sim(h3_location_res=15, h3_search_res=5, vehicles=(veh_low_battery,), stations=(s1, s2,))
+        sim = mock_sim(h3_location_res=15,
+                       h3_search_res=5,
+                       vehicles=(veh_low_battery, ),
+                       stations=(
+                           s1,
+                           s2,
+                       ))
         env = mock_env()
 
-        charging_fleet_manager, instructions = charging_fleet_manager.generate_instructions(sim, env)
+        charging_fleet_manager, instructions = charging_fleet_manager.generate_instructions(
+            sim, env)
 
-        self.assertGreaterEqual(len(instructions), 1, "Should have generated at least one instruction")
-        self.assertIsInstance(instructions[0],
-                              DispatchStationInstruction,
+        self.assertGreaterEqual(len(instructions), 1,
+                                "Should have generated at least one instruction")
+        self.assertIsInstance(instructions[0], DispatchStationInstruction,
                               "Should have instructed vehicle to dispatch to station")
-        self.assertEqual(instructions[0].station_id, s2.id, "should have instructed vehicle to go to s2")
+        self.assertEqual(instructions[0].station_id, s2.id,
+                         "should have instructed vehicle to go to s2")

--- a/tests/test_local_simulation_runner.py
+++ b/tests/test_local_simulation_runner.py
@@ -7,19 +7,14 @@ from hive.resources.mock_lobster import *
 
 
 class TestLocalSimulationRunner(TestCase):
-
     def test_run(self):
         config = mock_config(end_time=600, timestep_duration_seconds=60)
         env = mock_env(config)
-        req = mock_request(
-            request_id='1',
-            departure_time=SimTime.build(0),
-            passengers=2
-        )
+        req = mock_request(request_id='1', departure_time=SimTime.build(0), passengers=2)
         initial_sim = mock_sim(
             vehicles=(mock_vehicle(), ),
-            stations=(mock_station(),),
-            bases=(mock_base(stall_count=5),),
+            stations=(mock_station(), ),
+            bases=(mock_base(stall_count=5), ),
         )
 
         _, initial_sim = simulation_state_ops.add_request(initial_sim, req)
@@ -37,7 +32,9 @@ class TestLocalSimulationRunner(TestCase):
 
         self.assertEqual(vehicle.geoid, req.destination, "Vehicle should be at request destination")
 
-        self.assertAlmostEqual(0.56, result.s.vehicles[DefaultIds.mock_vehicle_id()].distance_traveled_km, places=1)
+        self.assertAlmostEqual(0.56,
+                               result.s.vehicles[DefaultIds.mock_vehicle_id()].distance_traveled_km,
+                               places=1)
 
     def test_step(self):
         config = mock_config()
@@ -59,4 +56,5 @@ class TestLocalSimulationRunner(TestCase):
 
         stepped = LocalSimulationRunner.step(runner_payload)
 
-        self.assertEqual(stepped, None, "we should not be able to step a simulation that has exceeded end_time")
+        self.assertEqual(stepped, None,
+                         "we should not be able to step a simulation that has exceeded end_time")

--- a/tests/test_osm_roadnetwork.py
+++ b/tests/test_osm_roadnetwork.py
@@ -31,7 +31,12 @@ class TestOSMRoadNetwork(TestCase):
         destination_position = network.position_from_geoid(destination)
         route = network.route(origin_position, destination_position)
 
-        self.assertEqual(origin_position.link_id, route[0].link_id, "origin link id should be first route link id")
-        self.assertEqual(destination_position.link_id, route[-1].link_id, "destination link id should be the last route link id")
-        self.assertEqual(origin_position.geoid, route[0].start, "route should start at origin GeoId (stationary road network location)")
-        self.assertEqual(destination_position.geoid, route[-1].end, "route should end at destination GeoId (stationary road network location)")
+        self.assertEqual(origin_position.link_id, route[0].link_id,
+                         "origin link id should be first route link id")
+        self.assertEqual(destination_position.link_id, route[-1].link_id,
+                         "destination link id should be the last route link id")
+        self.assertEqual(origin_position.geoid, route[0].start,
+                         "route should start at origin GeoId (stationary road network location)")
+        self.assertEqual(
+            destination_position.geoid, route[-1].end,
+            "route should end at destination GeoId (stationary road network location)")

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -13,16 +13,14 @@ class TestRequest(TestCase):
     departure_time = 28800
     passengers = 2
 
-    request = mock_request(
-        request_id=request_id,
-        o_lat=0,
-        o_lon=0,
-        d_lat=3,
-        d_lon=4,
-        h3_res=11,
-        departure_time=28800,
-        passengers=2
-    )
+    request = mock_request(request_id=request_id,
+                           o_lat=0,
+                           o_lon=0,
+                           d_lat=3,
+                           d_lon=4,
+                           h3_res=11,
+                           departure_time=28800,
+                           passengers=2)
 
     def test_request_constructor(self):
         """
@@ -43,8 +41,10 @@ class TestRequest(TestCase):
         network = mock_network()
         _, req = Request.from_row(row, env, network)
         self.assertEqual(req.id, "1_a")
-        self.assertEqual(req.origin, h3.geo_to_h3(31.2074449, 121.4294263, env.config.sim.sim_h3_resolution))
-        self.assertEqual(req.destination, h3.geo_to_h3(31.2109091, 121.4532226, env.config.sim.sim_h3_resolution))
+        self.assertEqual(req.origin,
+                         h3.geo_to_h3(31.2074449, 121.4294263, env.config.sim.sim_h3_resolution))
+        self.assertEqual(req.destination,
+                         h3.geo_to_h3(31.2109091, 121.4532226, env.config.sim.sim_h3_resolution))
         self.assertEqual(req.departure_time, 61200)
         self.assertEqual(len(req.passengers), 4)
         self.assertTrue(req.membership.public)
@@ -58,8 +58,10 @@ class TestRequest(TestCase):
         network = mock_network()
         _, req = Request.from_row(row, env, network)
         self.assertEqual(req.id, "1_a")
-        self.assertEqual(req.origin, h3.geo_to_h3(31.2074449, 121.4294263, env.config.sim.sim_h3_resolution))
-        self.assertEqual(req.destination, h3.geo_to_h3(31.2109091, 121.4532226, env.config.sim.sim_h3_resolution))
+        self.assertEqual(req.origin,
+                         h3.geo_to_h3(31.2074449, 121.4294263, env.config.sim.sim_h3_resolution))
+        self.assertEqual(req.destination,
+                         h3.geo_to_h3(31.2109091, 121.4532226, env.config.sim.sim_h3_resolution))
         self.assertEqual(req.departure_time, 61200)
         self.assertEqual(len(req.passengers), 4)
         self.assertTrue('uber' in req.membership.memberships)

--- a/tests/test_routetraversal.py
+++ b/tests/test_routetraversal.py
@@ -12,10 +12,7 @@ class TestRouteTraversal(TestCase):
         """
         links = mock_route()
 
-        _, result = traverse(
-            route_estimate=links,
-            duration_seconds=hours_to_seconds(4)
-        )
+        _, result = traverse(route_estimate=links, duration_seconds=hours_to_seconds(4))
         self.assertGreater(result.remaining_time_seconds, 0, "should have more time left")
         self.assertEqual(len(result.remaining_route), 0, "should have no more route")
         self.assertEqual(len(result.experienced_route), 3, "should have hit all 3 links")
@@ -46,9 +43,12 @@ class TestRouteTraversal(TestCase):
         traversed = result.traversed
         remaining = result.remaining
 
-        self.assertEqual(test_link.start, traversed.start, "Original link and traversed link should share start")
-        self.assertEqual(test_link.end, remaining.end, "Original link and remaining link should share end")
-        self.assertEqual(traversed.end, remaining.start, "Traversed end should match remaining start")
+        self.assertEqual(test_link.start, traversed.start,
+                         "Original link and traversed link should share start")
+        self.assertEqual(test_link.end, remaining.end,
+                         "Original link and remaining link should share end")
+        self.assertEqual(traversed.end, remaining.start,
+                         "Traversed end should match remaining start")
 
     def test_traverse_up_to_no_split(self):
         links = mock_route()
@@ -62,6 +62,8 @@ class TestRouteTraversal(TestCase):
         traversed = result.traversed
         remaining = result.remaining
 
-        self.assertEqual(test_link.start, traversed.start, "Original link and traversed link should share start")
-        self.assertEqual(test_link.end, traversed.end, "Original link and traversed link should share end")
+        self.assertEqual(test_link.start, traversed.start,
+                         "Original link and traversed link should share start")
+        self.assertEqual(test_link.end, traversed.end,
+                         "Original link and traversed link should share end")
         self.assertIsNone(remaining, "There should be no remaining route")

--- a/tests/test_run_cosim.py
+++ b/tests/test_run_cosim.py
@@ -6,11 +6,10 @@ from hive.app import hive_cosim
 
 
 class TestRunCosim(TestCase):
-
     def test_load_and_run_denver(self):
         # read scenario
-        scenario_file = Path(resource_filename('hive.resources.scenarios.denver_downtown',
-                                               'denver_demo.yaml'))
+        scenario_file = Path(
+            resource_filename('hive.resources.scenarios.denver_downtown', 'denver_demo.yaml'))
 
         rp0 = hive_cosim.load_scenario(scenario_file)
         time_steps = 5
@@ -22,7 +21,8 @@ class TestRunCosim(TestCase):
 
         # crank 5 more time steps
         crank_result_2 = hive_cosim.crank(crank_result_1.runner_payload, time_steps=time_steps)
-        expected_time_2 = crank_result_1.runner_payload.s.sim_time + (time_steps * rp0.s.sim_timestep_duration_seconds)
+        expected_time_2 = crank_result_1.runner_payload.s.sim_time + (
+            time_steps * rp0.s.sim_timestep_duration_seconds)
         self.assertEqual(crank_result_2.sim_time, expected_time_2, 'expected sim time is incorrect')
 
         hive_cosim.close(crank_result_2.runner_payload)

--- a/tests/test_sample_functions.py
+++ b/tests/test_sample_functions.py
@@ -10,7 +10,6 @@ from hive.resources.mock_lobster import *
 
 
 class TestSampleVehicles(TestCase):
-
     def test_sample_n_requests_default(self):
         n = 100
         sim = mock_sim(road_network=mock_osm_network())
@@ -21,7 +20,8 @@ class TestSampleVehicles(TestCase):
         self.assertEquals(len(sample_requests), n, f"should have sampled {n} requests")
 
         for r in sample_requests:
-            self.assertNotEqual(r.origin, r.destination, f"request should not have equal origin and destination")
+            self.assertNotEqual(r.origin, r.destination,
+                                f"request should not have equal origin and destination")
 
     def test_sample_n_vehicles_default(self):
         """
@@ -29,20 +29,18 @@ class TestSampleVehicles(TestCase):
         """
         n = 10
         base = mock_base()
-        bases = (base,)
+        bases = (base, )
         sim = mock_sim(bases=bases, road_network=mock_osm_network())
         env = mock_env()
         mechatronics_id = DefaultIds.mock_mechatronics_bev_id()
         loc_fn = build_default_location_sampling_fn()
         soc_fn = build_default_soc_sampling_fn()
 
-        result: Result = sample_vehicles(
-            count=n,
-            sim=sim,
-            env=env,
-            location_sampling_function=loc_fn,
-            soc_sampling_function=soc_fn
-        )
+        result: Result = sample_vehicles(count=n,
+                                         sim=sim,
+                                         env=env,
+                                         location_sampling_function=loc_fn,
+                                         soc_sampling_function=soc_fn)
 
         def check_vehicle(v: Vehicle):
             self.assertEquals(v.mechatronics_id, DefaultIds.mock_mechatronics_bev_id())
@@ -64,7 +62,7 @@ class TestSampleVehicles(TestCase):
         fail_at_vehicle_n = 4
         failure_msg = f"fails after {fail_at_vehicle_n} attempts"
         base = mock_base()
-        bases = (base,)
+        bases = (base, )
         sim = mock_sim(bases=bases, road_network=mock_osm_network())
         env = mock_env()
 
@@ -79,13 +77,11 @@ class TestSampleVehicles(TestCase):
 
         soc_fn = build_default_soc_sampling_fn()
 
-        result: Result = sample_vehicles(
-            count=n,
-            sim=sim,
-            env=env,
-            location_sampling_function=wonky_loc_fn,
-            soc_sampling_function=soc_fn
-        )
+        result: Result = sample_vehicles(count=n,
+                                         sim=sim,
+                                         env=env,
+                                         location_sampling_function=wonky_loc_fn,
+                                         soc_sampling_function=soc_fn)
 
         with self.assertRaises(UnwrapFailedError):
             result.unwrap()

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -5,7 +5,6 @@ from hive.resources.mock_lobster import *
 
 
 class TestSchedules(TestCase):
-
     def test_time_range_schedule(self):
         schedules_input = """schedule_id,start_time,end_time
                              first,"09:00:00","17:00:00"
@@ -28,17 +27,20 @@ class TestSchedules(TestCase):
         self.assertFalse(first_shift_schedule_fn(mock_sim(sim_time=eight_am), unused))
         self.assertTrue(first_shift_schedule_fn(mock_sim(sim_time=ten_am), unused))
         self.assertFalse(first_shift_schedule_fn(mock_sim(sim_time=midnight), unused))
-        self.assertFalse(first_shift_schedule_fn(mock_sim(sim_time=eleven_fifty_nine_fifty_nine), unused))
+        self.assertFalse(
+            first_shift_schedule_fn(mock_sim(sim_time=eleven_fifty_nine_fifty_nine), unused))
         # self.assertFalse(first_shift_schedule_fn(mock_sim(sim_time=not_a_time), unused))
 
         self.assertFalse(second_shift_schedule_fn(mock_sim(sim_time=eight_am), unused))
         self.assertFalse(second_shift_schedule_fn(mock_sim(sim_time=ten_am), unused))
         self.assertTrue(second_shift_schedule_fn(mock_sim(sim_time=midnight), unused))
-        self.assertTrue(second_shift_schedule_fn(mock_sim(sim_time=eleven_fifty_nine_fifty_nine), unused))
+        self.assertTrue(
+            second_shift_schedule_fn(mock_sim(sim_time=eleven_fifty_nine_fifty_nine), unused))
         # self.assertFalse(second_shift_schedule_fn(mock_sim(sim_time=not_a_time), unused))
 
         self.assertFalse(third_shift_schedule_fn(mock_sim(sim_time=eight_am), unused))
         self.assertFalse(third_shift_schedule_fn(mock_sim(sim_time=ten_am), unused))
         self.assertTrue(third_shift_schedule_fn(mock_sim(sim_time=midnight), unused))
-        self.assertFalse(third_shift_schedule_fn(mock_sim(sim_time=eleven_fifty_nine_fifty_nine), unused))
+        self.assertFalse(
+            third_shift_schedule_fn(mock_sim(sim_time=eleven_fifty_nine_fifty_nine), unused))
         # self.assertFalse(third_shift_schedule_fn(mock_sim(sim_time=not_a_time), unused))

--- a/tests/test_simulation_state_ops.py
+++ b/tests/test_simulation_state_ops.py
@@ -4,14 +4,15 @@ from hive.resources.mock_lobster import *
 
 
 class TestSimulationStateOps(TestCase):
-
     def test_add_request(self):
         req = mock_request()
         sim = mock_sim()
         error, sim_with_req = simulation_state_ops.add_request(sim, req)
         self.assertIsNone(error, "should be no error")
-        self.assertEqual(len(sim.requests), 0, "the original sim object should not have been mutated")
-        self.assertEqual(sim_with_req.requests[req.id], req, "request contents should be idempotent")
+        self.assertEqual(len(sim.requests), 0,
+                         "the original sim object should not have been mutated")
+        self.assertEqual(sim_with_req.requests[req.id], req,
+                         "request contents should be idempotent")
 
         at_loc = sim_with_req.r_locations[req.origin]
 
@@ -27,15 +28,17 @@ class TestSimulationStateOps(TestCase):
         e2, sim_after_remove = simulation_state_ops.remove_request(sim_with_req, req.id)
 
         self.assertIsNone(e2, "should be no error")
-        self.assertEqual(len(sim_with_req.requests), 1, "the sim with req added should not have been mutated")
+        self.assertEqual(len(sim_with_req.requests), 1,
+                         "the sim with req added should not have been mutated")
         self.assertEqual(len(sim_after_remove.requests), 0, "the request should have been removed")
 
-        self.assertNotIn(req.origin, sim_after_remove.r_locations, "there should be no key for this geoid")
+        self.assertNotIn(req.origin, sim_after_remove.r_locations,
+                         "there should be no key for this geoid")
 
     def test_modify_request(self):
         req = mock_request()
         veh = mock_vehicle()
-        sim = mock_sim(vehicles=(veh,))
+        sim = mock_sim(vehicles=(veh, ))
         e1, sim_with_req = simulation_state_ops.add_request(sim, req)
         self.assertIsNone(e1, "test invariant did not hold")
         current_time = sim.sim_time
@@ -45,12 +48,13 @@ class TestSimulationStateOps(TestCase):
 
         updated_req = sim_after_modify.requests.get(req.id)
         self.assertIsNone(e2, "should be no error")
-        self.assertEqual(updated_req.dispatched_vehicle, veh.id, "the request in the sim should have been modified")
+        self.assertEqual(updated_req.dispatched_vehicle, veh.id,
+                         "the request in the sim should have been modified")
 
     def test_modify_request_no_previous_request(self):
         req = mock_request()
         veh = mock_vehicle()
-        sim = mock_sim(vehicles=(veh,))
+        sim = mock_sim(vehicles=(veh, ))
         current_time = sim.sim_time
 
         updated_req_to_set = req.assign_dispatched_vehicle(veh.id, current_time)
@@ -71,11 +75,9 @@ class TestSimulationStateOps(TestCase):
         error, sim_remove_req1 = simulation_state_ops.remove_request(sim_with_reqs, req1.id)
 
         self.assertIsNone(error, "should be no error")
-        self.assertIn(req2.origin,
-                      sim_remove_req1.r_locations,
+        self.assertIn(req2.origin, sim_remove_req1.r_locations,
                       "geoid related to both reqs should still exist")
-        self.assertIn(req2.id,
-                      sim_remove_req1.r_locations[req2.origin],
+        self.assertIn(req2.id, sim_remove_req1.r_locations[req2.origin],
                       "req2.id should still be found in r_locations")
 
     def test_add_vehicle(self):
@@ -84,8 +86,10 @@ class TestSimulationStateOps(TestCase):
         error, sim_with_veh = simulation_state_ops.add_vehicle(sim, veh)
 
         self.assertIsNone(error, "should be no error")
-        self.assertEqual(len(sim.vehicles), 0, "the original sim object should not have been mutated")
-        self.assertEqual(sim_with_veh.vehicles[veh.id], veh, "the vehicle should not have been mutated")
+        self.assertEqual(len(sim.vehicles), 0,
+                         "the original sim object should not have been mutated")
+        self.assertEqual(sim_with_veh.vehicles[veh.id], veh,
+                         "the vehicle should not have been mutated")
 
         at_loc = sim_with_veh.v_locations[veh.geoid]
 
@@ -105,8 +109,7 @@ class TestSimulationStateOps(TestCase):
 
         self.assertIsNone(e2, "should not have an error")
         # confirm sim reflects changes to vehicle
-        self.assertEqual(sim_after_update.vehicles[veh.id].mechatronics_id,
-                         "test_update",
+        self.assertEqual(sim_after_update.vehicles[veh.id].mechatronics_id, "test_update",
                          "new vehicle was not updated correctly")
 
     def test_remove_vehicle(self):
@@ -118,10 +121,12 @@ class TestSimulationStateOps(TestCase):
         error, sim_after_remove = simulation_state_ops.remove_vehicle(sim_with_veh, veh.id)
 
         self.assertIsNone(error, "should have no error")
-        self.assertEqual(len(sim_with_veh.vehicles), 1, "the sim with vehicle added should not have been mutated")
+        self.assertEqual(len(sim_with_veh.vehicles), 1,
+                         "the sim with vehicle added should not have been mutated")
         self.assertEqual(len(sim_after_remove.vehicles), 0, "the vehicle should have been removed")
 
-        self.assertNotIn(veh.geoid, sim_after_remove.v_locations, "there should be no key for this geoid")
+        self.assertNotIn(veh.geoid, sim_after_remove.v_locations,
+                         "there should be no key for this geoid")
 
     def test_pop_vehicle(self):
         veh = mock_vehicle()
@@ -131,7 +136,8 @@ class TestSimulationStateOps(TestCase):
         e2, (sim_after_pop, veh_after_pop) = simulation_state_ops.pop_vehicle(sim_with_veh, veh.id)
 
         self.assertIsNone(e2, "should have no error")
-        self.assertEqual(len(sim_with_veh.vehicles), 1, "the sim with vehicle added should not have been mutated")
+        self.assertEqual(len(sim_with_veh.vehicles), 1,
+                         "the sim with vehicle added should not have been mutated")
         self.assertEqual(len(sim_after_pop.vehicles), 0, "the vehicle should have been removed")
         self.assertEqual(veh, veh_after_pop, "should be the same vehicle that gets popped")
 
@@ -141,8 +147,10 @@ class TestSimulationStateOps(TestCase):
         error, sim_after_station = simulation_state_ops.add_station(sim, station)
 
         self.assertIsNone(error, "should have no error")
-        self.assertEqual(len(sim_after_station.stations), 1, "the sim should have one station added")
-        self.assertEqual(sim_after_station.stations[station.id], station, "the station should not have been mutated")
+        self.assertEqual(len(sim_after_station.stations), 1,
+                         "the sim should have one station added")
+        self.assertEqual(sim_after_station.stations[station.id], station,
+                         "the station should not have been mutated")
 
         at_loc = sim_after_station.s_locations[station.geoid]
 
@@ -155,18 +163,20 @@ class TestSimulationStateOps(TestCase):
 
         self.assertIsNone(error, "should have no error")
         self.assertNotIn(station.id, sim_after_remove.stations, "station should be removed")
-        self.assertNotIn(station.geoid, sim_after_remove.s_locations, "nothing should be left at geoid")
+        self.assertNotIn(station.geoid, sim_after_remove.s_locations,
+                         "nothing should be left at geoid")
 
     def test_update_station(self):
         station = mock_station()
-        sim = mock_sim(stations=(station,))
+        sim = mock_sim(stations=(station, ))
         new_position = EntityPosition("test", station.geoid)
         updated_station = station._replace(position=new_position)
         error, sim_after_station = simulation_state_ops.modify_station(sim, updated_station)
         self.assertIsNone(error, "should have no error")
 
         updated_station_in_sim = sim_after_station.stations[station.id]
-        self.assertEqual(updated_station_in_sim.position, updated_station.position, "station should have been updated")
+        self.assertEqual(updated_station_in_sim.position, updated_station.position,
+                         "station should have been updated")
 
         at_loc = sim_after_station.s_locations[station.geoid]
         self.assertIn(station.id, at_loc, "the station's id should be found at it's geoid")
@@ -178,7 +188,8 @@ class TestSimulationStateOps(TestCase):
 
         self.assertIsNone(error, "should have no error")
         self.assertEqual(len(sim_after_base.bases), 1, "the sim should have one base added")
-        self.assertEqual(sim_after_base.bases[base.id], base, "the base should not have been mutated")
+        self.assertEqual(sim_after_base.bases[base.id], base,
+                         "the base should not have been mutated")
 
         at_loc = sim_after_base.b_locations[base.geoid]
 
@@ -186,9 +197,10 @@ class TestSimulationStateOps(TestCase):
 
     def test_remove_base(self):
         base = mock_base()
-        sim = mock_sim(bases=(base,))
+        sim = mock_sim(bases=(base, ))
         error, sim_after_remove = simulation_state_ops.remove_base(sim, base.id)
 
         self.assertIsNone(error, "should have no error")
         self.assertNotIn(base.id, sim_after_remove.bases, "base should be removed")
-        self.assertNotIn(base.geoid, sim_after_remove.b_locations, "nothing should be left at geoid")
+        self.assertNotIn(base.geoid, sim_after_remove.b_locations,
+                         "nothing should be left at geoid")

--- a/tests/test_simulationstate.py
+++ b/tests/test_simulationstate.py
@@ -8,7 +8,6 @@ from hive.resources.mock_lobster import *
 
 
 class TestSimulationState(TestCase):
-
     def test_at_vehicle_geoid(self):
         somewhere = h3.geo_to_h3(39.7539, -104.974, 15)
         somewhere_else = h3.geo_to_h3(39.755, -104.976, 15)
@@ -16,11 +15,7 @@ class TestSimulationState(TestCase):
         req = mock_request_from_geoids(origin=somewhere)
         sta = mock_station_from_geoid(geoid=somewhere)
         b = mock_base_from_geoid(geoid=somewhere_else)
-        sim = mock_sim(
-            vehicles=(veh,),
-            stations=(sta,),
-            bases=(b,)
-        )
+        sim = mock_sim(vehicles=(veh, ), stations=(sta, ), bases=(b, ))
         error, sim_with_request = simulation_state_ops.add_request(sim, req)
         self.assertIsNone(error, "test invariant failed")
 
@@ -34,7 +29,7 @@ class TestSimulationState(TestCase):
         somewhere = h3.geo_to_h3(39.7539, -104.974, 15)
         veh = mock_vehicle_from_geoid(geoid=somewhere)
         req = mock_request_from_geoids(origin=somewhere)
-        sim = mock_sim(vehicles=(veh,))
+        sim = mock_sim(vehicles=(veh, ))
         error, sim_with_veh = simulation_state_ops.add_request(sim, req)
         self.assertIsNone(error, "test invariant failed")
         result = sim_with_veh.vehicle_at_request(veh.id, req.id)
@@ -45,7 +40,7 @@ class TestSimulationState(TestCase):
         somewhere_else = h3.geo_to_h3(39.755, -104.976, 15)
         veh = mock_vehicle_from_geoid(geoid=somewhere)
         req = mock_request_from_geoids(origin=somewhere_else)
-        sim = mock_sim(vehicles=(veh,))
+        sim = mock_sim(vehicles=(veh, ))
         error, sim_with_veh = simulation_state_ops.add_request(sim, req)
         result = sim_with_veh.vehicle_at_request(veh.id, req.id)
         self.assertFalse(result, "the vehicle should not be at the request")
@@ -54,7 +49,7 @@ class TestSimulationState(TestCase):
         somewhere = h3.geo_to_h3(39.7539, -104.974, 15)
         veh = mock_vehicle_from_geoid(geoid=somewhere)
         sta = mock_station_from_geoid(geoid=somewhere)
-        sim = mock_sim(vehicles=(veh,), stations=(sta,))
+        sim = mock_sim(vehicles=(veh, ), stations=(sta, ))
         result = sim.vehicle_at_station(veh.id, sta.id)
         self.assertTrue(result, "the vehicle should be at the station")
 
@@ -63,7 +58,7 @@ class TestSimulationState(TestCase):
         somewhere_else = h3.geo_to_h3(39.755, -104.976, 15)
         veh = mock_vehicle_from_geoid(geoid=somewhere)
         sta = mock_station_from_geoid(geoid=somewhere_else)
-        sim = mock_sim(vehicles=(veh,), stations=(sta,))
+        sim = mock_sim(vehicles=(veh, ), stations=(sta, ))
         result = sim.vehicle_at_station(veh.id, sta.id)
         self.assertFalse(result, "the vehicle should not be at the station")
 
@@ -71,7 +66,7 @@ class TestSimulationState(TestCase):
         somewhere = h3.geo_to_h3(39.7539, -104.974, 15)
         veh = mock_vehicle_from_geoid(geoid=somewhere)
         base = mock_base_from_geoid(geoid=somewhere)
-        sim = mock_sim(vehicles=(veh,), bases=(base,))
+        sim = mock_sim(vehicles=(veh, ), bases=(base, ))
         result = sim.vehicle_at_base(veh.id, base.id)
         self.assertTrue(result, "the vehicle should be at the base")
 
@@ -80,7 +75,7 @@ class TestSimulationState(TestCase):
         somewhere_else = h3.geo_to_h3(39.755, -104.976, 15)
         veh = mock_vehicle_from_geoid(geoid=somewhere)
         base = mock_base_from_geoid(geoid=somewhere_else)
-        sim = mock_sim(vehicles=(veh,), bases=(base,))
+        sim = mock_sim(vehicles=(veh, ), bases=(base, ))
         result = sim.vehicle_at_base(veh.id, base.id)
         self.assertFalse(result, "the vehicle should not be at the base")
 
@@ -88,14 +83,15 @@ class TestSimulationState(TestCase):
         somewhere = h3.geo_to_h3(39.7539, -104.974, 15)
         bas = mock_base_from_geoid(geoid=somewhere)
         veh = mock_vehicle_from_geoid(geoid=somewhere)
-        sim = mock_sim(vehicles=(veh,), bases=(bas,))
+        sim = mock_sim(vehicles=(veh, ), bases=(bas, ))
         env = mock_env()
 
         instruction = ReserveBaseInstruction(vehicle_id=veh.id, base_id=bas.id)
         error, instruction_result = instruction.apply_instruction(sim, env)
         if error:
             self.fail(error.args)
-        sim_error, sim_updated = entity_state_ops.transition_previous_to_next(sim, env, instruction_result.prev_state, instruction_result.next_state)
+        sim_error, sim_updated = entity_state_ops.transition_previous_to_next(
+            sim, env, instruction_result.prev_state, instruction_result.next_state)
 
         updated_veh = sim_updated.vehicles[veh.id]
         self.assertIsInstance(updated_veh.vehicle_state, ReserveBase, "should be reserving at base")
@@ -105,14 +101,15 @@ class TestSimulationState(TestCase):
         somewhere_else = h3.geo_to_h3(39.755, -104.976, 15)
         bas = mock_base_from_geoid(geoid=somewhere)
         veh = mock_vehicle_from_geoid(geoid=somewhere_else)
-        sim = mock_sim(vehicles=(veh,), bases=(bas,))
+        sim = mock_sim(vehicles=(veh, ), bases=(bas, ))
         env = mock_env()
 
         instruction = ReserveBaseInstruction(vehicle_id=veh.id, base_id=bas.id)
         error, instruction_result = instruction.apply_instruction(sim, env)
         if error:
             self.fail(error.args)
-        sim_error, sim_updated = entity_state_ops.transition_previous_to_next(sim, env, instruction_result.prev_state, instruction_result.next_state)
+        sim_error, sim_updated = entity_state_ops.transition_previous_to_next(
+            sim, env, instruction_result.prev_state, instruction_result.next_state)
 
         self.assertIsNone(sim_updated)
 
@@ -120,18 +117,17 @@ class TestSimulationState(TestCase):
         somewhere = h3.geo_to_h3(39.7539, -104.974, 15)
         sta = mock_station_from_geoid(geoid=somewhere)
         veh = mock_vehicle_from_geoid(geoid=somewhere)
-        sim = mock_sim(vehicles=(veh,), stations=(sta,))
+        sim = mock_sim(vehicles=(veh, ), stations=(sta, ))
         env = mock_env()
 
-        instruction = ChargeStationInstruction(
-            vehicle_id=veh.id,
-            station_id=sta.id,
-            charger_id=mock_dcfc_charger_id()
-        )
+        instruction = ChargeStationInstruction(vehicle_id=veh.id,
+                                               station_id=sta.id,
+                                               charger_id=mock_dcfc_charger_id())
         error, instruction_result = instruction.apply_instruction(sim, env)
         if error:
             self.fail(error.args)
-        sim_error, sim_updated = entity_state_ops.transition_previous_to_next(sim, env, instruction_result.prev_state, instruction_result.next_state)
+        sim_error, sim_updated = entity_state_ops.transition_previous_to_next(
+            sim, env, instruction_result.prev_state, instruction_result.next_state)
 
         self.assertIsNotNone(sim_updated)
 
@@ -143,72 +139,63 @@ class TestSimulationState(TestCase):
         somewhere_else = h3.geo_to_h3(39.755, -104.976, 15)
         sta = mock_station_from_geoid(geoid=somewhere)
         veh = mock_vehicle_from_geoid(geoid=somewhere_else)
-        sim = mock_sim(vehicles=(veh,), stations=(sta,))
+        sim = mock_sim(vehicles=(veh, ), stations=(sta, ))
         env = mock_env()
 
-        instruction = ChargeStationInstruction(
-            vehicle_id=veh.id,
-            station_id=sta.id,
-            charger_id=mock_dcfc_charger_id()
-        )
+        instruction = ChargeStationInstruction(vehicle_id=veh.id,
+                                               station_id=sta.id,
+                                               charger_id=mock_dcfc_charger_id())
 
         error, instruction_result = instruction.apply_instruction(sim, env)
         if error:
             self.fail(error.args)
-        sim_error, sim_updated = entity_state_ops.transition_previous_to_next(sim, env, instruction_result.prev_state, instruction_result.next_state)
+        sim_error, sim_updated = entity_state_ops.transition_previous_to_next(
+            sim, env, instruction_result.prev_state, instruction_result.next_state)
 
         self.assertIsNone(sim_updated)
-
-
 
     def test_step_charging_vehicle(self):
         somewhere = h3.geo_to_h3(39.7539, -104.974, 15)
         sta = mock_station_from_geoid(geoid=somewhere)
         veh = mock_vehicle_from_geoid(geoid=somewhere, soc=0.5)
-        sim = mock_sim(vehicles=(veh,), stations=(sta,))
+        sim = mock_sim(vehicles=(veh, ), stations=(sta, ))
         env = mock_env()
 
-        instruction = ChargeStationInstruction(
-            vehicle_id=veh.id,
-            station_id=sta.id,
-            charger_id=mock_dcfc_charger_id()
-        )
+        instruction = ChargeStationInstruction(vehicle_id=veh.id,
+                                               station_id=sta.id,
+                                               charger_id=mock_dcfc_charger_id())
 
         error, instruction_result = instruction.apply_instruction(sim, env)
         if error:
             self.fail(error.args)
-        sim_error, sim_updated = entity_state_ops.transition_previous_to_next(sim, env, instruction_result.prev_state, instruction_result.next_state)
+        sim_error, sim_updated = entity_state_ops.transition_previous_to_next(
+            sim, env, instruction_result.prev_state, instruction_result.next_state)
         sim_charging_veh = perform_vehicle_state_updates(sim_updated, env)
 
         charged_veh = sim_charging_veh.vehicles[veh.id]
 
-        self.assertGreater(charged_veh.energy[EnergyType.ELECTRIC],
-                           veh.energy[EnergyType.ELECTRIC],
+        self.assertGreater(charged_veh.energy[EnergyType.ELECTRIC], veh.energy[EnergyType.ELECTRIC],
                            "Vehicle should have gained energy")
 
     def test_step_idle_vehicle(self):
         veh = mock_vehicle_from_geoid()
-        sim = mock_sim(vehicles=(veh,))
+        sim = mock_sim(vehicles=(veh, ))
         env = mock_env()
 
         sim_idle_veh = perform_vehicle_state_updates(sim, env)
 
         idle_veh = sim_idle_veh.vehicles[veh.id]
 
-        self.assertLess(idle_veh.energy[EnergyType.ELECTRIC],
-                        veh.energy[EnergyType.ELECTRIC],
+        self.assertLess(idle_veh.energy[EnergyType.ELECTRIC], veh.energy[EnergyType.ELECTRIC],
                         "Idle vehicle should have consumed energy")
-
 
     def test_terminal_state_starting_trip(self):
         # approx 8.5 km distance.
         somewhere = h3.geo_to_h3(39.7539, -104.974, 15)
         somewhere_else = h3.geo_to_h3(39.755, -104.976, 15)
         veh = mock_vehicle_from_geoid(geoid=somewhere)
-        req = mock_request_from_geoids(origin=somewhere_else,
-                                       destination=somewhere,
-                                       passengers=2)
-        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(veh,)), req)
+        req = mock_request_from_geoids(origin=somewhere_else, destination=somewhere, passengers=2)
+        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(veh, )), req)
         self.assertIsNone(e1, "test invariant failed")
 
         instruction = DispatchTripInstruction(vehicle_id=veh.id, request_id=req.id)
@@ -216,14 +203,17 @@ class TestSimulationState(TestCase):
         e2, instruction_result = instruction.apply_instruction(sim, env)
         if e2:
             self.fail(e2.args)
-        sim_error, sim_updated = entity_state_ops.transition_previous_to_next(sim, env, instruction_result.prev_state, instruction_result.next_state)
+        sim_error, sim_updated = entity_state_ops.transition_previous_to_next(
+            sim, env, instruction_result.prev_state, instruction_result.next_state)
         self.assertIsNotNone(sim, "Vehicle should have set instruction.")
 
         # should take about 17 seconds to arrive at trip origin, and
         # 1 more state step of any size to transition state
 
-        sim_at_req = perform_vehicle_state_updates(sim_updated._replace(sim_timestep_duration_seconds=20), env)
-        sim_with_req = perform_vehicle_state_updates(sim_at_req._replace(sim_timestep_duration_seconds=1), env)
+        sim_at_req = perform_vehicle_state_updates(
+            sim_updated._replace(sim_timestep_duration_seconds=20), env)
+        sim_with_req = perform_vehicle_state_updates(
+            sim_at_req._replace(sim_timestep_duration_seconds=1), env)
 
         tripping_veh = sim_with_req.vehicles[veh.id]
 
@@ -231,14 +221,19 @@ class TestSimulationState(TestCase):
 
         # should take about 17 seconds to arrive at trip destination
         # we take 1 small time step crank afterward to find we are in our terminal condition -> Idle
-        sim_dropoff = perform_vehicle_state_updates(sim_with_req._replace(sim_timestep_duration_seconds=20), env)
-        sim_idle = perform_vehicle_state_updates(sim_dropoff._replace(sim_timestep_duration_seconds=1), env)
+        sim_dropoff = perform_vehicle_state_updates(
+            sim_with_req._replace(sim_timestep_duration_seconds=20), env)
+        sim_idle = perform_vehicle_state_updates(
+            sim_dropoff._replace(sim_timestep_duration_seconds=1), env)
 
         idle_veh = sim_idle.vehicles[veh.id]
 
-        self.assertIsInstance(idle_veh.vehicle_state, Idle, "Vehicle should have transitioned to idle.")
-        self.assertEqual(idle_veh.geoid, req.destination, "Vehicle should be at request destination.")
-        self.assertEqual(req.id not in sim_idle.requests, True, "Request should have been removed from simulation.")
+        self.assertIsInstance(idle_veh.vehicle_state, Idle,
+                              "Vehicle should have transitioned to idle.")
+        self.assertEqual(idle_veh.geoid, req.destination,
+                         "Vehicle should be at request destination.")
+        self.assertEqual(req.id not in sim_idle.requests, True,
+                         "Request should have been removed from simulation.")
 
     def test_terminal_state_dispatch_station(self):
         # approx 8.5 km distance.
@@ -246,24 +241,28 @@ class TestSimulationState(TestCase):
         somewhere_else = h3.geo_to_h3(39.755, -104.976, 15)
         veh = mock_vehicle_from_geoid(geoid=somewhere, soc=0.5)
         sta = mock_station_from_geoid(geoid=somewhere_else)
-        sim = mock_sim(vehicles=(veh,), stations=(sta,))
+        sim = mock_sim(vehicles=(veh, ), stations=(sta, ))
         env = mock_env()
 
-        instruction = DispatchStationInstruction(vehicle_id=veh.id, station_id=sta.id, charger_id=mock_dcfc_charger_id())
+        instruction = DispatchStationInstruction(vehicle_id=veh.id,
+                                                 station_id=sta.id,
+                                                 charger_id=mock_dcfc_charger_id())
         error, instruction_result = instruction.apply_instruction(sim, env)
         if error:
             self.fail(error.args)
-        sim_error, sim_updated = entity_state_ops.transition_previous_to_next(sim, env, instruction_result.prev_state, instruction_result.next_state)
+        sim_error, sim_updated = entity_state_ops.transition_previous_to_next(
+            sim, env, instruction_result.prev_state, instruction_result.next_state)
         self.assertIsNotNone(sim, "Vehicle should have set instruction.")
 
-        sim_at_sta = perform_vehicle_state_updates(sim_updated._replace(sim_timestep_duration_seconds=1000), env)
-        sim_in_sta = perform_vehicle_state_updates(sim_at_sta._replace(sim_timestep_duration_seconds=1), env)
+        sim_at_sta = perform_vehicle_state_updates(
+            sim_updated._replace(sim_timestep_duration_seconds=1000), env)
+        sim_in_sta = perform_vehicle_state_updates(
+            sim_at_sta._replace(sim_timestep_duration_seconds=1), env)
 
         charging_veh = sim_in_sta.vehicles[veh.id]
         station_w_veh = sim_in_sta.stations[sta.id]
 
-        self.assertIsInstance(charging_veh.vehicle_state,
-                              ChargingStation,
+        self.assertIsInstance(charging_veh.vehicle_state, ChargingStation,
                               "Vehicle should have transitioned to charging.")
         self.assertEqual(charging_veh.geoid, sta.geoid, "Vehicle should be at station.")
         self.assertLess(station_w_veh.available_chargers[mock_dcfc_charger_id()],
@@ -276,117 +275,119 @@ class TestSimulationState(TestCase):
         somewhere_else = h3.geo_to_h3(39.755, -104.976, 15)
         veh = mock_vehicle_from_geoid(geoid=somewhere)
         base = mock_base_from_geoid(base_id='b1', geoid=somewhere_else)
-        sim = mock_sim(vehicles=(veh,), bases=(base,))
+        sim = mock_sim(vehicles=(veh, ), bases=(base, ))
         env = mock_env()
 
         instruction = DispatchBaseInstruction(vehicle_id=veh.id, base_id=base.id)
         error, instruction_result = instruction.apply_instruction(sim, env)
         if error:
             self.fail(error.args)
-        sim_error, sim_updated = entity_state_ops.transition_previous_to_next(sim, env, instruction_result.prev_state, instruction_result.next_state)
+        sim_error, sim_updated = entity_state_ops.transition_previous_to_next(
+            sim, env, instruction_result.prev_state, instruction_result.next_state)
         self.assertIsNotNone(sim, "Vehicle should have set instruction.")
 
         # 1000 seconds should get us there, and 1 more sim step of any size to transition vehicle state
-        sim_at_base = perform_vehicle_state_updates(sim_updated._replace(sim_timestep_duration_seconds=1000), env)
-        sim_in_base = perform_vehicle_state_updates(sim_at_base._replace(sim_timestep_duration_seconds=1), env)
+        sim_at_base = perform_vehicle_state_updates(
+            sim_updated._replace(sim_timestep_duration_seconds=1000), env)
+        sim_in_base = perform_vehicle_state_updates(
+            sim_at_base._replace(sim_timestep_duration_seconds=1), env)
 
         veh_at_base = sim_in_base.vehicles[veh.id]
 
-        self.assertIsInstance(veh_at_base.vehicle_state,
-                              ReserveBase,
+        self.assertIsInstance(veh_at_base.vehicle_state, ReserveBase,
                               "Vehicle should have transitioned to RESERVE_BASE")
-        self.assertEqual(veh_at_base.geoid,
-                         base.geoid,
-                         "Vehicle should be located at base")
+        self.assertEqual(veh_at_base.geoid, base.geoid, "Vehicle should be located at base")
 
     def test_terminal_state_repositioning(self):
         # approx 8.5 km distance.
         somewhere = h3.geo_to_h3(39.7539, -104.974, 15)
         somewhere_else = h3.geo_to_h3(39.755, -104.976, 15)
         veh = mock_vehicle_from_geoid(geoid=somewhere)
-        sim = mock_sim(vehicles=(veh,))
+        sim = mock_sim(vehicles=(veh, ))
         env = mock_env()
         somewhere_else_link = sim.road_network.position_from_geoid(somewhere_else)
 
-        instruction = RepositionInstruction(vehicle_id=veh.id, destination=somewhere_else_link.link_id)
+        instruction = RepositionInstruction(vehicle_id=veh.id,
+                                            destination=somewhere_else_link.link_id)
         error, instruction_result = instruction.apply_instruction(sim, env)
         if error:
             self.fail(error.args)
 
         self.assertIsNotNone(sim, "Vehicle should have set instruction.")
-        sim_error, sim_updated = entity_state_ops.transition_previous_to_next(sim, env, instruction_result.prev_state, instruction_result.next_state)
+        sim_error, sim_updated = entity_state_ops.transition_previous_to_next(
+            sim, env, instruction_result.prev_state, instruction_result.next_state)
         # 1000 seconds should get us there, and 1 more sim step of any size to transition vehicle state
-        sim_at_new_pos = perform_vehicle_state_updates(sim_updated._replace(sim_timestep_duration_seconds=1000), env)
-        sim_in_new_state = perform_vehicle_state_updates(sim_at_new_pos._replace(sim_timestep_duration_seconds=1), env)
+        sim_at_new_pos = perform_vehicle_state_updates(
+            sim_updated._replace(sim_timestep_duration_seconds=1000), env)
+        sim_in_new_state = perform_vehicle_state_updates(
+            sim_at_new_pos._replace(sim_timestep_duration_seconds=1), env)
 
         veh_at_new_loc = sim_in_new_state.vehicles[veh.id]
 
-        self.assertIsInstance(veh_at_new_loc.vehicle_state,
-                              Idle,
+        self.assertIsInstance(veh_at_new_loc.vehicle_state, Idle,
                               "Vehicle should have transitioned to IDLE")
-        self.assertEqual(veh_at_new_loc.geoid,
-                         somewhere_else,
+        self.assertEqual(veh_at_new_loc.geoid, somewhere_else,
                          "Vehicle should be located at somewhere_else")
 
     def test_terminal_state_charging(self):
         sta = mock_station_from_geoid()
         veh = mock_vehicle_from_geoid(soc=0.75)
-        sim = mock_sim(vehicles=(veh,), stations=(sta,))
+        sim = mock_sim(vehicles=(veh, ), stations=(sta, ))
 
-        instruction = ChargeStationInstruction(
-            vehicle_id=veh.id,
-            station_id=sta.id,
-            charger_id=mock_dcfc_charger_id()
-        )
+        instruction = ChargeStationInstruction(vehicle_id=veh.id,
+                                               station_id=sta.id,
+                                               charger_id=mock_dcfc_charger_id())
         env = mock_env()
         error, instruction_result = instruction.apply_instruction(sim, env)
         if error:
             self.fail(error.args)
 
         self.assertIsNotNone(sim, "Vehicle should have set instruction.")
-        sim_error, sim_updated = entity_state_ops.transition_previous_to_next(sim, env, instruction_result.prev_state, instruction_result.next_state)
+        sim_error, sim_updated = entity_state_ops.transition_previous_to_next(
+            sim, env, instruction_result.prev_state, instruction_result.next_state)
         # 10 hours should get us charged , and 1 more sim step of any size to transition vehicle state
-        sim_charged = perform_vehicle_state_updates(sim_updated._replace(sim_timestep_duration_seconds=36000), env)
-        sim_in_new_state = perform_vehicle_state_updates(sim_charged._replace(sim_timestep_duration_seconds=1), env)
+        sim_charged = perform_vehicle_state_updates(
+            sim_updated._replace(sim_timestep_duration_seconds=36000), env)
+        sim_in_new_state = perform_vehicle_state_updates(
+            sim_charged._replace(sim_timestep_duration_seconds=1), env)
 
         fully_charged_veh = sim_in_new_state.vehicles[veh.id]
 
-        self.assertIsInstance(fully_charged_veh.vehicle_state,
-                              Idle,
+        self.assertIsInstance(fully_charged_veh.vehicle_state, Idle,
                               "Vehicle should have transitioned to IDLE")
 
     def test_terminal_state_charging_base(self):
         veh = mock_vehicle_from_geoid(soc=0.75)
         sta = mock_station_from_geoid()
         bas = mock_base_from_geoid(station_id=sta.id)
-        sim = mock_sim(vehicles=(veh,), stations=(sta,), bases=(bas,))
+        sim = mock_sim(vehicles=(veh, ), stations=(sta, ), bases=(bas, ))
 
-        instruction = ChargeBaseInstruction(
-            vehicle_id=veh.id,
-            base_id=bas.id,
-            charger_id=mock_dcfc_charger_id()
-        )
+        instruction = ChargeBaseInstruction(vehicle_id=veh.id,
+                                            base_id=bas.id,
+                                            charger_id=mock_dcfc_charger_id())
         env = mock_env()
         error, instruction_result = instruction.apply_instruction(sim, env)
         if error:
             self.fail(error.args)
 
         self.assertIsNotNone(sim, "Vehicle should have set instruction.")
-        sim_error, sim_updated = entity_state_ops.transition_previous_to_next(sim, env, instruction_result.prev_state, instruction_result.next_state)
+        sim_error, sim_updated = entity_state_ops.transition_previous_to_next(
+            sim, env, instruction_result.prev_state, instruction_result.next_state)
         # 10 hours should get us charged, and 1 more sim step of any size to transition vehicle state
-        sim_charged = perform_vehicle_state_updates(sim_updated._replace(sim_timestep_duration_seconds=36000), env)
-        sim_in_new_state = perform_vehicle_state_updates(sim_charged._replace(sim_timestep_duration_seconds=1), env)
+        sim_charged = perform_vehicle_state_updates(
+            sim_updated._replace(sim_timestep_duration_seconds=36000), env)
+        sim_in_new_state = perform_vehicle_state_updates(
+            sim_charged._replace(sim_timestep_duration_seconds=1), env)
 
         fully_charged_veh = sim_in_new_state.vehicles[veh.id]
 
-        self.assertIsInstance(fully_charged_veh.vehicle_state,
-                              ReserveBase,
+        self.assertIsInstance(fully_charged_veh.vehicle_state, ReserveBase,
                               "Vehicle should have transitioned to RESERVE_BASE")
 
     def test_vehicle_runs_out_of_energy(self):
 
         low_energy_veh = mock_vehicle_from_geoid(soc=0.01)
-        sim = mock_sim(vehicles=(low_energy_veh,), sim_timestep_duration_seconds=3600)
+        sim = mock_sim(vehicles=(low_energy_veh, ), sim_timestep_duration_seconds=3600)
 
         env = mock_env()
 
@@ -396,20 +397,24 @@ class TestSimulationState(TestCase):
         error, instruction_result = instruction.apply_instruction(sim, env)
         if error:
             self.fail(error.args)
-        sim_error, sim_updated = entity_state_ops.transition_previous_to_next(sim, env, instruction_result.prev_state, instruction_result.next_state)
-        self.assertIsNotNone(sim_updated, "test invariant failed - should be able to reposition default vehicle")
+        sim_error, sim_updated = entity_state_ops.transition_previous_to_next(
+            sim, env, instruction_result.prev_state, instruction_result.next_state)
+        self.assertIsNotNone(
+            sim_updated, "test invariant failed - should be able to reposition default vehicle")
 
         # one movement takes more energy than this agent has
         sim_out_of_order = perform_vehicle_state_updates(sim_updated, env)
 
         veh_result = sim_out_of_order.vehicles.get(DefaultIds.mock_vehicle_id())
-        self.assertIsNotNone(veh_result, "stepped vehicle should have advanced the simulation state")
+        self.assertIsNotNone(veh_result,
+                             "stepped vehicle should have advanced the simulation state")
         self.assertIsInstance(veh_result.vehicle_state, OutOfService,
                               "should have landed in out of service state")
 
     def test_get_stations(self):
         sim = mock_sim(stations=(
-            mock_station('s1', lat=0, lon=0, chargers=immutables.Map({mock_dcfc_charger_id(): 1}, )),
+            mock_station('s1', lat=0, lon=0, chargers=immutables.Map({mock_dcfc_charger_id(): 1},
+                                                                     )),
             mock_station('s2', lat=1, lon=1, chargers=immutables.Map({mock_l2_charger_id(): 1}, )),
         ))
 
@@ -423,7 +428,8 @@ class TestSimulationState(TestCase):
 
     def test_get_stations_at_same_geoid(self):
         sim = mock_sim(stations=(
-            mock_station('s1', lat=0, lon=0, chargers=immutables.Map({mock_dcfc_charger_id(): 1}, )),
+            mock_station('s1', lat=0, lon=0, chargers=immutables.Map({mock_dcfc_charger_id(): 1},
+                                                                     )),
             mock_station('s2', lat=0, lon=0, chargers=immutables.Map({mock_l2_charger_id(): 1}, )),
         ))
 
@@ -441,7 +447,9 @@ class TestSimulationState(TestCase):
             mock_base('b3', lat=2, lon=2, stall_count=1),
         ))
 
-        sorted_bases = sim.get_bases(sort=True, sort_reversed=True, sort_key=lambda b: b.total_stalls)
+        sorted_bases = sim.get_bases(sort=True,
+                                     sort_reversed=True,
+                                     sort_key=lambda b: b.total_stalls)
 
         self.assertEqual(sorted_bases[0].id, 'b2', 'base 2 has the most stalls')
 
@@ -486,4 +494,3 @@ class TestSimulationState(TestCase):
         sorted_requests = sim.get_requests(sort=True, sort_key=lambda r: r.departure_time)
 
         self.assertEqual(sorted_requests[0].id, 'r1', 'r1 has lowest departure time')
-

--- a/tests/test_station.py
+++ b/tests/test_station.py
@@ -5,7 +5,6 @@ from hive.resources.mock_lobster import *
 
 
 class TestStation(TestCase):
-
     def test_from_row(self):
         source = """station_id,lat,lon,charger_id,charger_count,on_shift_access
                  s1,37,122,DCFC,10,true
@@ -72,9 +71,9 @@ class TestStation(TestCase):
         self.assertEqual(station2.total_chargers[mock_dcfc_charger_id()], 15)
 
     def test_checkout_charger(self):
-        updated_station = mock_station(chargers=immutables.Map({mock_dcfc_charger_id(): 1})).checkout_charger(
-            mock_dcfc_charger_id(),
-        )
+        updated_station = mock_station(
+            chargers=immutables.Map({mock_dcfc_charger_id(): 1})).checkout_charger(
+                                         mock_dcfc_charger_id(), )
 
         self.assertEqual(updated_station.available_chargers[mock_dcfc_charger_id()], 0)
 
@@ -86,9 +85,9 @@ class TestStation(TestCase):
         self.assertIsNone(no_dcfc_station)
 
     def test_return_charger(self):
-        updated_station = mock_station(chargers=immutables.Map({mock_l2_charger_id(): 1})).checkout_charger(
-            mock_l2_charger_id(),
-        )
+        updated_station = mock_station(
+            chargers=immutables.Map({mock_l2_charger_id(): 1})).checkout_charger(
+                                         mock_l2_charger_id(), )
 
         error, station_w_l2 = updated_station.return_charger(mock_l2_charger_id())
 
@@ -106,13 +105,8 @@ class TestStation(TestCase):
     def test_enqueue_for_charger(self):
         station = mock_station()
 
-        has_queues = station.enqueue_for_charger(
-            mock_dcfc_charger_id(),
-        ).enqueue_for_charger(
-            mock_dcfc_charger_id(),
-        ).enqueue_for_charger(
-            mock_l1_charger_id(),
-        )
+        has_queues = station.enqueue_for_charger(mock_dcfc_charger_id(), ).enqueue_for_charger(
+            mock_dcfc_charger_id(), ).enqueue_for_charger(mock_l1_charger_id(), )
         dc_count = has_queues.enqueued_vehicle_count_for_charger(mock_dcfc_charger_id())
         l1_count = has_queues.enqueued_vehicle_count_for_charger(mock_l1_charger_id())
         l2_count = has_queues.enqueued_vehicle_count_for_charger(mock_l2_charger_id())

--- a/tests/test_station_load_handler.py
+++ b/tests/test_station_load_handler.py
@@ -5,7 +5,6 @@ from hive.resources.mock_lobster import *
 
 
 class TestStationLoadHandler(TestCase):
-
     def test_correctly_reads_one_vehicle_charge_event(self):
         """
         this test is mostly here just to make sure we don't mess with
@@ -13,14 +12,12 @@ class TestStationLoadHandler(TestCase):
         break station load reporting
         :return:
         """
-        state = ChargingStation(
-            vehicle_id=DefaultIds.mock_vehicle_id(),
-            station_id=DefaultIds.mock_station_id(),
-            charger_id=mock_dcfc_charger_id()
-        )
+        state = ChargingStation(vehicle_id=DefaultIds.mock_vehicle_id(),
+                                station_id=DefaultIds.mock_station_id(),
+                                charger_id=mock_dcfc_charger_id())
         veh = mock_vehicle(soc=0.1)
         sta = mock_station()
-        sim = mock_sim(vehicles=(veh,), stations=(sta,))
+        sim = mock_sim(vehicles=(veh, ), stations=(sta, ))
         env = mock_env()
 
         err, sim_charging = state.enter(sim, env)

--- a/tests/test_step_simulation_ops.py
+++ b/tests/test_step_simulation_ops.py
@@ -5,7 +5,6 @@ from hive.resources.mock_lobster import *
 
 
 class TestStepSimulationOps(TestCase):
-
     def test_step_vehicle(self):
         """
         build a sim with two idle vehicles and only step one of them for 10 time steps (600 seconds)
@@ -27,7 +26,8 @@ class TestStepSimulationOps(TestCase):
         veh2_idle_time = vehicle2.vehicle_state.idle_duration
 
         self.assertEqual(veh1_idle_time, 0, "vehicle 1 should not have idled")
-        self.assertEqual(veh2_idle_time, 600, "vehicle 2 should have idled for 10 time steps (600 s)")
+        self.assertEqual(veh2_idle_time, 600,
+                         "vehicle 2 should have idled for 10 time steps (600 s)")
 
     def test_step_vehicle_state_change(self):
         """
@@ -44,7 +44,7 @@ class TestStepSimulationOps(TestCase):
             vehicle_id="2",
             vehicle_state=ChargingStation("2", "s1", mock_dcfc_charger_id()),
         )
-        sim = mock_sim(vehicles=(vehicle1, vehicle2), stations=(station,))
+        sim = mock_sim(vehicles=(vehicle1, vehicle2), stations=(station, ))
         env = mock_env()
 
         for _ in range(10):
@@ -56,5 +56,6 @@ class TestStepSimulationOps(TestCase):
         veh1_state = vehicle1.vehicle_state
         veh2_state = vehicle2.vehicle_state
 
-        self.assertIsInstance(veh1_state, ChargingStation, "vehicle 1 should still be in charging state")
+        self.assertIsInstance(veh1_state, ChargingStation,
+                              "vehicle 1 should still be in charging state")
         self.assertIsInstance(veh2_state, Idle, "vehicle 2 should have transitioned to idle")

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -11,7 +11,7 @@ class TestUpdateRequests(TestCase):
         t3 = read_time_string("7:00:00")
         t4 = read_time_string("13:00:00")
 
-        self.assertEqual(t1, time(hour=0, minute=0 ,second=0))
+        self.assertEqual(t1, time(hour=0, minute=0, second=0))
         self.assertEqual(t2, time(hour=23, minute=59, second=59))
         self.assertEqual(t3, time(hour=7, minute=0, second=0))
         self.assertEqual(t4, time(hour=13, minute=0, second=0))

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -5,7 +5,6 @@ from hive.resources.mock_lobster import *
 
 
 class TestUpdate(TestCase):
-
     def test_apply_update_with_user_provided_generator_update_function(self):
         """
         tests that a user can inject a function like `user_provided_update_fn` below and that it will
@@ -21,7 +20,8 @@ class TestUpdate(TestCase):
         class MockGenerator(NamedTuple, InstructionGenerator):
             stored_magic_number: int = old_magic_number
 
-            def generate_instructions(self, simulation_state: SimulationState, envronment: Environment):
+            def generate_instructions(self, simulation_state: SimulationState,
+                                      envronment: Environment):
                 return self, ()
 
         def user_provided_update_fn(instr_gen, sim):
@@ -32,11 +32,9 @@ class TestUpdate(TestCase):
 
         sim = mock_sim()
         env = mock_env()
-        u = Update.build(mock_config(), (MockGenerator(),), user_provided_update_fn)
+        u = Update.build(mock_config(), (MockGenerator(), ), user_provided_update_fn)
         runner = RunnerPayload(sim, env, u)
         result = u.apply_update(runner)
         updated_mock_gen = result.u.step_update.instruction_generators[0]
         self.assertEqual(updated_mock_gen.stored_magic_number, 42,
                          "the user provided update function should have been called")
-
-

--- a/tests/test_update_requests.py
+++ b/tests/test_update_requests.py
@@ -5,21 +5,22 @@ from hive.resources.mock_lobster import *
 
 
 class TestUpdateRequests(TestCase):
-
     def test_update(self):
         """
         test invariant: the below file resource exists
         """
-        sim_time = SimTime.build(180)  # will pull in all requests with departure_time earlier than 180
+        sim_time = SimTime.build(
+            180)  # will pull in all requests with departure_time earlier than 180
         sim = mock_sim(sim_time=sim_time)
         config = mock_config(
             start_time="2019-01-09T00:00:00",
             end_time="2019-01-10T00:00:00",
         )
         env = mock_env(config, fleet_ids=frozenset())
-        req_file = resource_filename("hive.resources.scenarios.denver_downtown.requests", "denver_demo_requests.csv")
-        rate_structure_file = resource_filename("hive.resources.scenarios.denver_downtown.service_prices",
-                                                "rate_structure.csv")
+        req_file = resource_filename("hive.resources.scenarios.denver_downtown.requests",
+                                     "denver_demo_requests.csv")
+        rate_structure_file = resource_filename(
+            "hive.resources.scenarios.denver_downtown.service_prices", "rate_structure.csv")
         fn = UpdateRequestsFromFile.build(req_file, rate_structure_file)
         result, _ = fn.update(sim, env)
         self.assertEqual(len(result.requests), 2, "should have added the reqs")
@@ -31,7 +32,8 @@ class TestUpdateRequests(TestCase):
         won't add requests whos cancel_time has already been exceeded, will instead report them
         test invariant: the below file resource exists
         """
-        sim_time = SimTime.build(720)  # will pull in all requests with departure_time earlier than 720
+        sim_time = SimTime.build(
+            720)  # will pull in all requests with departure_time earlier than 720
         expected_reqs = 18
         sim = mock_sim(sim_time=sim_time, sim_timestep_duration_seconds=1)
         config = mock_config(
@@ -39,9 +41,10 @@ class TestUpdateRequests(TestCase):
             end_time="2019-01-10T00:00:00",
         )
         env = mock_env(config, fleet_ids=frozenset())
-        req_file = resource_filename("hive.resources.scenarios.denver_downtown.requests", "denver_demo_requests.csv")
-        rate_structure_file = resource_filename("hive.resources.scenarios.denver_downtown.service_prices",
-                                                "rate_structure.csv")
+        req_file = resource_filename("hive.resources.scenarios.denver_downtown.requests",
+                                     "denver_demo_requests.csv")
+        rate_structure_file = resource_filename(
+            "hive.resources.scenarios.denver_downtown.service_prices", "rate_structure.csv")
         fn = UpdateRequestsFromFile.build(req_file, rate_structure_file)
         result, _ = fn.update(sim, env)
         self.assertEqual(expected_reqs, len(result.requests), "should have added the reqs")
@@ -53,36 +56,41 @@ class TestUpdateRequests(TestCase):
         won't add requests whos cancel_time has already been exceeded, will instead report them
         test invariant: the below file resource exists
         """
-        sim_time = SimTime.build(720)  # will pull in all requests with departure_time earlier than 720
+        sim_time = SimTime.build(
+            720)  # will pull in all requests with departure_time earlier than 720
         sim = mock_sim(sim_time=sim_time, sim_timestep_duration_seconds=1)
         config = mock_config(
             start_time="2019-01-09T00:00:00",
             end_time="2019-01-10T00:00:00",
         )
         env = mock_env(config, fleet_ids=frozenset())
-        req_file = resource_filename("hive.resources.scenarios.denver_downtown.requests", "denver_demo_requests.csv")
-        rate_structure_file = resource_filename("hive.resources.scenarios.denver_downtown.service_prices",
-                                                "rate_structure.csv")
+        req_file = resource_filename("hive.resources.scenarios.denver_downtown.requests",
+                                     "denver_demo_requests.csv")
+        rate_structure_file = resource_filename(
+            "hive.resources.scenarios.denver_downtown.service_prices", "rate_structure.csv")
         fn = UpdateRequestsFromFile.build(req_file, rate_structure_file)
         result, _ = fn.update(sim, env)
         for req in result.requests.values():
             print(req)
-            self.assertGreaterEqual(req.value, 5, f"should be greater/equal than minimum price of 5")
+            self.assertGreaterEqual(req.value, 5,
+                                    f"should be greater/equal than minimum price of 5")
 
     def test_update_lazy_file_reading(self):
         """
         test invariant: the below file resource exists
         """
-        sim_time = SimTime.build(180)  # will pull in all requests with departure_time earlier than 180
+        sim_time = SimTime.build(
+            180)  # will pull in all requests with departure_time earlier than 180
         sim = mock_sim(sim_time=sim_time)
         config = mock_config(
             start_time="2019-01-09T00:00:00",
             end_time="2019-01-10T00:00:00",
         )
         env = mock_env(config, fleet_ids=frozenset())
-        req_file = resource_filename("hive.resources.scenarios.denver_downtown.requests", "denver_demo_requests.csv")
-        rate_structure_file = resource_filename("hive.resources.scenarios.denver_downtown.service_prices",
-                                                "rate_structure.csv")
+        req_file = resource_filename("hive.resources.scenarios.denver_downtown.requests",
+                                     "denver_demo_requests.csv")
+        rate_structure_file = resource_filename(
+            "hive.resources.scenarios.denver_downtown.service_prices", "rate_structure.csv")
         fn = UpdateRequestsFromFile.build(req_file, rate_structure_file, lazy_file_reading=True)
         result, _ = fn.update(sim, env)
         self.assertEqual(len(result.requests), 2, "should have added the reqs")

--- a/tests/test_update_requests_sampling.py
+++ b/tests/test_update_requests_sampling.py
@@ -5,7 +5,6 @@ from hive.resources.mock_lobster import *
 
 
 class TestUpdateRequestsSampling(TestCase):
-
     def test_update(self):
         sim = mock_sim(
             sim_time=SimTime.build(180),
@@ -20,5 +19,5 @@ class TestUpdateRequestsSampling(TestCase):
         self.assertEqual(len(result.requests), 5, "should have added 5 requests")
 
         for r in result.requests.values():
-            self.assertNotEqual(r.origin, r.destination, "origin and destination should not be equal")
-
+            self.assertNotEqual(r.origin, r.destination,
+                                "origin and destination should not be equal")

--- a/tests/test_vehicle_state.py
+++ b/tests/test_vehicle_state.py
@@ -18,10 +18,7 @@ class TestVehicleState(TestCase):
         vehicle = mock_vehicle()
         station = mock_station()
         charger = mock_dcfc_charger_id()
-        sim = mock_sim(
-            vehicles=(vehicle,),
-            stations=(station,)
-        )
+        sim = mock_sim(vehicles=(vehicle, ), stations=(station, ))
         env = mock_env()
 
         state = ChargingStation(vehicle.id, station.id, charger)
@@ -32,17 +29,15 @@ class TestVehicleState(TestCase):
         updated_vehicle = updated_sim.vehicles.get(vehicle.id)
         updated_station = updated_sim.stations.get(station.id)
         available_chargers = updated_station.available_chargers.get(charger)
-        self.assertIsInstance(updated_vehicle.vehicle_state, ChargingStation, "should be in a charging state")
+        self.assertIsInstance(updated_vehicle.vehicle_state, ChargingStation,
+                              "should be in a charging state")
         self.assertEquals(available_chargers, 0, "should have claimed the only DCFC charger_id")
 
     def test_charging_station_bad_membership(self):
         vehicle = mock_vehicle(membership=Membership.single_membership("uber"))
         station = mock_station(membership=Membership.single_membership("lyft"))
 
-        sim = mock_sim(
-            vehicles=(vehicle,),
-            stations=(station,)
-        )
+        sim = mock_sim(vehicles=(vehicle, ), stations=(station, ))
         env = mock_env()
 
         state = ChargingStation(vehicle.id, station.id, mock_dcfc_charger_id())
@@ -54,10 +49,7 @@ class TestVehicleState(TestCase):
         vehicle = mock_vehicle()
         station = mock_station()
         charger = mock_dcfc_charger_id()
-        sim = mock_sim(
-            vehicles=(vehicle,),
-            stations=(station,)
-        )
+        sim = mock_sim(vehicles=(vehicle, ), stations=(station, ))
         env = mock_env()
 
         state = ChargingStation(vehicle.id, station.id, charger)
@@ -72,17 +64,15 @@ class TestVehicleState(TestCase):
         updated_vehicle = updated_sim.vehicles.get(vehicle.id)
         updated_station = updated_sim.stations.get(station.id)
         available_chargers = updated_station.available_chargers.get(charger)
-        self.assertIsInstance(updated_vehicle.vehicle_state, ChargingStation, "should still be in a charging state")
+        self.assertIsInstance(updated_vehicle.vehicle_state, ChargingStation,
+                              "should still be in a charging state")
         self.assertEquals(available_chargers, 1, "should have returned the only DCFC charger_id")
 
     def test_charging_station_update(self):
         vehicle = mock_vehicle(soc=0.5)
         station = mock_station()
         charger = mock_dcfc_charger_id()
-        sim = mock_sim(
-            vehicles=(vehicle,),
-            stations=(station,)
-        )
+        sim = mock_sim(vehicles=(vehicle, ), stations=(station, ))
         env = mock_env()
 
         state = ChargingStation(vehicle.id, station.id, charger)
@@ -93,20 +83,16 @@ class TestVehicleState(TestCase):
         self.assertIsNone(update_error, "should have no error from update call")
 
         updated_vehicle = sim_updated.vehicles.get(vehicle.id)
-        self.assertAlmostEqual(
-            first=updated_vehicle.energy[EnergyType.ELECTRIC],
-            second=vehicle.energy[EnergyType.ELECTRIC] + 0.76,
-            places=2,
-            msg="should have charged for 60 seconds")
+        self.assertAlmostEqual(first=updated_vehicle.energy[EnergyType.ELECTRIC],
+                               second=vehicle.energy[EnergyType.ELECTRIC] + 0.76,
+                               places=2,
+                               msg="should have charged for 60 seconds")
 
     def test_charging_station_update_terminal(self):
         vehicle = mock_vehicle(soc=1)
         station = mock_station()
         charger = mock_dcfc_charger_id()
-        sim = mock_sim(
-            vehicles=(vehicle,),
-            stations=(station,)
-        )
+        sim = mock_sim(vehicles=(vehicle, ), stations=(station, ))
         env = mock_env()
 
         state = ChargingStation(vehicle.id, station.id, charger)
@@ -118,15 +104,15 @@ class TestVehicleState(TestCase):
 
         updated_vehicle = sim_updated.vehicles.get(vehicle.id)
         updated_station = sim_updated.stations.get(station.id)
-        self.assertIsInstance(updated_vehicle.vehicle_state, Idle, "vehicle should be in idle state")
-        self.assertEquals(updated_station.available_chargers.get(charger), 1, "should have returned the charger_id")
+        self.assertIsInstance(updated_vehicle.vehicle_state, Idle,
+                              "vehicle should be in idle state")
+        self.assertEquals(updated_station.available_chargers.get(charger), 1,
+                          "should have returned the charger_id")
 
     def test_charging_station_enter_with_no_station(self):
         vehicle = mock_vehicle(soc=0.99)
         charger = mock_dcfc_charger_id()
-        sim = mock_sim(
-            vehicles=(vehicle,),
-        )
+        sim = mock_sim(vehicles=(vehicle, ), )
         env = mock_env()
 
         state = ChargingStation(vehicle.id, DefaultIds.mock_station_id(), charger)
@@ -137,9 +123,7 @@ class TestVehicleState(TestCase):
     def test_charging_station_enter_with_no_vehicle(self):
         station = mock_station()
         charger = mock_dcfc_charger_id()
-        sim = mock_sim(
-            stations=(station,),
-        )
+        sim = mock_sim(stations=(station, ), )
         env = mock_env()
 
         state = ChargingStation(DefaultIds.mock_vehicle_id(), DefaultIds.mock_station_id(), charger)
@@ -152,8 +136,8 @@ class TestVehicleState(TestCase):
         charger = mock_dcfc_charger_id()
         vehicle = mock_vehicle(mechatronics=mock_ice())
         sim = mock_sim(
-            stations=(station,),
-            vehicles=(vehicle,),
+            stations=(station, ),
+            vehicles=(vehicle, ),
         )
         env = mock_env(mechatronics={DefaultIds.mock_mechatronics_ice_id(): mock_ice()})
 
@@ -164,11 +148,11 @@ class TestVehicleState(TestCase):
 
     def test_charging_station_subsequent_charge_instructions(self):
         vehicle = mock_vehicle()
-        station = mock_station(chargers=immutables.Map({mock_l2_charger_id(): 1, mock_dcfc_charger_id(): 1}))
-        sim = mock_sim(
-            vehicles=(vehicle,),
-            stations=(station,)
-        )
+        station = mock_station(chargers=immutables.Map({
+            mock_l2_charger_id(): 1,
+            mock_dcfc_charger_id(): 1
+        }))
+        sim = mock_sim(vehicles=(vehicle, ), stations=(station, ))
         env = mock_env()
 
         state = ChargingStation(vehicle.id, station.id, mock_dcfc_charger_id())
@@ -186,7 +170,8 @@ class TestVehicleState(TestCase):
         dc_available = updated_station.available_chargers.get(mock_dcfc_charger_id())
         l2_available = updated_station.available_chargers.get(mock_l2_charger_id())
         self.assertEqual(dc_available, 1, "should have released DC charger_id on second transition")
-        self.assertEqual(l2_available, 0, "second instruction should have claimed the only L2 charger_id")
+        self.assertEqual(l2_available, 0,
+                         "second instruction should have claimed the only L2 charger_id")
 
     ####################################################################################################################
     # ChargingBase #####################################################################################################
@@ -197,11 +182,7 @@ class TestVehicleState(TestCase):
         station = mock_station()
         base = mock_base(station_id=DefaultIds.mock_station_id())
         charger = mock_dcfc_charger_id()
-        sim = mock_sim(
-            vehicles=(vehicle,),
-            stations=(station,),
-            bases=(base,)
-        )
+        sim = mock_sim(vehicles=(vehicle, ), stations=(station, ), bases=(base, ))
         env = mock_env()
 
         state = ChargingBase(vehicle.id, base.id, charger)
@@ -212,7 +193,8 @@ class TestVehicleState(TestCase):
         updated_vehicle = updated_sim.vehicles.get(vehicle.id)
         updated_station = updated_sim.stations.get(station.id)
         available_chargers = updated_station.available_chargers.get(charger)
-        self.assertIsInstance(updated_vehicle.vehicle_state, ChargingBase, "should be in a charging state")
+        self.assertIsInstance(updated_vehicle.vehicle_state, ChargingBase,
+                              "should be in a charging state")
         self.assertEquals(available_chargers, 0, "should have claimed the only DCFC charger_id")
 
     def test_charging_base_bad_membership(self):
@@ -224,11 +206,7 @@ class TestVehicleState(TestCase):
         station = mock_station(membership=base.membership)
 
         charger = mock_dcfc_charger_id()
-        sim = mock_sim(
-            vehicles=(vehicle,),
-            stations=(station,),
-            bases=(base,)
-        )
+        sim = mock_sim(vehicles=(vehicle, ), stations=(station, ), bases=(base, ))
         env = mock_env()
 
         state = ChargingBase(vehicle.id, base.id, charger)
@@ -242,9 +220,9 @@ class TestVehicleState(TestCase):
         charger = mock_l2_charger_id()
         vehicle = mock_vehicle(mechatronics=mock_ice())
         sim = mock_sim(
-            stations=(station,),
-            vehicles=(vehicle,),
-            bases=(base,),
+            stations=(station, ),
+            vehicles=(vehicle, ),
+            bases=(base, ),
         )
         env = mock_env(mechatronics={DefaultIds.mock_mechatronics_ice_id(): mock_ice()})
 
@@ -258,11 +236,7 @@ class TestVehicleState(TestCase):
         station = mock_station()
         base = mock_base(station_id=DefaultIds.mock_station_id())
         charger = mock_dcfc_charger_id()
-        sim = mock_sim(
-            vehicles=(vehicle,),
-            stations=(station,),
-            bases=(base,)
-        )
+        sim = mock_sim(vehicles=(vehicle, ), stations=(station, ), bases=(base, ))
         env = mock_env()
 
         state = ChargingBase(vehicle.id, base.id, charger)
@@ -277,7 +251,8 @@ class TestVehicleState(TestCase):
         updated_vehicle = updated_sim.vehicles.get(vehicle.id)
         updated_station = updated_sim.stations.get(station.id)
         available_chargers = updated_station.available_chargers.get(charger)
-        self.assertIsInstance(updated_vehicle.vehicle_state, ChargingBase, "should still be in a charging state")
+        self.assertIsInstance(updated_vehicle.vehicle_state, ChargingBase,
+                              "should still be in a charging state")
         self.assertEquals(available_chargers, 1, "should have returned the only DCFC charger_id")
 
     def test_charging_base_update(self):
@@ -285,11 +260,7 @@ class TestVehicleState(TestCase):
         station = mock_station()
         base = mock_base(station_id=DefaultIds.mock_station_id())
         charger = mock_l2_charger_id()
-        sim = mock_sim(
-            vehicles=(vehicle,),
-            stations=(station,),
-            bases=(base,)
-        )
+        sim = mock_sim(vehicles=(vehicle, ), stations=(station, ), bases=(base, ))
         env = mock_env()
 
         state = ChargingBase(vehicle.id, base.id, charger)
@@ -300,22 +271,17 @@ class TestVehicleState(TestCase):
         self.assertIsNone(update_error, "should have no error from update call")
 
         updated_vehicle = sim_updated.vehicles.get(vehicle.id)
-        self.assertAlmostEqual(
-            first=updated_vehicle.energy[EnergyType.ELECTRIC],
-            second=vehicle.energy[EnergyType.ELECTRIC] + 0.12,
-            places=2,
-            msg="should have charged for 60 seconds")
+        self.assertAlmostEqual(first=updated_vehicle.energy[EnergyType.ELECTRIC],
+                               second=vehicle.energy[EnergyType.ELECTRIC] + 0.12,
+                               places=2,
+                               msg="should have charged for 60 seconds")
 
     def test_charging_base_update_terminal(self):
         vehicle = mock_vehicle(soc=1.0)
         station = mock_station()
         base = mock_base(station_id=DefaultIds.mock_station_id())
         charger = mock_dcfc_charger_id()
-        sim = mock_sim(
-            vehicles=(vehicle,),
-            stations=(station,),
-            bases=(base,)
-        )
+        sim = mock_sim(vehicles=(vehicle, ), stations=(station, ), bases=(base, ))
         env = mock_env()
 
         state = ChargingBase(vehicle.id, base.id, charger)
@@ -327,16 +293,18 @@ class TestVehicleState(TestCase):
 
         updated_vehicle = sim_updated.vehicles.get(vehicle.id)
         updated_base = sim_updated.bases.get(base.id)
-        self.assertIsInstance(updated_vehicle.vehicle_state, ReserveBase, "vehicle should be in ReserveBase state")
-        self.assertEquals(updated_base.available_stalls, 0, "should have taken the only available stall")
+        self.assertIsInstance(updated_vehicle.vehicle_state, ReserveBase,
+                              "vehicle should be in ReserveBase state")
+        self.assertEquals(updated_base.available_stalls, 0,
+                          "should have taken the only available stall")
 
     def test_charging_base_enter_with_no_base(self):
         vehicle = mock_vehicle(soc=1.0)
         station = mock_station()
         charger = mock_dcfc_charger_id()
         sim = mock_sim(
-            vehicles=(vehicle,),
-            stations=(station,),
+            vehicles=(vehicle, ),
+            stations=(station, ),
         )
         env = mock_env()
 
@@ -349,10 +317,7 @@ class TestVehicleState(TestCase):
         vehicle = mock_vehicle(soc=1.0)
         base = mock_base(station_id=DefaultIds.mock_station_id())
         charger = mock_dcfc_charger_id()
-        sim = mock_sim(
-            vehicles=(vehicle,),
-            bases=(base,)
-        )
+        sim = mock_sim(vehicles=(vehicle, ), bases=(base, ))
         env = mock_env()
 
         state = ChargingBase(vehicle.id, base.id, charger)
@@ -364,10 +329,7 @@ class TestVehicleState(TestCase):
         vehicle = mock_vehicle(soc=1.0)
         base = mock_base()
         charger = mock_dcfc_charger_id()
-        sim = mock_sim(
-            vehicles=(vehicle,),
-            bases=(base,)
-        )
+        sim = mock_sim(vehicles=(vehicle, ), bases=(base, ))
         env = mock_env()
 
         state = ChargingBase(vehicle.id, base.id, charger)
@@ -379,10 +341,7 @@ class TestVehicleState(TestCase):
         station = mock_station()
         base = mock_base(station_id=DefaultIds.mock_station_id())
         charger = mock_dcfc_charger_id()
-        sim = mock_sim(
-            stations=(station,),
-            bases=(base,)
-        )
+        sim = mock_sim(stations=(station, ), bases=(base, ))
         env = mock_env()
 
         state = ChargingBase(DefaultIds.mock_vehicle_id(), base.id, charger)
@@ -392,13 +351,12 @@ class TestVehicleState(TestCase):
 
     def test_charging_base_subsequent_charge_instructions(self):
         vehicle = mock_vehicle()
-        station = mock_station(chargers=immutables.Map({mock_l2_charger_id(): 1, mock_dcfc_charger_id(): 1}))
+        station = mock_station(chargers=immutables.Map({
+            mock_l2_charger_id(): 1,
+            mock_dcfc_charger_id(): 1
+        }))
         base = mock_base(station_id=DefaultIds.mock_station_id())
-        sim = mock_sim(
-            vehicles=(vehicle,),
-            stations=(station,),
-            bases=(base,)
-        )
+        sim = mock_sim(vehicles=(vehicle, ), stations=(station, ), bases=(base, ))
         env = mock_env()
 
         state = ChargingBase(vehicle.id, base.id, mock_dcfc_charger_id())
@@ -416,7 +374,8 @@ class TestVehicleState(TestCase):
         dc_available = updated_station.available_chargers.get(mock_dcfc_charger_id())
         l2_available = updated_station.available_chargers.get(mock_l2_charger_id())
         self.assertEqual(dc_available, 1, "should have released DC charger_id on second transition")
-        self.assertEqual(l2_available, 0, "second instruction should have claimed the only L2 charger_id")
+        self.assertEqual(l2_available, 0,
+                         "second instruction should have claimed the only L2 charger_id")
 
     ####################################################################################################################
     # DispatchBase #####################################################################################################
@@ -425,10 +384,7 @@ class TestVehicleState(TestCase):
     def test_dispatch_base_enter(self):
         vehicle = mock_vehicle()
         base = mock_base()
-        sim = mock_sim(
-            vehicles=(vehicle,),
-            bases=(base,)
-        )
+        sim = mock_sim(vehicles=(vehicle, ), bases=(base, ))
         env = mock_env()
         route = mock_route_from_geoids(vehicle.geoid, base.geoid)
 
@@ -438,17 +394,15 @@ class TestVehicleState(TestCase):
         self.assertIsNone(error, "should have no errors")
 
         updated_vehicle = updated_sim.vehicles.get(vehicle.id)
-        self.assertIsInstance(updated_vehicle.vehicle_state, DispatchBase, "should be in a dispatch to base state")
+        self.assertIsInstance(updated_vehicle.vehicle_state, DispatchBase,
+                              "should be in a dispatch to base state")
         self.assertEquals(len(updated_vehicle.vehicle_state.route), 1, "should have a route")
 
     def test_dispatch_base_bad_membership(self):
         vehicle = mock_vehicle(membership=Membership.single_membership("uber"))
         base = mock_base(membership=Membership.single_membership("lyft"))
 
-        sim = mock_sim(
-            vehicles=(vehicle,),
-            bases=(base,)
-        )
+        sim = mock_sim(vehicles=(vehicle, ), bases=(base, ))
         env = mock_env()
         route = mock_route_from_geoids(vehicle.geoid, base.geoid)
 
@@ -460,10 +414,7 @@ class TestVehicleState(TestCase):
     def test_dispatch_base_exit(self):
         vehicle = mock_vehicle()
         base = mock_base()
-        sim = mock_sim(
-            vehicles=(vehicle,),
-            bases=(base,)
-        )
+        sim = mock_sim(vehicles=(vehicle, ), bases=(base, ))
         env = mock_env()
         route = mock_route_from_geoids(vehicle.geoid, base.geoid)
 
@@ -482,10 +433,7 @@ class TestVehicleState(TestCase):
         omf_brewing = h3.geo_to_h3(39.7608873, -104.9845391, 15)
         vehicle = mock_vehicle_from_geoid(geoid=near)
         base = mock_base_from_geoid(geoid=omf_brewing)
-        sim = mock_sim(
-            vehicles=(vehicle,),
-            bases=(base,)
-        )
+        sim = mock_sim(vehicles=(vehicle, ), bases=(base, ))
         env = mock_env()
         route = mock_route_from_geoids(near, omf_brewing)
 
@@ -498,7 +446,8 @@ class TestVehicleState(TestCase):
 
         updated_vehicle = sim_updated.vehicles.get(vehicle.id)
         old_soc = env.mechatronics.get(vehicle.mechatronics_id).fuel_source_soc(vehicle)
-        new_soc = env.mechatronics.get(updated_vehicle.mechatronics_id).fuel_source_soc(updated_vehicle)
+        new_soc = env.mechatronics.get(
+            updated_vehicle.mechatronics_id).fuel_source_soc(updated_vehicle)
         self.assertNotEqual(vehicle.geoid, updated_vehicle.geoid, "should have moved")
         self.assertIsInstance(updated_vehicle.vehicle_state, DispatchBase,
                               "should still be in a dispatch to base state")
@@ -507,10 +456,7 @@ class TestVehicleState(TestCase):
     def test_dispatch_base_update_terminal(self):
         vehicle = mock_vehicle()
         base = mock_base()
-        sim = mock_sim(
-            vehicles=(vehicle,),
-            bases=(base,)
-        )
+        sim = mock_sim(vehicles=(vehicle, ), bases=(base, ))
         env = mock_env()
         route = ()  # empty route should trigger a default transition
 
@@ -523,14 +469,14 @@ class TestVehicleState(TestCase):
 
         updated_vehicle = sim_updated.vehicles.get(vehicle.id)
         updated_base = sim_updated.bases.get(base.id)
-        self.assertIsInstance(updated_vehicle.vehicle_state, ReserveBase, "vehicle should be in ReserveBase state")
-        self.assertEquals(updated_base.available_stalls, 0, "should have taken the only available stall")
+        self.assertIsInstance(updated_vehicle.vehicle_state, ReserveBase,
+                              "vehicle should be in ReserveBase state")
+        self.assertEquals(updated_base.available_stalls, 0,
+                          "should have taken the only available stall")
 
     def test_dispatch_base_enter_no_base(self):
         vehicle = mock_vehicle()
-        sim = mock_sim(
-            vehicles=(vehicle,),
-        )
+        sim = mock_sim(vehicles=(vehicle, ), )
         env = mock_env()
         route = ()
 
@@ -540,9 +486,7 @@ class TestVehicleState(TestCase):
 
     def test_dispatch_base_enter_no_vehicle(self):
         base = mock_base()
-        sim = mock_sim(
-            bases=(base,),
-        )
+        sim = mock_sim(bases=(base, ), )
         env = mock_env()
         route = ()
 
@@ -556,8 +500,8 @@ class TestVehicleState(TestCase):
         vehicle = mock_vehicle()
         base = mock_base()
         sim = mock_sim(
-            vehicles=(vehicle,),
-            bases=(base,),
+            vehicles=(vehicle, ),
+            bases=(base, ),
         )
         env = mock_env()
         route = mock_route_from_geoids(omf_brewing, base.geoid)
@@ -573,8 +517,8 @@ class TestVehicleState(TestCase):
         vehicle = mock_vehicle()
         base = mock_base()
         sim = mock_sim(
-            vehicles=(vehicle,),
-            bases=(base,),
+            vehicles=(vehicle, ),
+            bases=(base, ),
         )
         env = mock_env()
         route = mock_route_from_geoids(vehicle.geoid, omf_brewing)
@@ -593,10 +537,7 @@ class TestVehicleState(TestCase):
         vehicle = mock_vehicle()
         station = mock_station_from_geoid(geoid=outer_range_brewing)
         charger = mock_dcfc_charger_id()
-        sim = mock_sim(
-            vehicles=(vehicle,),
-            stations=(station,)
-        )
+        sim = mock_sim(vehicles=(vehicle, ), stations=(station, ))
         env = mock_env()
         route = mock_route_from_geoids(vehicle.geoid, station.geoid)
 
@@ -616,8 +557,8 @@ class TestVehicleState(TestCase):
         charger = mock_dcfc_charger_id()
 
         sim = mock_sim(
-            vehicles=(vehicle,),
-            stations=(station,),
+            vehicles=(vehicle, ),
+            stations=(station, ),
         )
         env = mock_env()
         route = mock_route_from_geoids(vehicle.geoid, station.geoid)
@@ -632,10 +573,7 @@ class TestVehicleState(TestCase):
         vehicle = mock_vehicle()
         station = mock_station()
         charger = mock_dcfc_charger_id()
-        sim = mock_sim(
-            vehicles=(vehicle,),
-            stations=(station,)
-        )
+        sim = mock_sim(vehicles=(vehicle, ), stations=(station, ))
         env = mock_env()
         route = mock_route_from_geoids(vehicle.geoid, station.geoid)
 
@@ -645,17 +583,15 @@ class TestVehicleState(TestCase):
         self.assertIsNone(error, "should have no errors")
 
         updated_vehicle = updated_sim.vehicles.get(vehicle.id)
-        self.assertIsInstance(updated_vehicle.vehicle_state, ChargingStation,
-                              "should actually end up charging with no delay since we are already at the destination")
+        self.assertIsInstance(
+            updated_vehicle.vehicle_state, ChargingStation,
+            "should actually end up charging with no delay since we are already at the destination")
 
     def test_dispatch_station_exit(self):
         vehicle = mock_vehicle()
         station = mock_station()
         charger = mock_dcfc_charger_id()
-        sim = mock_sim(
-            vehicles=(vehicle,),
-            stations=(station,)
-        )
+        sim = mock_sim(vehicles=(vehicle, ), stations=(station, ))
         env = mock_env()
         route = mock_route_from_geoids(vehicle.geoid, station.geoid)
 
@@ -675,10 +611,7 @@ class TestVehicleState(TestCase):
         vehicle = mock_vehicle_from_geoid(geoid=near)
         station = mock_station_from_geoid(geoid=omf_brewing)
         charger = mock_dcfc_charger_id()
-        sim = mock_sim(
-            vehicles=(vehicle,),
-            stations=(station,)
-        )
+        sim = mock_sim(vehicles=(vehicle, ), stations=(station, ))
         env = mock_env()
         route = mock_route_from_geoids(near, omf_brewing)
 
@@ -691,7 +624,8 @@ class TestVehicleState(TestCase):
 
         updated_vehicle = sim_updated.vehicles.get(vehicle.id)
         old_soc = env.mechatronics.get(vehicle.mechatronics_id).fuel_source_soc(vehicle)
-        new_soc = env.mechatronics.get(updated_vehicle.mechatronics_id).fuel_source_soc(updated_vehicle)
+        new_soc = env.mechatronics.get(
+            updated_vehicle.mechatronics_id).fuel_source_soc(updated_vehicle)
         self.assertNotEqual(vehicle.geoid, updated_vehicle.geoid, "should have moved")
         self.assertIsInstance(updated_vehicle.vehicle_state, DispatchStation,
                               "should still be in a dispatch to station state")
@@ -701,18 +635,11 @@ class TestVehicleState(TestCase):
         initial_soc = 0.1
         charger = mock_dcfc_charger_id()
         route = ()  # empty route should trigger a default transition
-        state = DispatchStation(
-            DefaultIds.mock_vehicle_id(),
-            DefaultIds.mock_station_id(),
-            route,
-            charger
-        )
+        state = DispatchStation(DefaultIds.mock_vehicle_id(), DefaultIds.mock_station_id(), route,
+                                charger)
         vehicle = mock_vehicle(soc=initial_soc, vehicle_state=state)
         station = mock_station()
-        sim = mock_sim(
-            vehicles=(vehicle,),
-            stations=(station,)
-        )
+        sim = mock_sim(vehicles=(vehicle, ), stations=(station, ))
         env = mock_env()
 
         # enter_error, sim_with_dispatch_vehicle = state.enter(sim, env)
@@ -723,7 +650,8 @@ class TestVehicleState(TestCase):
 
         updated_vehicle = sim_updated.vehicles.get(vehicle.id)
         updated_station = sim_updated.stations.get(station.id)
-        new_soc = env.mechatronics.get(updated_vehicle.mechatronics_id).fuel_source_soc(updated_vehicle)
+        new_soc = env.mechatronics.get(
+            updated_vehicle.mechatronics_id).fuel_source_soc(updated_vehicle)
         self.assertIsInstance(updated_vehicle.vehicle_state, ChargingStation,
                               "vehicle should be in ChargingStation state")
         self.assertEquals(updated_station.available_chargers.get(charger), 0,
@@ -733,9 +661,7 @@ class TestVehicleState(TestCase):
     def test_dispatch_station_enter_no_station(self):
         vehicle = mock_vehicle()
         charger = mock_dcfc_charger_id()
-        sim = mock_sim(
-            vehicles=(vehicle,),
-        )
+        sim = mock_sim(vehicles=(vehicle, ), )
         env = mock_env()
         route = ()
 
@@ -746,9 +672,7 @@ class TestVehicleState(TestCase):
     def test_dispatch_station_enter_no_vehicle(self):
         station = mock_station()
         charger = mock_dcfc_charger_id()
-        sim = mock_sim(
-            stations=(station,),
-        )
+        sim = mock_sim(stations=(station, ), )
         env = mock_env()
         route = ()
 
@@ -762,8 +686,8 @@ class TestVehicleState(TestCase):
         station = mock_station_from_geoid(geoid=omf_brewing)
         charger = mock_dcfc_charger_id()
         sim = mock_sim(
-            vehicles=(vehicle,),
-            stations=(station,),
+            vehicles=(vehicle, ),
+            stations=(station, ),
         )
         env = mock_env()
         route = mock_route_from_geoids(omf_brewing, station.geoid)
@@ -780,8 +704,8 @@ class TestVehicleState(TestCase):
         station = mock_station_from_geoid(geoid=omf_brewing)
         charger = mock_dcfc_charger_id()
         sim = mock_sim(
-            vehicles=(vehicle,),
-            stations=(station,),
+            vehicles=(vehicle, ),
+            stations=(station, ),
         )
         env = mock_env()
         route = mock_route_from_geoids(vehicle.geoid, outer_range_brewing)
@@ -789,8 +713,10 @@ class TestVehicleState(TestCase):
         state = DispatchStation(vehicle.id, station.id, route, charger)
         enter_error, enter_sim = state.enter(sim, env)
         self.assertIsNone(enter_error, "should be no error")
-        self.assertIsNone(enter_sim,
-                          "invalid route should have not changed sim state - station and route destination do not match")
+        self.assertIsNone(
+            enter_sim,
+            "invalid route should have not changed sim state - station and route destination do not match"
+        )
 
     ####################################################################################################################
     # DispatchTrip #####################################################################################################
@@ -799,7 +725,7 @@ class TestVehicleState(TestCase):
     def test_dispatch_trip_enter(self):
         vehicle = mock_vehicle()
         request = mock_request()
-        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle,)), request)
+        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle, )), request)
         self.assertIsNone(e1, "test invariant failed")
         env = mock_env()
         route = mock_route_from_geoids(vehicle.geoid, request.geoid)
@@ -811,15 +737,17 @@ class TestVehicleState(TestCase):
 
         updated_vehicle = updated_sim.vehicles.get(vehicle.id)
         updated_request = updated_sim.requests.get(request.id)
-        self.assertIsInstance(updated_vehicle.vehicle_state, DispatchTrip, "should be in a dispatch to request state")
-        self.assertEquals(updated_request.dispatched_vehicle, vehicle.id, "request should be assigned this vehicle")
+        self.assertIsInstance(updated_vehicle.vehicle_state, DispatchTrip,
+                              "should be in a dispatch to request state")
+        self.assertEquals(updated_request.dispatched_vehicle, vehicle.id,
+                          "request should be assigned this vehicle")
         self.assertEquals(len(updated_vehicle.vehicle_state.route), 1, "should have a route")
 
     def test_dispatch_trip_bad_membership(self):
         vehicle = mock_vehicle(membership=Membership.single_membership("uber"))
         request = mock_request(fleet_id="lyft")
 
-        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle,)), request)
+        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle, )), request)
         self.assertIsNone(e1, "test invariant failed")
         env = mock_env()
         route = mock_route_from_geoids(vehicle.geoid, request.geoid)
@@ -832,7 +760,7 @@ class TestVehicleState(TestCase):
     def test_dispatch_trip_exit(self):
         vehicle = mock_vehicle()
         request = mock_request()
-        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle,)), request)
+        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle, )), request)
         self.assertIsNone(e1, "test invariant failed")
         env = mock_env()
         route = mock_route_from_geoids(vehicle.geoid, request.geoid)
@@ -840,20 +768,24 @@ class TestVehicleState(TestCase):
         state = DispatchTrip(vehicle.id, request.id, route)
         enter_error, entered_sim = state.enter(sim, env)
         self.assertIsNone(enter_error, "test precondition (enter works correctly) not met")
-        self.assertTrue(entered_sim.requests.get(request.id).dispatched_vehicle == vehicle.id, "test precondition not met")
+        self.assertTrue(
+            entered_sim.requests.get(request.id).dispatched_vehicle == vehicle.id,
+            "test precondition not met")
 
         # begin test
         error, exited_sim = state.exit(Idle(vehicle.id), entered_sim, env)
 
         self.assertIsNone(error, "should have no errors")
-        self.assertIsNone(exited_sim.requests.get(request.id).dispatched_vehicle, "should have unset the dispatched vehicle")
+        self.assertIsNone(
+            exited_sim.requests.get(request.id).dispatched_vehicle,
+            "should have unset the dispatched vehicle")
 
     def test_dispatch_trip_update(self):
         near = h3.geo_to_h3(39.7539, -104.974, 15)
         omf_brewing = h3.geo_to_h3(39.7608873, -104.9845391, 15)
         vehicle = mock_vehicle()
         request = mock_request_from_geoids(origin=omf_brewing)
-        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle,)), request)
+        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle, )), request)
         self.assertIsNone(e1, "test invariant failed")
         env = mock_env()
         route = mock_route_from_geoids(near, omf_brewing)
@@ -882,9 +814,8 @@ class TestVehicleState(TestCase):
             destination="8f268cdac70e2d3",
         )._replace(  # a hack so we can test equality on this request later
             dispatched_vehicle=vehicle.id,
-            dispatched_vehicle_time=mock_sim().sim_time
-        )
-        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle,)), request)
+            dispatched_vehicle_time=mock_sim().sim_time)
+        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle, )), request)
         self.assertIsNone(e1, "test invariant failed")
         env = mock_env()
         route = ()  # vehicle is at the request
@@ -898,14 +829,17 @@ class TestVehicleState(TestCase):
 
         updated_vehicle = sim_updated.vehicles.get(vehicle.id)
         updated_request = sim_updated.requests.get(request.id)
-        self.assertIsInstance(updated_vehicle.vehicle_state, ServicingTrip, "vehicle should be in ServicingTrip state")
-        self.assertEquals(request, updated_vehicle.vehicle_state.request, "passengers not picked up")
-        self.assertIsNone(updated_request, "request should no longer exist as it has been picked up")
+        self.assertIsInstance(updated_vehicle.vehicle_state, ServicingTrip,
+                              "vehicle should be in ServicingTrip state")
+        self.assertEquals(request, updated_vehicle.vehicle_state.request,
+                          "passengers not picked up")
+        self.assertIsNone(updated_request,
+                          "request should no longer exist as it has been picked up")
 
     def test_dispatch_trip_enter_no_request(self):
         vehicle = mock_vehicle()
         request = mock_request()
-        sim = mock_sim(vehicles=(vehicle,))  # request not added to sim
+        sim = mock_sim(vehicles=(vehicle, ))  # request not added to sim
         env = mock_env()
         route = mock_route_from_geoids(vehicle.geoid, request.geoid)
 
@@ -931,7 +865,7 @@ class TestVehicleState(TestCase):
         omf_brewing = h3.geo_to_h3(39.7608873, -104.9845391, 15)
         vehicle = mock_vehicle()
         request = mock_request()
-        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle,)), request)
+        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle, )), request)
         self.assertIsNone(e1, "test invariant failed")
         env = mock_env()
         route = mock_route_from_geoids(omf_brewing, request.geoid)
@@ -946,7 +880,7 @@ class TestVehicleState(TestCase):
         omf_brewing = h3.geo_to_h3(39.7608873, -104.9845391, 15)
         vehicle = mock_vehicle()
         request = mock_request()
-        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle,)), request)
+        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle, )), request)
         self.assertIsNone(e1, "test invariant failed")
         env = mock_env()
         route = mock_route_from_geoids(vehicle.geoid, omf_brewing)
@@ -964,7 +898,7 @@ class TestVehicleState(TestCase):
         # should intially not be in an Idle state
         vehicle = mock_vehicle().modify_vehicle_state(
             DispatchBase(DefaultIds.mock_vehicle_id(), DefaultIds.mock_base_id(), ()))
-        sim = mock_sim(vehicles=(vehicle,))
+        sim = mock_sim(vehicles=(vehicle, ))
         env = mock_env()
 
         state = Idle(vehicle.id)
@@ -973,13 +907,14 @@ class TestVehicleState(TestCase):
         self.assertIsNone(error, "should have no errors")
 
         updated_vehicle = updated_sim.vehicles.get(vehicle.id)
-        self.assertIsInstance(updated_vehicle.vehicle_state, Idle, "should be in an idle to request state")
+        self.assertIsInstance(updated_vehicle.vehicle_state, Idle,
+                              "should be in an idle to request state")
 
     def test_idle_exit(self):
         # should intially not be in an Idle state
         vehicle = mock_vehicle().modify_vehicle_state(
             DispatchBase(DefaultIds.mock_vehicle_id(), DefaultIds.mock_base_id(), ()))
-        sim = mock_sim(vehicles=(vehicle,))
+        sim = mock_sim(vehicles=(vehicle, ))
         env = mock_env()
 
         state = Idle(vehicle.id)
@@ -996,7 +931,7 @@ class TestVehicleState(TestCase):
         # should intially not be in an Idle state
         vehicle = mock_vehicle().modify_vehicle_state(
             DispatchBase(DefaultIds.mock_vehicle_id(), DefaultIds.mock_base_id(), ()))
-        sim = mock_sim(vehicles=(vehicle,))
+        sim = mock_sim(vehicles=(vehicle, ))
         env = mock_env()
 
         state = Idle(vehicle.id)
@@ -1008,21 +943,21 @@ class TestVehicleState(TestCase):
 
         updated_vehicle = sim_updated.vehicles.get(vehicle.id)
         self.assertEqual(vehicle.geoid, updated_vehicle.geoid, "should not have moved")
-        self.assertIsInstance(updated_vehicle.vehicle_state, Idle, "should still be in an Idle state")
+        self.assertIsInstance(updated_vehicle.vehicle_state, Idle,
+                              "should still be in an Idle state")
         self.assertLess(
             updated_vehicle.energy[EnergyType.ELECTRIC],
             vehicle.energy[EnergyType.ELECTRIC],
             "should have less energy",
         )
         self.assertEqual(updated_vehicle.vehicle_state.idle_duration,
-                         sim.sim_timestep_duration_seconds,
-                         "should have recorded the idle time")
+                         sim.sim_timestep_duration_seconds, "should have recorded the idle time")
 
     def test_idle_update_terminal(self):
         initial_soc = 0.0
         ititial_state = DispatchBase(DefaultIds.mock_vehicle_id(), DefaultIds.mock_base_id(), ())
         vehicle = mock_vehicle(soc=initial_soc).modify_vehicle_state(ititial_state)
-        sim = mock_sim(vehicles=(vehicle,))
+        sim = mock_sim(vehicles=(vehicle, ))
         env = mock_env()
 
         state = Idle(vehicle.id)
@@ -1034,7 +969,8 @@ class TestVehicleState(TestCase):
 
         updated_vehicle = sim_updated.vehicles.get(vehicle.id)
         is_empty = env.mechatronics.get(updated_vehicle.mechatronics_id).is_empty(updated_vehicle)
-        self.assertIsInstance(updated_vehicle.vehicle_state, OutOfService, "vehicle should be OutOfService")
+        self.assertIsInstance(updated_vehicle.vehicle_state, OutOfService,
+                              "vehicle should be OutOfService")
         self.assertTrue(is_empty, "vehicle should have no energy")
 
     ####################################################################################################################
@@ -1044,7 +980,7 @@ class TestVehicleState(TestCase):
     def test_out_of_service_enter(self):
         # should intially not be in an Idle state
         vehicle = mock_vehicle(soc=0.0)
-        sim = mock_sim(vehicles=(vehicle,))
+        sim = mock_sim(vehicles=(vehicle, ))
         env = mock_env()
 
         state = OutOfService(vehicle.id)
@@ -1053,12 +989,13 @@ class TestVehicleState(TestCase):
         self.assertIsNone(error, "should have no errors")
 
         updated_vehicle = updated_sim.vehicles.get(vehicle.id)
-        self.assertIsInstance(updated_vehicle.vehicle_state, OutOfService, "should be in an OutOfService state")
+        self.assertIsInstance(updated_vehicle.vehicle_state, OutOfService,
+                              "should be in an OutOfService state")
 
     def test_out_of_service_exit(self):
         # should intially not be in an Idle state
         vehicle = mock_vehicle(soc=0.0)
-        sim = mock_sim(vehicles=(vehicle,))
+        sim = mock_sim(vehicles=(vehicle, ))
         env = mock_env()
 
         state = OutOfService(vehicle.id)
@@ -1074,7 +1011,7 @@ class TestVehicleState(TestCase):
     def test_out_of_service_update(self):
         # should intially not be in an Idle state
         vehicle = mock_vehicle(soc=0.0)
-        sim = mock_sim(vehicles=(vehicle,))
+        sim = mock_sim(vehicles=(vehicle, ))
         env = mock_env()
 
         state = OutOfService(vehicle.id)
@@ -1086,7 +1023,8 @@ class TestVehicleState(TestCase):
 
         updated_vehicle = updated_sim.vehicles.get(vehicle.id)
         self.assertEqual(vehicle.geoid, updated_vehicle.geoid, "should not have moved")
-        self.assertIsInstance(updated_vehicle.vehicle_state, OutOfService, "should still be in an OutOfService state")
+        self.assertIsInstance(updated_vehicle.vehicle_state, OutOfService,
+                              "should still be in an OutOfService state")
         self.assertEqual(
             updated_vehicle.energy[EnergyType.ELECTRIC],
             vehicle.energy[EnergyType.ELECTRIC],
@@ -1101,9 +1039,7 @@ class TestVehicleState(TestCase):
 
     def test_repositioning_enter(self):
         vehicle = mock_vehicle()
-        sim = mock_sim(
-            vehicles=(vehicle,),
-        )
+        sim = mock_sim(vehicles=(vehicle, ), )
         env = mock_env()
         route = mock_route_from_geoids(vehicle.geoid, vehicle.geoid)
 
@@ -1113,14 +1049,13 @@ class TestVehicleState(TestCase):
         self.assertIsNone(error, "should have no errors")
 
         updated_vehicle = updated_sim.vehicles.get(vehicle.id)
-        self.assertIsInstance(updated_vehicle.vehicle_state, Repositioning, "should be in a repositioning state")
+        self.assertIsInstance(updated_vehicle.vehicle_state, Repositioning,
+                              "should be in a repositioning state")
         self.assertEquals(len(updated_vehicle.vehicle_state.route), 1, "should have a route")
 
     def test_repositioning_exit(self):
         vehicle = mock_vehicle()
-        sim = mock_sim(
-            vehicles=(vehicle,),
-        )
+        sim = mock_sim(vehicles=(vehicle, ), )
         env = mock_env()
         route = mock_route_from_geoids(vehicle.geoid, vehicle.geoid)
 
@@ -1138,9 +1073,7 @@ class TestVehicleState(TestCase):
         near = h3.geo_to_h3(39.7539, -104.974, 15)
         omf_brewing = h3.geo_to_h3(39.7608873, -104.9845391, 15)
         vehicle = mock_vehicle()
-        sim = mock_sim(
-            vehicles=(vehicle,),
-        )
+        sim = mock_sim(vehicles=(vehicle, ), )
         env = mock_env()
         route = mock_route_from_geoids(near, omf_brewing)
 
@@ -1153,7 +1086,8 @@ class TestVehicleState(TestCase):
 
         updated_vehicle = sim_updated.vehicles.get(vehicle.id)
         self.assertNotEqual(vehicle.geoid, updated_vehicle.geoid, "should have moved")
-        self.assertIsInstance(updated_vehicle.vehicle_state, Repositioning, "should still be in a Repositioning state")
+        self.assertIsInstance(updated_vehicle.vehicle_state, Repositioning,
+                              "should still be in a Repositioning state")
         self.assertLess(
             updated_vehicle.energy[EnergyType.ELECTRIC],
             vehicle.energy[EnergyType.ELECTRIC],
@@ -1162,9 +1096,7 @@ class TestVehicleState(TestCase):
 
     def test_repositioning_update_terminal(self):
         vehicle = mock_vehicle()
-        sim = mock_sim(
-            vehicles=(vehicle,),
-        )
+        sim = mock_sim(vehicles=(vehicle, ), )
         env = mock_env()
         route = ()
 
@@ -1177,7 +1109,8 @@ class TestVehicleState(TestCase):
         self.assertIsNone(update_error, "should have no error from update call")
 
         updated_vehicle = sim_updated.vehicles.get(vehicle.id)
-        self.assertIsInstance(updated_vehicle.vehicle_state, Idle, "vehicle should be in Idle state")
+        self.assertIsInstance(updated_vehicle.vehicle_state, Idle,
+                              "vehicle should be in Idle state")
 
     def test_repositioning_enter_no_vehicle(self):
         vehicle = mock_vehicle()
@@ -1193,7 +1126,7 @@ class TestVehicleState(TestCase):
     def test_repositioning_enter_route_with_bad_source(self):
         omf_brewing = h3.geo_to_h3(39.7608873, -104.9845391, 15)
         vehicle = mock_vehicle()
-        sim = mock_sim(vehicles=(vehicle,))
+        sim = mock_sim(vehicles=(vehicle, ))
         env = mock_env()
         route = mock_route_from_geoids(omf_brewing, vehicle.geoid)
 
@@ -1211,7 +1144,7 @@ class TestVehicleState(TestCase):
     def test_reserve_base_enter(self):
         vehicle = mock_vehicle()
         base = mock_base()
-        sim = mock_sim(vehicles=(vehicle,), bases=(base,))
+        sim = mock_sim(vehicles=(vehicle, ), bases=(base, ))
         env = mock_env()
 
         state = ReserveBase(vehicle.id, base.id)
@@ -1221,14 +1154,15 @@ class TestVehicleState(TestCase):
 
         updated_vehicle = updated_sim.vehicles.get(vehicle.id)
         updated_base = updated_sim.bases.get(base.id)
-        self.assertIsInstance(updated_vehicle.vehicle_state, ReserveBase, "should be in an ReserveBase state")
+        self.assertIsInstance(updated_vehicle.vehicle_state, ReserveBase,
+                              "should be in an ReserveBase state")
         self.assertEqual(updated_base.available_stalls, 0, "only stall should now be occupied")
 
     def test_reserve_base_bad_membership(self):
         vehicle = mock_vehicle(membership=Membership.single_membership("uber"))
         base = mock_base(membership=Membership.single_membership("lyft"))
 
-        sim = mock_sim(vehicles=(vehicle,), bases=(base,))
+        sim = mock_sim(vehicles=(vehicle, ), bases=(base, ))
         env = mock_env()
 
         state = ReserveBase(vehicle.id, base.id)
@@ -1239,14 +1173,15 @@ class TestVehicleState(TestCase):
     def test_reserve_base_exit(self):
         vehicle = mock_vehicle()
         base = mock_base()
-        sim = mock_sim(vehicles=(vehicle,), bases=(base,))
+        sim = mock_sim(vehicles=(vehicle, ), bases=(base, ))
         env = mock_env()
 
         state = ReserveBase(vehicle.id, base.id)
         enter_error, entered_sim = state.enter(sim, env)
         entered_base = entered_sim.bases.get(base.id)
         self.assertIsNone(enter_error, "test precondition (enter works correctly) not met")
-        self.assertEqual(entered_base.available_stalls, 0, "test precondition (stall in use) not met")
+        self.assertEqual(entered_base.available_stalls, 0,
+                         "test precondition (stall in use) not met")
 
         # begin test
         error, exited_sim = state.exit(Idle(vehicle.id), entered_sim, env)
@@ -1258,7 +1193,7 @@ class TestVehicleState(TestCase):
     def test_reserve_base_update(self):
         vehicle = mock_vehicle()
         base = mock_base()
-        sim = mock_sim(vehicles=(vehicle,), bases=(base,))
+        sim = mock_sim(vehicles=(vehicle, ), bases=(base, ))
         env = mock_env()
 
         state = ReserveBase(vehicle.id, base.id)
@@ -1270,7 +1205,8 @@ class TestVehicleState(TestCase):
 
         updated_vehicle = updated_sim.vehicles.get(vehicle.id)
         self.assertEqual(vehicle.geoid, updated_vehicle.geoid, "should not have moved")
-        self.assertIsInstance(updated_vehicle.vehicle_state, ReserveBase, "should still be in a ReserveBase state")
+        self.assertIsInstance(updated_vehicle.vehicle_state, ReserveBase,
+                              "should still be in a ReserveBase state")
         self.assertEqual(
             updated_vehicle.energy[EnergyType.ELECTRIC],
             vehicle.energy[EnergyType.ELECTRIC],
@@ -1279,9 +1215,7 @@ class TestVehicleState(TestCase):
 
     def test_reserve_base_enter_no_base(self):
         vehicle = mock_vehicle()
-        sim = mock_sim(
-            vehicles=(vehicle,),
-        )
+        sim = mock_sim(vehicles=(vehicle, ), )
         env = mock_env()
         route = ()
 
@@ -1291,9 +1225,7 @@ class TestVehicleState(TestCase):
 
     def test_reserve_base_enter_no_vehicle(self):
         base = mock_base()
-        sim = mock_sim(
-            bases=(base,),
-        )
+        sim = mock_sim(bases=(base, ), )
         env = mock_env()
         route = ()
 
@@ -1304,13 +1236,15 @@ class TestVehicleState(TestCase):
     def test_reserve_base_no_stalls_available(self):
         vehicle = mock_vehicle()
         base = mock_base(stall_count=0)
-        sim = mock_sim(vehicles=(vehicle,), bases=(base,))
+        sim = mock_sim(vehicles=(vehicle, ), bases=(base, ))
         env = mock_env()
 
         state = ReserveBase(vehicle.id, base.id)
         enter_error, entered_sim = state.enter(sim, env)
-        self.assertIsNone(enter_error, "no stall failure should not result in an exception (fail silently)")
-        self.assertIsNone(entered_sim, "no stall failure should result in no SimulationState result")
+        self.assertIsNone(enter_error,
+                          "no stall failure should not result in an exception (fail silently)")
+        self.assertIsNone(entered_sim,
+                          "no stall failure should result in no SimulationState result")
 
     # def test_reserve_base_update_terminal(self):  # there is no terminal state for OutOfService
 
@@ -1322,7 +1256,7 @@ class TestVehicleState(TestCase):
         prev_state = DispatchTrip(DefaultIds.mock_vehicle_id(), DefaultIds.mock_request_id(), ())
         vehicle = mock_vehicle(vehicle_state=prev_state)
         request = mock_request_from_geoids(origin=vehicle.geoid)
-        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle,)), request)
+        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle, )), request)
         self.assertIsNone(e1, "test invariant failed")
         env = mock_env()
         route = mock_route_from_geoids(vehicle.geoid, request.destination)
@@ -1333,14 +1267,15 @@ class TestVehicleState(TestCase):
         self.assertIsNone(error, "should have no errors")
 
         updated_vehicle = updated_sim.vehicles.get(vehicle.id)
-        self.assertIsInstance(updated_vehicle.vehicle_state, ServicingTrip, "should be in a ServicingTrip state")
+        self.assertIsInstance(updated_vehicle.vehicle_state, ServicingTrip,
+                              "should be in a ServicingTrip state")
         self.assertEquals(len(updated_vehicle.vehicle_state.route), 1, "should have a route")
 
     def test_servicing_trip_bad_membership(self):
         vehicle = mock_vehicle(membership=Membership.single_membership("uber"))
         request = mock_request(fleet_id="lyft")
 
-        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle,)), request)
+        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle, )), request)
         self.assertIsNone(e1, "test invariant failed")
         env = mock_env()
         route = mock_route_from_geoids(vehicle.geoid, request.destination)
@@ -1354,7 +1289,7 @@ class TestVehicleState(TestCase):
         prev_state = DispatchTrip(DefaultIds.mock_vehicle_id(), DefaultIds.mock_request_id(), ())
         vehicle = mock_vehicle(vehicle_state=prev_state)
         request = mock_request_from_geoids(destination=vehicle.geoid)
-        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle,)), request)
+        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle, )), request)
         self.assertIsNone(e1, "test invariant failed")
         env = mock_env()
         route = mock_route_from_geoids(request.origin, request.destination)
@@ -1366,14 +1301,15 @@ class TestVehicleState(TestCase):
         # begin test
         error, exited_sim = state.exit(Idle(vehicle.id), entered_sim, env)
 
-        self.assertIsNone(error, "should have no errors")  # errors due to passengers not being at destination
+        self.assertIsNone(
+            error, "should have no errors")  # errors due to passengers not being at destination
 
     def test_servicing_trip_exit_when_still_has_passengers(self):
         prev_state = DispatchTrip(DefaultIds.mock_vehicle_id(), DefaultIds.mock_request_id(), ())
         vehicle = mock_vehicle(vehicle_state=prev_state)
         request = mock_request_from_geoids()
         self.assertNotEqual(request.origin, request.destination, "test invariant failed")
-        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle,)), request)
+        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle, )), request)
 
         self.assertIsNone(e1, "test invariant failed")
         env = mock_env()
@@ -1386,7 +1322,8 @@ class TestVehicleState(TestCase):
         # begin test
         error, exited_sim = state.exit(Idle(vehicle.id), entered_sim, env)
 
-        self.assertIsNone(error, "should have no errors")  # errors due to passengers not being at destination
+        self.assertIsNone(
+            error, "should have no errors")  # errors due to passengers not being at destination
         self.assertIsNone(exited_sim, "should not have allowed exit of ServicingTrip")
 
     def test_servicing_trip_exit_when_still_has_passengers_but_out_of_fuel(self):
@@ -1394,7 +1331,7 @@ class TestVehicleState(TestCase):
         vehicle = mock_vehicle(soc=0, vehicle_state=prev_state)
         request = mock_request_from_geoids()
         self.assertNotEqual(request.origin, request.destination, "test invariant failed")
-        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle,)), request)
+        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle, )), request)
 
         self.assertIsNone(e1, "test invariant failed")
         env = mock_env()
@@ -1408,8 +1345,10 @@ class TestVehicleState(TestCase):
         error, updated_sim = state.update(entered_sim, env)
 
         updated_vehicle = updated_sim.vehicles.get(vehicle.id)
-        self.assertIsNone(error, "should have no errors")  # errors due to passengers not being at destination
-        self.assertIsInstance(updated_vehicle.vehicle_state, OutOfService, "vehicle should be out of service")
+        self.assertIsNone(
+            error, "should have no errors")  # errors due to passengers not being at destination
+        self.assertIsInstance(updated_vehicle.vehicle_state, OutOfService,
+                              "vehicle should be out of service")
         # self.assertIsNotNone(updated_sim,
         #                      "should have allowed exit of ServicingTrip because out of fuel allows transition to OutOfService")
 
@@ -1419,7 +1358,7 @@ class TestVehicleState(TestCase):
         prev_state = DispatchTrip(DefaultIds.mock_vehicle_id(), DefaultIds.mock_request_id(), ())
         vehicle = mock_vehicle_from_geoid(geoid=near, vehicle_state=prev_state)
         request = mock_request_from_geoids(origin=near, destination=omf_brewing)
-        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle,)), request)
+        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle, )), request)
         self.assertIsNone(e1, "test invariant failed")
         env = mock_env()
         route = mock_route_from_geoids(near, omf_brewing)
@@ -1433,7 +1372,8 @@ class TestVehicleState(TestCase):
 
         updated_vehicle = sim_updated.vehicles.get(vehicle.id)
         self.assertNotEqual(vehicle.geoid, updated_vehicle.geoid, "should have moved")
-        self.assertIsInstance(updated_vehicle.vehicle_state, ServicingTrip, "should still be in a servicing state")
+        self.assertIsInstance(updated_vehicle.vehicle_state, ServicingTrip,
+                              "should still be in a servicing state")
         self.assertLess(
             updated_vehicle.energy[EnergyType.ELECTRIC],
             vehicle.energy[EnergyType.ELECTRIC],
@@ -1445,7 +1385,7 @@ class TestVehicleState(TestCase):
         prev_state = DispatchTrip(DefaultIds.mock_vehicle_id(), DefaultIds.mock_request_id(), ())
         vehicle = mock_vehicle(vehicle_state=prev_state)
         request = mock_request_from_geoids(origin=vehicle.geoid, destination=vehicle.geoid)
-        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle,)), request)
+        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle, )), request)
         self.assertIsNone(e1, "test invariant failed")
         env = mock_env()
         route = ()  # end of route
@@ -1458,12 +1398,13 @@ class TestVehicleState(TestCase):
         self.assertIsNone(update_error, "should have no error from update call")
 
         updated_vehicle = sim_updated.vehicles.get(vehicle.id)
-        self.assertIsInstance(updated_vehicle.vehicle_state, Idle, "vehicle should be in Idle state")
+        self.assertIsInstance(updated_vehicle.vehicle_state, Idle,
+                              "vehicle should be in Idle state")
 
     def test_servicing_trip_enter_no_request(self):
         vehicle = mock_vehicle()
         request = mock_request()
-        e0, sim_with_req = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle,)), request)
+        e0, sim_with_req = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle, )), request)
         self.assertIsNone(e0, "test invariant failed")
 
         env = mock_env()
@@ -1499,7 +1440,7 @@ class TestVehicleState(TestCase):
         prev_state = DispatchTrip(DefaultIds.mock_vehicle_id(), DefaultIds.mock_request_id(), ())
         vehicle = mock_vehicle(vehicle_state=prev_state)
         request = mock_request()
-        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle,)), request)
+        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle, )), request)
         self.assertIsNone(e1, "test invariant failed")
         env = mock_env()
         route = mock_route_from_geoids(omf_brewing, request.destination)
@@ -1514,10 +1455,11 @@ class TestVehicleState(TestCase):
         prev_state = DispatchTrip(DefaultIds.mock_vehicle_id(), DefaultIds.mock_request_id(), ())
         vehicle = mock_vehicle_from_geoid(vehicle_state=prev_state)
         request = mock_request_from_geoids(origin=vehicle.geoid)
-        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle,)), request)
+        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle, )), request)
         self.assertIsNone(e1, "test invariant failed")
         env = mock_env()
-        route = mock_route_from_geoids(vehicle.geoid, omf_brewing)  # request.destination should not be omf brewing co
+        route = mock_route_from_geoids(
+            vehicle.geoid, omf_brewing)  # request.destination should not be omf brewing co
 
         state = ServicingTrip(vehicle.id, request, sim.sim_time, route)
         enter_error, enter_sim = state.enter(sim, env)
@@ -1530,7 +1472,7 @@ class TestVehicleState(TestCase):
     def test_charge_queueing_enter(self):
         vehicle = mock_vehicle_from_geoid()
         station = mock_station_from_geoid(chargers={})
-        sim = mock_sim(vehicles=(vehicle,), stations=(station,))
+        sim = mock_sim(vehicles=(vehicle, ), stations=(station, ))
         env = mock_env()
 
         state = ChargeQueueing(vehicle.id, station.id, mock_dcfc_charger_id(), 0)
@@ -1541,12 +1483,13 @@ class TestVehicleState(TestCase):
 
         self.assertIsNone(error, "should have no errors")
         self.assertIsNotNone(updated_sim, "the sim should have been updated")
-        self.assertEqual(enqueued_count, 1, "the station should also know 1 new vehicle is enqueued")
+        self.assertEqual(enqueued_count, 1,
+                         "the station should also know 1 new vehicle is enqueued")
 
     def test_charge_queueing_exit(self):
         vehicle = mock_vehicle_from_geoid()
         station = mock_station_from_geoid(chargers={})
-        sim0 = mock_sim(vehicles=(vehicle,), stations=(station,))
+        sim0 = mock_sim(vehicles=(vehicle, ), stations=(station, ))
         env = mock_env()
 
         state = ChargeQueueing(vehicle.id, station.id, mock_dcfc_charger_id(), 0)
@@ -1568,7 +1511,10 @@ class TestVehicleState(TestCase):
         vehicle_charging = mock_vehicle_from_geoid(vehicle_id="charging")
         vehicle_queueing = mock_vehicle_from_geoid(vehicle_id="queueing")
         station = mock_station_from_geoid()
-        sim0 = mock_sim(vehicles=(vehicle_charging, vehicle_queueing,), stations=(station,))
+        sim0 = mock_sim(vehicles=(
+            vehicle_charging,
+            vehicle_queueing,
+        ), stations=(station, ))
         env = mock_env()
 
         charging_state = ChargingStation(vehicle_charging.id, station.id, mock_dcfc_charger_id())
@@ -1599,7 +1545,10 @@ class TestVehicleState(TestCase):
         vehicle_charging = mock_vehicle_from_geoid()
         vehicle_queueing = mock_vehicle_from_geoid()
         station = mock_station_from_geoid()
-        sim1 = mock_sim(vehicles=(vehicle_charging, vehicle_queueing,), stations=(station,))
+        sim1 = mock_sim(vehicles=(
+            vehicle_charging,
+            vehicle_queueing,
+        ), stations=(station, ))
         env = mock_env()
 
         charging_state = ChargingStation(vehicle_charging.id, station.id, mock_dcfc_charger_id())
@@ -1616,7 +1565,7 @@ class TestVehicleState(TestCase):
 
     def test_charge_queueing_enter_no_vehicle(self):
         station = mock_station_from_geoid()
-        sim = mock_sim(stations=(station,))
+        sim = mock_sim(stations=(station, ))
         env = mock_env()
 
         state = ChargeQueueing(DefaultIds.mock_vehicle_id(), station.id, mock_dcfc_charger_id(), 0)
@@ -1627,7 +1576,7 @@ class TestVehicleState(TestCase):
     def test_charge_queueing_enter_when_station_has_charger_available(self):
         vehicle_queueing = mock_vehicle_from_geoid()
         station = mock_station_from_geoid()
-        sim1 = mock_sim(vehicles=(vehicle_queueing,), stations=(station,))
+        sim1 = mock_sim(vehicles=(vehicle_queueing, ), stations=(station, ))
         env = mock_env()
 
         state = ChargeQueueing(vehicle_queueing.id, station.id, mock_dcfc_charger_id(), 0)
@@ -1643,7 +1592,7 @@ class TestVehicleState(TestCase):
     def test_dispatch_pooling_trip_enter(self):
         vehicle = mock_vehicle()
         request = mock_request()
-        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle,)), request)
+        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle, )), request)
         self.assertIsNone(e1, "test invariant failed")
         env = mock_env()
         route = mock_route_from_geoids(vehicle.geoid, request.geoid)
@@ -1656,15 +1605,17 @@ class TestVehicleState(TestCase):
 
         updated_vehicle = updated_sim.vehicles.get(vehicle.id)
         updated_request = updated_sim.requests.get(request.id)
-        self.assertIsInstance(updated_vehicle.vehicle_state, DispatchPoolingTrip, "should be in a dispatch to request state")
-        self.assertEquals(updated_request.dispatched_vehicle, vehicle.id, "request should be assigned this vehicle")
+        self.assertIsInstance(updated_vehicle.vehicle_state, DispatchPoolingTrip,
+                              "should be in a dispatch to request state")
+        self.assertEquals(updated_request.dispatched_vehicle, vehicle.id,
+                          "request should be assigned this vehicle")
         self.assertEquals(len(updated_vehicle.vehicle_state.route), 1, "should have a route")
 
     def test_dispatch_pooling_trip_enter_two_requests(self):
         vehicle = mock_vehicle()
         r1 = mock_request('r1', 39.70, -104.97, 39.85, -104.97)  # pickup 1, dropoff 2
         r2 = mock_request('r2', 39.75, -104.97, 39.80, -104.97)  # pickup 2, dropoff 1
-        s0 = mock_sim(vehicles=(vehicle,))
+        s0 = mock_sim(vehicles=(vehicle, ))
         env = mock_env()
         e1, s1 = simulation_state_ops.add_request(s0, r1)
         e2, s2 = simulation_state_ops.add_request(s1, r2)
@@ -1673,7 +1624,8 @@ class TestVehicleState(TestCase):
         self.assertIsNone(e2, "test invariant failed")
 
         route = mock_route_from_geoids(vehicle.geoid, r1.geoid)
-        trip_plan = ((r1.id, TripPhase.PICKUP), (r2.id, TripPhase.PICKUP), (r2.id, TripPhase.DROPOFF), (r1.id, TripPhase.DROPOFF))
+        trip_plan = ((r1.id, TripPhase.PICKUP), (r2.id, TripPhase.PICKUP),
+                     (r2.id, TripPhase.DROPOFF), (r1.id, TripPhase.DROPOFF))
 
         state = DispatchPoolingTrip(vehicle.id, trip_plan, route)
         error, updated_sim = state.enter(s2, env)
@@ -1683,15 +1635,18 @@ class TestVehicleState(TestCase):
         updated_vehicle = updated_sim.vehicles.get(vehicle.id)
         updated_r1 = updated_sim.requests.get(r1.id)
         updated_r2 = updated_sim.requests.get(r2.id)
-        self.assertIsInstance(updated_vehicle.vehicle_state, DispatchPoolingTrip, "should be in a dispatch to request state")
-        self.assertEquals(updated_r1.dispatched_vehicle, vehicle.id, "r1 should be assigned this vehicle")
-        self.assertEquals(updated_r2.dispatched_vehicle, vehicle.id, "r2 should be assigned this vehicle")
+        self.assertIsInstance(updated_vehicle.vehicle_state, DispatchPoolingTrip,
+                              "should be in a dispatch to request state")
+        self.assertEquals(updated_r1.dispatched_vehicle, vehicle.id,
+                          "r1 should be assigned this vehicle")
+        self.assertEquals(updated_r2.dispatched_vehicle, vehicle.id,
+                          "r2 should be assigned this vehicle")
         self.assertEquals(len(updated_vehicle.vehicle_state.route), 1, "should have a route")
 
     def test_dispatch_pooling_trip_bad_membership(self):
         vehicle = mock_vehicle(membership=Membership.single_membership("uber"))
         request = mock_request(fleet_id="lyft")
-        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle,)), request)
+        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle, )), request)
         self.assertIsNone(e1, "test invariant failed")
         env = mock_env()
         route = mock_route_from_geoids(vehicle.geoid, request.geoid)
@@ -1705,7 +1660,7 @@ class TestVehicleState(TestCase):
     def test_dispatch_pooling_trip_exit(self):
         vehicle = mock_vehicle()
         request = mock_request()
-        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle,)), request)
+        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle, )), request)
         self.assertIsNone(e1, "test invariant failed")
         env = mock_env()
         route = mock_route_from_geoids(vehicle.geoid, request.geoid)
@@ -1714,20 +1669,24 @@ class TestVehicleState(TestCase):
         state = DispatchPoolingTrip(vehicle.id, trip_plan, route)
         enter_error, entered_sim = state.enter(sim, env)
         self.assertIsNone(enter_error, "test precondition (enter works correctly) not met")
-        self.assertTrue(entered_sim.requests.get(request.id).dispatched_vehicle == vehicle.id, "test precondition not met")
+        self.assertTrue(
+            entered_sim.requests.get(request.id).dispatched_vehicle == vehicle.id,
+            "test precondition not met")
 
         # begin test
         error, exited_sim = state.exit(Idle(vehicle.id), entered_sim, env)
 
         self.assertIsNone(error, "should have no errors")
-        self.assertIsNone(exited_sim.requests.get(request.id).dispatched_vehicle, "should have unset the dispatched vehicle")
+        self.assertIsNone(
+            exited_sim.requests.get(request.id).dispatched_vehicle,
+            "should have unset the dispatched vehicle")
 
     def test_dispatch_pooling_trip_update(self):
         near = h3.geo_to_h3(39.7539, -104.974, 15)
         far = h3.geo_to_h3(39.7608873, -104.9845391, 15)
         vehicle = mock_vehicle_from_geoid(geoid=near)
         request = mock_request_from_geoids(origin=far)
-        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle,)), request)
+        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle, )), request)
         self.assertIsNone(e1, "test invariant failed")
         env = mock_env()
         route = mock_route_from_geoids(near, far)
@@ -1753,7 +1712,7 @@ class TestVehicleState(TestCase):
     def test_dispatch_pooling_trip_update_terminal(self):
         vehicle = mock_vehicle_from_geoid(geoid="8f268cdac30e2d3")
         request = mock_request_from_geoids(origin="8f268cdac30e2d3", destination="8f268cdac70e2d3")
-        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle,)), request)
+        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle, )), request)
         self.assertIsNone(e1, "test invariant failed")
         env = mock_env()
         route = ()  # vehicle is at the request
@@ -1769,15 +1728,21 @@ class TestVehicleState(TestCase):
         updated_vehicle = sim_updated.vehicles.get(vehicle.id)
         updated_request = sim_updated.requests.get(request.id)
         boarded_request = updated_vehicle.vehicle_state.boarded_requests.get(request.id)
-        self.assertIsInstance(updated_vehicle.vehicle_state, ServicingPoolingTrip, "vehicle should be in ServicingPoolingTrip state")
-        self.assertIsNone(updated_request, "request should no longer exist as it has been picked up")
-        self.assertIsNotNone(boarded_request, f"request {request.id} should have boarded the vehicle")
-        self.assertEquals(boarded_request.id, request.id, f"request {request.id} should have boarded the vehicle, found {boarded_request.id} instead")
+        self.assertIsInstance(updated_vehicle.vehicle_state, ServicingPoolingTrip,
+                              "vehicle should be in ServicingPoolingTrip state")
+        self.assertIsNone(updated_request,
+                          "request should no longer exist as it has been picked up")
+        self.assertIsNotNone(boarded_request,
+                             f"request {request.id} should have boarded the vehicle")
+        self.assertEquals(
+            boarded_request.id, request.id,
+            f"request {request.id} should have boarded the vehicle, found {boarded_request.id} instead"
+        )
 
     def test_dispatch_pooling_trip_enter_no_request(self):
         vehicle = mock_vehicle()
         request = mock_request()
-        sim = mock_sim(vehicles=(vehicle,))  # request not added to sim
+        sim = mock_sim(vehicles=(vehicle, ))  # request not added to sim
         env = mock_env()
         route = mock_route_from_geoids(vehicle.geoid, request.geoid)
 
@@ -1803,7 +1768,7 @@ class TestVehicleState(TestCase):
         omf_brewing = h3.geo_to_h3(39.7608873, -104.9845391, 15)
         vehicle = mock_vehicle()
         request = mock_request()
-        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle,)), request)
+        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle, )), request)
         self.assertIsNone(e1, "test invariant failed")
         env = mock_env()
         route = mock_route_from_geoids(omf_brewing, request.geoid)
@@ -1818,7 +1783,7 @@ class TestVehicleState(TestCase):
         omf_brewing = h3.geo_to_h3(39.7608873, -104.9845391, 15)
         vehicle = mock_vehicle()
         request = mock_request()
-        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle,)), request)
+        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle, )), request)
         self.assertIsNone(e1, "test invariant failed")
         env = mock_env()
         route = mock_route_from_geoids(vehicle.geoid, omf_brewing)
@@ -1835,7 +1800,7 @@ class TestVehicleState(TestCase):
     def test_servicing_pooling_trip_enter(self):
         vehicle = mock_vehicle()
         request = mock_request()
-        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle,)), request)
+        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle, )), request)
         self.assertIsNone(e1, "test invariant failed")
         env = mock_env()
         route = mock_route_from_geoids(vehicle.geoid, request.geoid)
@@ -1846,26 +1811,28 @@ class TestVehicleState(TestCase):
         self.assertIsNone(error, "test invariant failed")
 
         # things constructed when transitioning from DispatchPoolingTrip to ServicingPoolingTrip
-        boarded_trip_plan = ((request.id, TripPhase.DROPOFF),)
+        boarded_trip_plan = ((request.id, TripPhase.DROPOFF), )
         boarded_reqs = immutables.Map({request.id: request})
         departure_times = immutables.Map({request.id: SimTime(0)})
         route = mock_route_from_geoids(request.origin, request.destination)
-        routes = (route,)
+        routes = (route, )
 
-        next_state = ServicingPoolingTrip(vehicle.id, boarded_trip_plan, boarded_reqs, departure_times, routes, 1)
+        next_state = ServicingPoolingTrip(vehicle.id, boarded_trip_plan, boarded_reqs,
+                                          departure_times, routes, 1)
         error, updated_sim = next_state.enter(disp_sim, env)
 
         self.assertIsNone(error, "should have no errors")
 
         updated_vehicle = updated_sim.vehicles.get(vehicle.id)
-        self.assertIsInstance(updated_vehicle.vehicle_state, ServicingPoolingTrip, "should be in a ServicingPoolingTrip state")
+        self.assertIsInstance(updated_vehicle.vehicle_state, ServicingPoolingTrip,
+                              "should be in a ServicingPoolingTrip state")
         self.assertEquals(len(updated_vehicle.vehicle_state.routes), 1, "should have a route")
 
     def test_servicing_pooling_trip_update_terminal(self):
         # 3 adjacent h3 cells, total trip distance is ~ 2 meters
         vehicle = mock_vehicle_from_geoid(geoid='8f268cd9601daa1')
         request = mock_request_from_geoids(origin='8f268cd9601daac', destination='8f268cd9601da10')
-        sim0 = mock_sim(vehicles=(vehicle,), sim_timestep_duration_seconds=60)
+        sim0 = mock_sim(vehicles=(vehicle, ), sim_timestep_duration_seconds=60)
 
         # place request and vehicle in a mock simulation
         err1, sim1 = simulation_state_ops.add_request(sim0, request)
@@ -1896,7 +1863,8 @@ class TestVehicleState(TestCase):
         # test final state
         updated_vehicle = sim5.vehicles.get(vehicle.id)
         self.assertIsInstance(updated_vehicle.vehicle_state, Idle, "should be in an Idle state")
-        self.assertEqual(len(sim5.requests), 0, "request should have been picked up and dropped off fully")
+        self.assertEqual(len(sim5.requests), 0,
+                         "request should have been picked up and dropped off fully")
 
     def test_servicing_pooling_trip_update_picks_up_second_request(self):
         v0_src, r0_src, r1_src, r0_dst, r1_dst = '8f268cd9601daa1', '8f268cd9601daac', '8f268cd9601da10', '8f268cd9601da1a', '8f268cd9601da88'
@@ -1905,7 +1873,7 @@ class TestVehicleState(TestCase):
         v0 = mock_vehicle_from_geoid(geoid=v0_src)
         r0 = mock_request_from_geoids(request_id='r0', origin=r0_src, destination=r0_dst)
         r1 = mock_request_from_geoids(request_id='r1', origin=r1_src, destination=r1_dst)
-        sim0 = mock_sim(vehicles=(v0,), sim_timestep_duration_seconds=60)
+        sim0 = mock_sim(vehicles=(v0, ), sim_timestep_duration_seconds=60)
 
         # place request and vehicle in a mock simulation
         err1, sim1 = simulation_state_ops.add_request(sim0, r0)
@@ -1915,7 +1883,8 @@ class TestVehicleState(TestCase):
 
         env = mock_env()
         route = mock_route_from_geoids(v0.geoid, r0.geoid)
-        trip_plan = ((r0.id, TripPhase.PICKUP), (r1.id, TripPhase.PICKUP), (r0.id, TripPhase.DROPOFF), (r1.id, TripPhase.DROPOFF))
+        trip_plan = ((r0.id, TripPhase.PICKUP), (r1.id, TripPhase.PICKUP),
+                     (r0.id, TripPhase.DROPOFF), (r1.id, TripPhase.DROPOFF))
 
         # set vehicle to dispatch state
         prev_state = DispatchPoolingTrip(v0.id, trip_plan, route)
@@ -1935,7 +1904,8 @@ class TestVehicleState(TestCase):
         state_pooling = veh_pooling.vehicle_state
         self.assertEqual(veh_pooling.geoid, r1_src, "should be at the pickup location for r1")
         self.assertEqual(len(state_pooling.boarded_requests), 2, "should have 2 requests boarded")
-        self.assertEqual(state_pooling.trip_plan, trip_plan[2:4], "should have the correct remaining plan")
+        self.assertEqual(state_pooling.trip_plan, trip_plan[2:4],
+                         "should have the correct remaining plan")
         # todo: check state of remaining route, should be r1_src -> r0_dst, r0_dst -> r1_dst
 
     def test_servicing_pooling_trip_update_drops_off_first_request(self):
@@ -1945,7 +1915,7 @@ class TestVehicleState(TestCase):
         v0 = mock_vehicle_from_geoid(geoid=v0_src)
         r0 = mock_request_from_geoids(request_id='r0', origin=r0_src, destination=r0_dst)
         r1 = mock_request_from_geoids(request_id='r1', origin=r1_src, destination=r1_dst)
-        sim0 = mock_sim(vehicles=(v0,), sim_timestep_duration_seconds=60)
+        sim0 = mock_sim(vehicles=(v0, ), sim_timestep_duration_seconds=60)
 
         # place request and vehicle in a mock simulation
         err1, sim1 = simulation_state_ops.add_request(sim0, r0)
@@ -1955,7 +1925,8 @@ class TestVehicleState(TestCase):
 
         env = mock_env()
         route = mock_route_from_geoids(v0.geoid, r0.geoid)
-        trip_plan = ((r0.id, TripPhase.PICKUP), (r1.id, TripPhase.PICKUP), (r0.id, TripPhase.DROPOFF), (r1.id, TripPhase.DROPOFF))
+        trip_plan = ((r0.id, TripPhase.PICKUP), (r1.id, TripPhase.PICKUP),
+                     (r0.id, TripPhase.DROPOFF), (r1.id, TripPhase.DROPOFF))
 
         # set vehicle to dispatch state
         prev_state = DispatchPoolingTrip(v0.id, trip_plan, route)
@@ -1979,15 +1950,19 @@ class TestVehicleState(TestCase):
         veh_pooling = sim6.vehicles.get(v0.id)
         state_pooling = veh_pooling.vehicle_state
         self.assertEqual(veh_pooling.geoid, r0_dst, "should be at the dropoff location for r0")
-        self.assertEqual(len(state_pooling.boarded_requests), 1, "should have 1 requests still boarded")
-        self.assertIsNone(sim6.requests.get('r0'), "request 0 should have been dropped off and no longer be in the simulation")
-        self.assertEqual(state_pooling.trip_plan, trip_plan[3:4], "should have the correct remaining plan")
+        self.assertEqual(len(state_pooling.boarded_requests), 1,
+                         "should have 1 requests still boarded")
+        self.assertIsNone(
+            sim6.requests.get('r0'),
+            "request 0 should have been dropped off and no longer be in the simulation")
+        self.assertEqual(state_pooling.trip_plan, trip_plan[3:4],
+                         "should have the correct remaining plan")
         # todo: check state of remaining route, should be r0_dst -> r1_dst
 
     def test_servicing_single_pooling_trip_reaches_destination(self):
         vehicle = mock_vehicle()
         request = mock_request()
-        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle,)), request)
+        e1, sim = simulation_state_ops.add_request(mock_sim(vehicles=(vehicle, )), request)
         self.assertIsNone(e1, "test invariant failed")
         env = mock_env()
         route = mock_route_from_geoids(vehicle.geoid, request.geoid)
@@ -2000,8 +1975,10 @@ class TestVehicleState(TestCase):
 
         updated_vehicle = updated_sim.vehicles.get(vehicle.id)
         updated_request = updated_sim.requests.get(request.id)
-        self.assertIsInstance(updated_vehicle.vehicle_state, DispatchPoolingTrip, "should be in a dispatch to request state")
-        self.assertEquals(updated_request.dispatched_vehicle, vehicle.id, "request should be assigned this vehicle")
+        self.assertIsInstance(updated_vehicle.vehicle_state, DispatchPoolingTrip,
+                              "should be in a dispatch to request state")
+        self.assertEquals(updated_request.dispatched_vehicle, vehicle.id,
+                          "request should be assigned this vehicle")
         self.assertEquals(len(updated_vehicle.vehicle_state.route), 1, "should have a route")
 
     def test_servicing_pooling_trip_exit(self):

--- a/tests/test_vehicle_state_ops.py
+++ b/tests/test_vehicle_state_ops.py
@@ -5,7 +5,6 @@ from hive.resources.mock_lobster import *
 
 
 class TestVehicleStateOps(TestCase):
-
     def test_move(self):
         somewhere = h3.geo_to_h3(39.7539, -104.974, 15)
         somewhere_else = h3.geo_to_h3(39.7579, -104.978, 15)
@@ -32,20 +31,20 @@ class TestVehicleStateOps(TestCase):
 
         self.assertLess(soc, 1, "should have used 1 unit of mock energy")
         self.assertNotEqual(somewhere, moved_vehicle.geoid, "should not be at the same location")
-        self.assertNotEqual(somewhere, moved_vehicle.position.geoid, "link start location should not be the same")
+        self.assertNotEqual(somewhere, moved_vehicle.position.geoid,
+                            "link start location should not be the same")
 
     def test_charge(self):
 
-        state = ChargingBase(DefaultIds.mock_vehicle_id(), DefaultIds.mock_base_id(), mock_dcfc_charger_id())
+        state = ChargingBase(DefaultIds.mock_vehicle_id(), DefaultIds.mock_base_id(),
+                             mock_dcfc_charger_id())
         veh = mock_vehicle_from_geoid(vehicle_state=state, soc=0.5)
         sta = mock_station_from_geoid()
         bas = mock_base_from_geoid(station_id=sta.id)
-        sim = mock_sim(
-            vehicles=(veh,),
-            stations=(sta,),
-            bases=(bas,),
-            sim_timestep_duration_seconds=1
-        )
+        sim = mock_sim(vehicles=(veh, ),
+                       stations=(sta, ),
+                       bases=(bas, ),
+                       sim_timestep_duration_seconds=1)
         env = mock_env()
 
         error, result = vehicle_state_ops.charge(sim, env, veh.id, sta.id, mock_dcfc_charger_id())
@@ -54,23 +53,21 @@ class TestVehicleStateOps(TestCase):
 
         updated_veh = result.vehicles.get(veh.id)
 
-        self.assertGreater(
-            updated_veh.energy[EnergyType.ELECTRIC],
-            veh.energy[EnergyType.ELECTRIC],
-            msg="should have charged")
+        self.assertGreater(updated_veh.energy[EnergyType.ELECTRIC],
+                           veh.energy[EnergyType.ELECTRIC],
+                           msg="should have charged")
 
     def test_charge_when_full(self):
 
-        state = ChargingBase(DefaultIds.mock_vehicle_id(), DefaultIds.mock_base_id(), mock_dcfc_charger_id())
+        state = ChargingBase(DefaultIds.mock_vehicle_id(), DefaultIds.mock_base_id(),
+                             mock_dcfc_charger_id())
         veh = mock_vehicle_from_geoid(vehicle_state=state, soc=1.0)
         sta = mock_station_from_geoid()
         bas = mock_base_from_geoid(station_id=sta.id)
-        sim = mock_sim(
-            vehicles=(veh,),
-            stations=(sta,),
-            bases=(bas,),
-            sim_timestep_duration_seconds=1
-        )
+        sim = mock_sim(vehicles=(veh, ),
+                       stations=(sta, ),
+                       bases=(bas, ),
+                       sim_timestep_duration_seconds=1)
         env = mock_env()
 
         error, result = vehicle_state_ops.charge(sim, env, veh.id, sta.id, mock_dcfc_charger_id())


### PR DESCRIPTION
This applies the yapf formatter to all python files in the project in an attempt to make our diffs more readable. 

Perhaps we can discuss here and settle on our [preferred configuration](https://github.com/NREL/hive/blob/develop/setup.cfg) of the formatting and then merge everything in at once? Running yapf over all the files can be done with `yapf -ir .` while in the hive root directory. 