### PR TITLE
convert traversal duration from SimTime to int before conducting route traversal

### DIFF
--- a/hive/state/vehicle_state/vehicle_state_ops.py
+++ b/hive/state/vehicle_state/vehicle_state_ops.py
@@ -133,7 +133,7 @@ def move(sim: SimulationState, env: Environment,
 
     error, traverse_result = traverse(
         route_estimate=route,
-        duration_seconds=sim.sim_timestep_duration_seconds,
+        duration_seconds=int(sim.sim_timestep_duration_seconds),
     )
     if error:
         return error, None


### PR DESCRIPTION
this quick fix addresses this error message observed in hive-distributed when running hive step updates:

the offending line of code is h3_ops.py:207, where available_time_seconds (passed as a SimTime) is multipled against SECONDS_TO_HOURS. when this is a SimTime, the following error is displayed:

```
TypeError: int() argument must be a string, a bytes-like object or a number, not 'NotImplementedType'
```