### PR TITLE
add from polygon method to OSMRoadNetwork

### DIFF
--- a/examples/download_road_network.py
+++ b/examples/download_road_network.py
@@ -1,10 +1,8 @@
 from pathlib import Path
 
-import json
-
 import geopandas as gpd
-import osmnx as ox
-import networkx as nx
+
+from nrel.hive.model.roadnetwork.osm.osm_roadnetwork import OSMRoadNetwork
 
 GEOJSON_PATH = Path(
     "../nrel/hive/resources/scenarios/denver_downtown/geofence/downtown_denver.json"
@@ -17,17 +15,9 @@ def build_road_network(geojson_file: Path, outfile: Path):
 
     polygon = df.iloc[0].geometry
 
-    # we want to set the configuration to be all one-way.
-    # This doesn't eliminate two-way streets but rather returns two distinct one-way edges for each two-way street.
-    ox.utils.config(all_oneway=True)
+    rn = OSMRoadNetwork.from_polygon(polygon)
 
-    G = ox.graph_from_polygon(polygon, network_type="drive")
-
-    # hive expects the graph to be strongly connected
-    G = ox.utils_graph.get_largest_component(G, strongly=True)
-
-    with outfile.open("w") as f:
-        json.dump(nx.node_link_data(G), f)
+    rn.to_file(OUTFILE)
 
 
 if __name__ == "__main__":

--- a/nrel/hive/initialization/initialize_simulation.py
+++ b/nrel/hive/initialization/initialize_simulation.py
@@ -158,7 +158,7 @@ def osm_init_function(
     if config.input_config.road_network_file is None:
         raise IOError("Must supply a road network file when using the osm_network")
 
-    road_network = OSMRoadNetwork(  # type: ignore
+    road_network = OSMRoadNetwork.from_file(
         sim_h3_resolution=config.sim.sim_h3_resolution,
         road_network_file=Path(config.input_config.road_network_file),
         default_speed_kmph=config.network.default_speed_kmph,

--- a/nrel/hive/initialization/initialize_simulation_with_sampling.py
+++ b/nrel/hive/initialization/initialize_simulation_with_sampling.py
@@ -53,16 +53,10 @@ def initialize_simulation_with_sampling(
     :raises Exception due to IOErrors, missing keys in DictReader rows, or parsing errors
     """
 
-    # deprecated geofence input
-    if config.input_config.geofence_file:
-        geofence = GeoFence.from_geojson_file(config.input_config.geofence_file)
-    else:
-        geofence = None
-
     # set up road network based on user-configured road network type
     if config.network.network_type == "euclidean":
         haversine_road_network = HaversineRoadNetwork(
-            geofence=geofence, sim_h3_resolution=config.sim.sim_h3_resolution
+            sim_h3_resolution=config.sim.sim_h3_resolution
         )
         sim_initial = SimulationState(
             road_network=haversine_road_network,
@@ -75,8 +69,7 @@ def initialize_simulation_with_sampling(
         if config.input_config.road_network_file is None:
             raise ValueError("road_network_file required for osm_network")
 
-        osm_road_network = OSMRoadNetwork(
-            geofence=geofence,
+        osm_road_network = OSMRoadNetwork.from_file(
             sim_h3_resolution=config.sim.sim_h3_resolution,
             road_network_file=Path(config.input_config.road_network_file),
             default_speed_kmph=config.network.default_speed_kmph,

--- a/nrel/hive/model/roadnetwork/osm/osm_builders.py
+++ b/nrel/hive/model/roadnetwork/osm/osm_builders.py
@@ -1,0 +1,47 @@
+from typing import TYPE_CHECKING
+
+
+def osm_graph_from_polygon(polygon):
+    """
+    builds a OSM networkx graph using a shapely polygon and the osmnx package
+    """
+    try:
+        import osmnx as ox
+    except ImportError as e:
+        raise ImportError(
+            "the osmnx package is required for building an OSMRoadNetwork from a polygon"
+        ) from e
+
+    ox.settings.all_oneway = True
+
+    G = ox.graph_from_polygon(polygon, network_type="drive")
+
+    G = ox.utils_graph.get_largest_component(G, strongly=True)
+
+    G = ox.add_edge_speeds(G)
+
+    # remove any unnecessary information
+    for _, _, d in G.edges(data=True):
+        if "geometry" in d:
+            del d["geometry"]
+        if "speed_kph" in d:
+            d["speed_kmph"] = d["speed_kph"]
+            del d["speed_kph"]
+        if "reversed" in d:
+            del d["reversed"]
+        if "oneway" in d:
+            del d["oneway"]
+        if "name" in d:
+            del d["name"]
+        if "highway" in d:
+            del d["highway"]
+        if "lanes" in d:
+            del d["lanes"]
+
+    for _, d in G.nodes(data=True):
+        if "highway" in d:
+            del d["highway"]
+        if "street_count" in d:
+            del d["street_count"]
+
+    return G

--- a/nrel/hive/model/roadnetwork/osm/osm_road_network_link_helper.py
+++ b/nrel/hive/model/roadnetwork/osm/osm_road_network_link_helper.py
@@ -12,7 +12,7 @@ from nrel.hive.model.roadnetwork.link import Link
 from nrel.hive.model.roadnetwork.link_id import create_link_id
 from nrel.hive.model.roadnetwork.osm.osm_roadnetwork_ops import safe_get_node_coordinates
 from nrel.hive.util.typealiases import GeoId, LinkId
-from nrel.hive.util.units import M_TO_KM, Kmph, Kilometers
+from nrel.hive.util.units import M_TO_KM, Kmph
 
 
 class OSMRoadNetworkLinkHelper(NamedTuple):
@@ -62,14 +62,12 @@ class OSMRoadNetworkLinkHelper(NamedTuple):
         graph: MultiDiGraph,
         sim_h3_resolution: int,
         default_speed_kmph: Kmph = 40.0,
-        default_distance_km: Kilometers = 0.01,
     ) -> Tuple[Optional[Exception], Optional[OSMRoadNetworkLinkHelper]]:
         """
         reads in the graph links from a networkx graph and builds a table with Links by LinkId
         :param graph: the input graph
         :param sim_h3_resolution: h3 resolution for entities in sim
         :param default_speed_kmph: default link speed for unlabeled links
-        :param default_distance_km: default link length for unlabeled links
         :return: either an error, or, the lookup table
         """
 
@@ -174,12 +172,12 @@ class OSMRoadNetworkLinkHelper(NamedTuple):
                             if data
                             else default_speed_kmph
                         )
-                        distance_miles = (
-                            data.get("length", default_distance_km) if data else default_distance_km
-                        )
-                        distance = (
-                            distance_miles * M_TO_KM if distance_miles else default_distance_km
-                        )
+                        distance_miles = data.get("length") if data else None
+                        if distance_miles is None:
+                            err = ValueError("Link must have distance")
+                            return err, None
+
+                        distance = distance_miles * M_TO_KM
                         link = Link.build(link_id, src_geoid, dst_geoid, speed, distance)
                         (
                             add_link_error,

--- a/nrel/hive/model/roadnetwork/roadnetwork.py
+++ b/nrel/hive/model/roadnetwork/roadnetwork.py
@@ -21,7 +21,6 @@ class RoadNetwork(ABC):
     """
 
     sim_h3_resolution: H3Resolution
-    geofence: Optional[GeoFence]
 
     @abstractmethod
     def route(self, origin: EntityPosition, destination: EntityPosition) -> Route:

--- a/nrel/hive/resources/mock_lobster.py
+++ b/nrel/hive/resources/mock_lobster.py
@@ -141,9 +141,8 @@ def mock_osm_network(h3_res: H3Resolution = 15, geofence_res: H3Resolution = 10)
         "nrel.hive.resources.scenarios.denver_downtown.road_network",
         "downtown_denver_network.json",
     )
-    return OSMRoadNetwork(
+    return OSMRoadNetwork.from_file(
         road_network_file=Path(road_network_file),
-        geofence=mock_geofence(resolution=geofence_res),
         sim_h3_resolution=h3_res,
     )
 


### PR DESCRIPTION
In order to make building a new road network easier on the user, this adds a new `from_polygon` class method to the `OSMRoadNetwork` that uses osmnx and shapely on the backend to build a road network. 