### PR TITLE
custom road network

### DIFF
--- a/nrel/hive/app/hive_cosim.py
+++ b/nrel/hive/app/hive_cosim.py
@@ -29,9 +29,7 @@ def load_scenario(
     :raises: Error when issues with files
     """
     config = load_config(scenario_file)
-    initial_payload = load_simulation(
-        config, custom_instruction_generators, custom_init_functions
-    )
+    initial_payload = load_simulation(config, custom_instruction_generators, custom_init_functions)
 
     # add a specialized Reporter handler that catches vehicle charge events
     initial_payload.e.reporter.add_handler(VehicleChargeEventsHandler())

--- a/nrel/hive/app/hive_cosim.py
+++ b/nrel/hive/app/hive_cosim.py
@@ -7,7 +7,7 @@ from pandas import DataFrame
 from tqdm import tqdm
 
 from nrel.hive.dispatcher.instruction_generator.instruction_generator import InstructionGenerator
-from nrel.hive.initialization.load import load_simulation
+from nrel.hive.initialization.load import load_simulation, load_config
 from nrel.hive.initialization.initialize_simulation import InitFunction
 from nrel.hive.model.sim_time import SimTime
 from nrel.hive.reporting.handler.vehicle_charge_events_handler import VehicleChargeEventsHandler
@@ -28,8 +28,9 @@ def load_scenario(
     :return: the initial simulation state payload
     :raises: Error when issues with files
     """
+    config = load_config(scenario_file)
     initial_payload = load_simulation(
-        scenario_file, custom_instruction_generators, custom_init_functions
+        config, custom_instruction_generators, custom_init_functions
     )
 
     # add a specialized Reporter handler that catches vehicle charge events

--- a/nrel/hive/app/run.py
+++ b/nrel/hive/app/run.py
@@ -11,7 +11,6 @@ import yaml
 
 from nrel.hive.initialization.load import load_simulation, load_config
 from nrel.hive.initialization.initialize_simulation import InitFunction
-from nrel.hive.config import HiveConfig
 from nrel.hive.dispatcher.instruction_generator.instruction_generator import InstructionGenerator
 from nrel.hive.runner.local_simulation_runner import LocalSimulationRunner
 
@@ -36,7 +35,7 @@ T = TypeVar("T", bound=InstructionGenerator)
 
 
 def run_sim(
-    config: HiveConfig,
+    scenario_file: Union[Path, str],
     custom_instruction_generators: Optional[Tuple[T, ...]] = None,
     custom_init_functions: Optional[Iterable[InitFunction]] = None,
 ):
@@ -50,6 +49,8 @@ def run_sim(
     :return: 0 for success
     """
     _welcome_to_hive()
+
+    config = load_config(scenario_file)
 
     initial_payload = load_simulation(
         config,
@@ -94,10 +95,8 @@ def run(
     # main application
     if args.defaults:
         print_defaults()
-    
-    config = load_config(args.scenario_file)
 
-    return run_sim(config, custom_instruction_generators, custom_init_functions)
+    return run_sim(args.scenario_file, custom_instruction_generators, custom_init_functions)
 
 
 def _welcome_to_hive():

--- a/nrel/hive/app/run.py
+++ b/nrel/hive/app/run.py
@@ -2,23 +2,18 @@ from __future__ import annotations
 
 import argparse
 import logging
-import os
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Iterable, Optional, Tuple, TypeVar, Union
 
 import pkg_resources
 import yaml
 
-from nrel.hive.dispatcher.instruction_generator.charging_fleet_manager import ChargingFleetManager
-from nrel.hive.dispatcher.instruction_generator.dispatcher import Dispatcher
 from nrel.hive.initialization.load import load_simulation
-from nrel.hive.reporting import reporter_ops
+from nrel.hive.initialization.initialize_simulation import InitFunction
+from nrel.hive.dispatcher.instruction_generator.instruction_generator import InstructionGenerator
 from nrel.hive.runner.local_simulation_runner import LocalSimulationRunner
-from nrel.hive.runner.runner_payload import RunnerPayload
-from nrel.hive.state.simulation_state.update.update import Update
 from nrel.hive.util import fs
-from nrel.hive.util.fp import throw_on_failure
 
 if TYPE_CHECKING:
     pass
@@ -37,58 +32,51 @@ parser.add_argument(
 
 log = logging.getLogger("hive")
 
+T = TypeVar("T", bound=InstructionGenerator)
 
-def run_sim(scenario_file, position=0):
+
+def run_sim(
+    scenario_file: Union[str, Path],
+    custom_instruction_generators: Optional[Tuple[T, ...]] = None,
+    custom_init_functions: Optional[Iterable[InitFunction]] = None,
+):
     """
     runs a single sim and writes outputs
 
     :param scenario_file: the scenario file to run
-    :param position: the tqdm position
+    :param custom_instruction_generators: a set of user defined instruction generators to override the defaults
+    :param custom_init_functions: a set of user defined initialization functions to override the defaults
 
     :return: 0 for success
     """
-    sim, env = load_simulation(scenario_file)
-
-    if env.config.global_config.log_run:
-        run_log_path = os.path.join(env.config.scenario_output_directory, "run.log")
-        log_fh = logging.FileHandler(run_log_path)
-        formatter = logging.Formatter("[%(levelname)s] - %(name)s - %(message)s")
-        # log_fh.setLevel(env.config.global_config.log_level)
-        log_fh.setFormatter(formatter)
-        log.addHandler(log_fh)
-        log.info(
-            f"creating run log at {run_log_path} with log level {logging.getLevelName(log.getEffectiveLevel())}"
+    try:
+        scenario_path = fs.find_scenario(str(scenario_file))
+    except FileNotFoundError as fe:
+        log.error(
+            f"{repr(fe)}; please specify a path to a hive scenario file like denver_demo.yaml"
         )
+        return 1
 
-    if env.config.global_config.log_station_capacities:
-        result = reporter_ops.log_station_capacities(sim, env)
-        throw_on_failure(result)
-
-    # build the set of instruction generators which compose the control system for this hive run
-    # this ordering is important as the later managers will override any instructions from the previous
-    # instruction generator for a specific vehicle id.
-    instruction_generators = (
-        ChargingFleetManager(env.config.dispatcher),
-        Dispatcher(env.config.dispatcher),
+    initial_payload = load_simulation(
+        scenario_path,
+        custom_instruction_generators=custom_instruction_generators,
+        custom_init_functions=custom_init_functions,
     )
 
-    update = Update.build(env.config, instruction_generators)
-    initial_payload = RunnerPayload(sim, env, update)
-
     log.info(
-        f"running {env.config.sim.sim_name} for time {initial_payload.e.config.sim.start_time} "
+        f"running {initial_payload.e.config.sim.sim_name} for time {initial_payload.e.config.sim.start_time} "
         f"to {initial_payload.e.config.sim.end_time}:"
     )
     start = time.time()
-    sim_result = LocalSimulationRunner.run(initial_payload, position)
+    sim_result = LocalSimulationRunner.run(initial_payload)
     end = time.time()
 
     log.info(f"done! time elapsed: {round(end - start, 2)} seconds")
 
-    env.reporter.close(sim_result)
+    sim_result.e.reporter.close(sim_result)
 
-    if env.config.global_config.write_outputs:
-        env.config.to_yaml()
+    if initial_payload.e.config.global_config.write_outputs:
+        initial_payload.e.config.to_yaml()
 
     return 0
 
@@ -110,26 +98,10 @@ def run() -> int:
         return 1
 
     # main application
-    try:
-        if args.defaults:
-            print_defaults()
+    if args.defaults:
+        print_defaults()
 
-        # create the configuration and load the simulation
-        try:
-            scenario_file = fs.find_scenario(args.scenario_file)
-        except FileNotFoundError as fe:
-            log.error(
-                f"{repr(fe)}; please specify a path to a hive scenario file like denver_demo.yaml"
-            )
-            return 1
-
-        run_sim(scenario_file)
-
-        return 0
-
-    except Exception as e:
-        # perhaps in the future, a more robust handling here
-        raise e
+    return run_sim(args.scenario_file)
 
 
 def _welcome_to_hive():

--- a/nrel/hive/app/run_batch.py
+++ b/nrel/hive/app/run_batch.py
@@ -37,12 +37,11 @@ class BatchConfig(NamedTuple):
 
 class SimArgs(NamedTuple):
     scenario_file: Path
-    position: int
 
 
 def safe_sim(sim_args: SimArgs) -> int:
     try:
-        return run_sim(sim_args.scenario_file, sim_args.position)
+        return run_sim(sim_args.scenario_file)
     except Exception:
         log.error(f"{sim_args.scenario_file} failed, see traceback:")
         log.error(traceback.format_exc())
@@ -69,7 +68,7 @@ def run() -> int:
         d = yaml.safe_load(stream)
         config = BatchConfig.from_dict(d)
 
-    sim_args = [SimArgs(f, i) for i, f in enumerate(config.scenario_files)]
+    sim_args = [SimArgs(f) for f in config.scenario_files]
 
     # check to make sure we don't exceed system CPU
     os_cpu = os.cpu_count()

--- a/nrel/hive/app/run_batch.py
+++ b/nrel/hive/app/run_batch.py
@@ -42,8 +42,7 @@ class SimArgs(NamedTuple):
 
 def safe_sim(sim_args: SimArgs) -> int:
     try:
-        config = load_config(sim_args.scenario_file)
-        return run_sim(config)
+        return run_sim(sim_args.scenario_file)
     except Exception:
         log.error(f"{sim_args.scenario_file} failed, see traceback:")
         log.error(traceback.format_exc())

--- a/nrel/hive/app/run_batch.py
+++ b/nrel/hive/app/run_batch.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, NamedTuple, List
 
 import yaml
 
+from nrel.hive.initialization.load import load_config
 from nrel.hive.app.run import run_sim
 from nrel.hive.util import fs
 
@@ -41,7 +42,8 @@ class SimArgs(NamedTuple):
 
 def safe_sim(sim_args: SimArgs) -> int:
     try:
-        return run_sim(sim_args.scenario_file)
+        config = load_config(sim_args.scenario_file)
+        return run_sim(config)
     except Exception:
         log.error(f"{sim_args.scenario_file} failed, see traceback:")
         log.error(traceback.format_exc())

--- a/nrel/hive/app/run_tune.py
+++ b/nrel/hive/app/run_tune.py
@@ -7,14 +7,10 @@ from typing import Dict
 import ray
 from ray import tune
 
-from nrel.hive.dispatcher.instruction_generator.charging_fleet_manager import ChargingFleetManager
-from nrel.hive.dispatcher.instruction_generator.dispatcher import Dispatcher
-from nrel.hive.initialization.load import load_simulation
+from nrel.hive.initialization.load import load_simulation, load_config
 from nrel.hive.reporting.reporter import Reporter
 from nrel.hive.runner.local_simulation_runner import LocalSimulationRunner
 from nrel.hive.runner.runner_payload import RunnerPayload
-from nrel.hive.state.simulation_state.update.update import Update
-from nrel.hive.util import fs
 
 parser = argparse.ArgumentParser(description="run hive")
 parser.add_argument(
@@ -52,15 +48,16 @@ class OptimizationWrapper(tune.Trainable):
         print("VEHICLES ", payload.s.vehicles.values())
         return score
 
-    def _setup(self, config: Dict[str, int]):
+    def _setup(self, d: Dict[str, int]):
         scenarios = {
             1: "denver_demo.yaml",
             2: "denver_demo_constrained_charging.yaml",
         }
-        scenario_file = scenarios[config["scenario"]]
+        scenario_file = scenarios[d["scenario"]]
         log.info(f"setting up experiment with scenario {scenario_file}")
 
-        rp = load_simulation(fs.find_scenario(scenario_file))
+        config = load_config(scenario_file)
+        rp = load_simulation(config)
 
         self.initial_payload = rp 
 

--- a/nrel/hive/app/run_tune.py
+++ b/nrel/hive/app/run_tune.py
@@ -59,7 +59,7 @@ class OptimizationWrapper(tune.Trainable):
         config = load_config(scenario_file)
         rp = load_simulation(config)
 
-        self.initial_payload = rp 
+        self.initial_payload = rp
 
     def _train(self) -> Dict[str, float]:
         sim_result = LocalSimulationRunner.run(self.initial_payload)

--- a/nrel/hive/app/run_tune.py
+++ b/nrel/hive/app/run_tune.py
@@ -60,16 +60,9 @@ class OptimizationWrapper(tune.Trainable):
         scenario_file = scenarios[config["scenario"]]
         log.info(f"setting up experiment with scenario {scenario_file}")
 
-        # TODO: update this load method with a the new sampling loader.
-        sim, env = load_simulation(fs.find_scenario(scenario_file))
+        rp = load_simulation(fs.find_scenario(scenario_file))
 
-        instruction_generators = (
-            ChargingFleetManager(env.config.dispatcher),
-            Dispatcher(env.config.dispatcher),
-        )
-
-        update = Update.build(env.config, instruction_generators)
-        self.initial_payload = RunnerPayload(sim, env, update)
+        self.initial_payload = rp 
 
     def _train(self) -> Dict[str, float]:
         sim_result = LocalSimulationRunner.run(self.initial_payload)

--- a/nrel/hive/config/sim.py
+++ b/nrel/hive/config/sim.py
@@ -47,13 +47,19 @@ class Sim(NamedTuple):
 
         schedule_type = ScheduleType.from_string(d["schedule_type"])
 
+        sim_h3_resolution = int(d["sim_h3_resolution"])
+        sim_h3_search_resolution = int(d["sim_h3_search_resolution"])
+
+        if sim_h3_search_resolution >= sim_h3_resolution:
+            raise ValueError("sim_h3_search_resolution must be less than sim_h3_resolution")
+
         return Sim(
             sim_name=d["sim_name"],
             timestep_duration_seconds=int(d["timestep_duration_seconds"]),
             start_time=start_time,
             end_time=end_time,
-            sim_h3_resolution=d["sim_h3_resolution"],
-            sim_h3_search_resolution=d["sim_h3_search_resolution"],
+            sim_h3_resolution=sim_h3_resolution,
+            sim_h3_search_resolution=sim_h3_search_resolution,
             request_cancel_time_seconds=int(d["request_cancel_time_seconds"]),
             schedule_type=schedule_type,
         )

--- a/nrel/hive/initialization/load.py
+++ b/nrel/hive/initialization/load.py
@@ -55,7 +55,7 @@ def load_simulation(
     """
     takes a hive config and attempts to build all assets required to run a scenario
 
-    :param config: the hive config 
+    :param config: the hive config
     :param custom_instruction_generators: a set of user defined instruction generators to override the defaults
     :param custom_init_functions: a set of user defined initialization functions to override the defaults
 

--- a/nrel/hive/model/request/request.py
+++ b/nrel/hive/model/request/request.py
@@ -238,9 +238,13 @@ class Request(Entity):
 
         :return: the updated request
         """
-        distance_km = road_network.distance_by_geoid_km(self.origin, self.destination)
-        distance_miles = distance_km * KM_TO_MILE
-        price = rate_structure.base_price + (rate_structure.price_per_mile * distance_miles)
+        if rate_structure.price_per_mile > 0:
+            distance_km = road_network.distance_by_geoid_km(self.origin, self.destination)
+            distance_miles = distance_km * KM_TO_MILE
+            distance_price = rate_structure.price_per_mile * distance_miles
+        else:
+            distance_price = 0
+        price = rate_structure.base_price + distance_price
         return replace(self, value=max(rate_structure.minimum_price, price))
 
     def set_membership(self, member_ids: Tuple[str, ...]) -> Request:

--- a/nrel/hive/runner/local_simulation_runner.py
+++ b/nrel/hive/runner/local_simulation_runner.py
@@ -23,13 +23,11 @@ class LocalSimulationRunner(NamedTuple):
     def run(
         cls,
         runner_payload: RunnerPayload,
-        position: int = 0,
     ) -> RunnerPayload:
         """
         steps through time, running a simulation, and producing a simulation result
 
         :param runner_payload: the initial state of the simulation
-        :param position: position for tqdm
         :return: the final simulation state and dispatcher state
         """
 
@@ -38,8 +36,7 @@ class LocalSimulationRunner(NamedTuple):
                 int(runner_payload.e.config.sim.start_time),
                 int(runner_payload.e.config.sim.end_time),
                 runner_payload.e.config.sim.timestep_duration_seconds,
-            ),
-            position=position,
+            )
         )
 
         final_payload = ft.reduce(

--- a/nrel/hive/state/simulation_state/simulation_state.py
+++ b/nrel/hive/state/simulation_state/simulation_state.py
@@ -13,8 +13,8 @@ from typing import (
 import immutables
 
 from nrel.hive.state.simulation_state.at_location_response import AtLocationResponse
-from nrel.hive.model.membership import PUBLIC_MEMBERSHIP_ID
 from nrel.hive.model.sim_time import SimTime
+from nrel.hive.model.roadnetwork.haversine_roadnetwork import HaversineRoadNetwork
 from nrel.hive.util import geo
 from nrel.hive.util.typealiases import (
     RequestId,
@@ -22,7 +22,6 @@ from nrel.hive.util.typealiases import (
     BaseId,
     StationId,
     GeoId,
-    MembershipId,
 )
 
 if TYPE_CHECKING:
@@ -44,13 +43,13 @@ class SimulationState(NamedTuple):
     """
 
     # road network representation
-    road_network: RoadNetwork
+    road_network: RoadNetwork = HaversineRoadNetwork()
 
     # simulation parameters
-    sim_time: SimTime
-    sim_timestep_duration_seconds: Seconds
-    sim_h3_location_resolution: int
-    sim_h3_search_resolution: int
+    sim_time: SimTime = SimTime(0)
+    sim_timestep_duration_seconds: Seconds = 60
+    sim_h3_location_resolution: int = 15
+    sim_h3_search_resolution: int = 7
 
     # objects of the simulation
     stations: immutables.Map[StationId, Station] = immutables.Map()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,3 +61,6 @@ hive-batch = "nrel.hive.app.run_batch:run"
 
 [tool.black]
 line-length = 100
+
+[tool.setuptools.package-data]
+"*" = ["py.typed"]

--- a/tests/test_initialize_simulation.py
+++ b/tests/test_initialize_simulation.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
 from nrel.hive.config.network import Network
-from nrel.hive.initialization.initialize_simulation import initialize_simulation
+from nrel.hive.initialization.initialize_simulation import initialize
 from nrel.hive.initialization.initialize_simulation_with_sampling import (
     initialize_simulation_with_sampling,
 )
@@ -12,39 +12,10 @@ class TestInitializeSimulation(TestCase):
     def test_initialize_simulation(self):
         conf = mock_config().suppress_logging()
 
-        sim, env = initialize_simulation(conf)
+        sim, env = initialize(conf)
         self.assertEqual(len(sim.vehicles), 20, "should have loaded 20 vehicles")
         self.assertEqual(len(sim.stations), 4, "should have loaded 4 stations")
         self.assertEqual(len(sim.bases), 2, "should have loaded 1 base")
-
-    def test_initialize_simulation_with_filtering(self):
-        conf = mock_config().suppress_logging()
-
-        def filter_veh(v: Vehicle) -> bool:
-            if v.id == "v1":
-                return False
-            return True
-
-        def filter_base(b: Base) -> bool:
-            if b.id == "b1":
-                return False
-            return True
-
-        def filter_station(s: Station) -> bool:
-            if s.id == "s1":
-                return False
-            return True
-
-        sim, env = initialize_simulation(
-            conf,
-            vehicle_filter=filter_veh,
-            base_filter=filter_base,
-            station_filter=filter_station,
-        )
-
-        self.assertIsNone(sim.vehicles.get("v1"), "should not have loaded vehicle v1")
-        self.assertIsNone(sim.bases.get("b1"), "should not have loaded base b1")
-        self.assertIsNone(sim.stations.get("s1"), "should not have loaded station s1")
 
     def test_initialize_simulation_with_sampling(self):
         conf = (

--- a/tests/test_initialize_simulation.py
+++ b/tests/test_initialize_simulation.py
@@ -1,11 +1,13 @@
 from unittest import TestCase
 
 from nrel.hive.config.network import Network
-from nrel.hive.initialization.initialize_simulation import initialize
+from nrel.hive.initialization.initialize_simulation import initialize, default_init_functions
 from nrel.hive.initialization.initialize_simulation_with_sampling import (
     initialize_simulation_with_sampling,
 )
 from nrel.hive.resources.mock_lobster import *
+
+import nrel.hive.state.simulation_state.simulation_state_ops as sso
 
 
 class TestInitializeSimulation(TestCase):
@@ -16,6 +18,36 @@ class TestInitializeSimulation(TestCase):
         self.assertEqual(len(sim.vehicles), 20, "should have loaded 20 vehicles")
         self.assertEqual(len(sim.stations), 4, "should have loaded 4 stations")
         self.assertEqual(len(sim.bases), 2, "should have loaded 1 base")
+
+    def test_initialize_simulation_with_filtering(self):
+        conf = mock_config().suppress_logging()
+
+        def filter_veh(
+            conf: HiveConfig, sim: SimulationState, env: Environment
+        ) -> Tuple[SimulationState, Environment]:
+            sim_or_error = sso.remove_vehicle_safe(sim, "v1")
+            return sim_or_error.unwrap(), env
+
+        def filter_base(
+            conf: HiveConfig, sim: SimulationState, env: Environment
+        ) -> Tuple[SimulationState, Environment]:
+            sim_or_error = sso.remove_base_safe(sim, "b1")
+            return sim_or_error.unwrap(), env
+
+        def filter_station(
+            conf: HiveConfig, sim: SimulationState, env: Environment
+        ) -> Tuple[SimulationState, Environment]:
+            sim_or_error = sso.remove_station_safe(sim, "s1")
+            return sim_or_error.unwrap(), env
+
+        init_funtions = default_init_functions()
+        init_funtions.extend([filter_veh, filter_base, filter_station])
+
+        sim, env = initialize(conf, init_functions=init_funtions)
+
+        self.assertIsNone(sim.vehicles.get("v1"), "should not have loaded vehicle v1")
+        self.assertIsNone(sim.bases.get("b1"), "should not have loaded base b1")
+        self.assertIsNone(sim.stations.get("s1"), "should not have loaded station s1")
 
     def test_initialize_simulation_with_sampling(self):
         conf = (


### PR DESCRIPTION
Updates how we initialize a simulation to support injection of a custom road network at the highest level.

Now, an extension to the core library could call `run_sim()` and pass a set of custom initialization functions.