### PR TITLE
return error from step_vehicle function

### DIFF
--- a/tests/test_step_simulation_ops.py
+++ b/tests/test_step_simulation_ops.py
@@ -17,7 +17,9 @@ class TestStepSimulationOps(TestCase):
         env = mock_env()
 
         for _ in range(10):
-            sim = step_vehicle(sim, env, vehicle_id="2")
+            err, sim = step_vehicle(sim, env, vehicle_id="2")
+            if err is not None:
+                self.fail(err)
 
         vehicle1: Vehicle = sim.vehicles.get("1")
         vehicle2: Vehicle = sim.vehicles.get("2")
@@ -48,7 +50,9 @@ class TestStepSimulationOps(TestCase):
         env = mock_env()
 
         for _ in range(10):
-            sim = step_vehicle(sim, env, vehicle_id="2")
+            err, sim = step_vehicle(sim, env, vehicle_id="2")
+            if err is not None:
+                self.fail(err)
 
         vehicle1: Vehicle = sim.vehicles.get("1")
         vehicle2: Vehicle = sim.vehicles.get("2")


### PR DESCRIPTION
this PR changes the signature of `step_simulation_ops.step_vehicle` so that it is error-returning.

in the future, we should do this for `perform_driver_state_updates`, `perform_vehicle_state_updates`, and `apply_instructions` as well (which in turn affects StepSimulation.update, which is called by a bunch of stuff which makes this a bigger fix).

Closes #75.