### PR TITLE
fix charge queue bug

### DIFF
--- a/nrel/hive/model/roadnetwork/osm/osm_road_network_link_helper.py
+++ b/nrel/hive/model/roadnetwork/osm/osm_road_network_link_helper.py
@@ -6,7 +6,7 @@ from typing import Tuple, Optional, NamedTuple
 import h3
 import immutables
 from networkx import MultiDiGraph
-from scipy.spatial.ckdtree import cKDTree
+from scipy.spatial import cKDTree
 
 from nrel.hive.model.roadnetwork.link import Link
 from nrel.hive.model.roadnetwork.link_id import create_link_id

--- a/nrel/hive/model/station/station.py
+++ b/nrel/hive/model/station/station.py
@@ -266,7 +266,7 @@ class Station(Entity):
         else:
             return None, cs.charger
 
-    def get_available_chargers(self, charger_id: ChargerId) -> Optional[int]:
+    def get_available_chargers(self, charger_id: ChargerId) -> int:
         """
         gets the number of available chargers for a charger type at this station
 
@@ -274,8 +274,10 @@ class Station(Entity):
         :return: the number of available chargers of this charger type at this station
         """
         cs = self.state.get(charger_id)
-        chargers = cs.available_chargers if cs is not None else None
-        return chargers
+        if cs is None:
+            return 0
+        else:
+            return cs.available_chargers
 
     def get_total_chargers(self, charger_id: ChargerId) -> Optional[int]:
         """

--- a/nrel/hive/state/vehicle_state/charging_station.py
+++ b/nrel/hive/state/vehicle_state/charging_station.py
@@ -194,7 +194,8 @@ class ChargingStation(VehicleState):
             if mechatronics is None:
                 log.error(f"could not find mechatronics {vehicle.mechatronics_id} in environemnt")
                 return False
-            return mechatronics.is_full(vehicle)
+            is_full = mechatronics.is_full(vehicle)
+            return is_full 
 
     def _default_terminal_state(
         self, sim: "SimulationState", env: Environment

--- a/nrel/hive/state/vehicle_state/charging_station.py
+++ b/nrel/hive/state/vehicle_state/charging_station.py
@@ -195,7 +195,7 @@ class ChargingStation(VehicleState):
                 log.error(f"could not find mechatronics {vehicle.mechatronics_id} in environemnt")
                 return False
             is_full = mechatronics.is_full(vehicle)
-            return is_full 
+            return is_full
 
     def _default_terminal_state(
         self, sim: "SimulationState", env: Environment

--- a/nrel/hive/state/vehicle_state/dispatch_station.py
+++ b/nrel/hive/state/vehicle_state/dispatch_station.py
@@ -125,7 +125,6 @@ class DispatchStation(VehicleState):
         """
         vehicle = sim.vehicles.get(self.vehicle_id)
         station = sim.stations.get(self.station_id)
-        available_chargers = station.get_available_chargers(self.charger_id) if station else None
         context = f"vehicle {self.vehicle_id} entering default terminal state for dispatch station state for station {self.station_id} with charger {self.charger_id}"
         if not vehicle:
             return (
@@ -142,9 +141,10 @@ class DispatchStation(VehicleState):
             message = f"vehicle {self.vehicle_id} ended trip to station {self.station_id} but locations do not match: {locations}"
             return SimulationStateError(message), None
         else:
+            available_chargers = station.get_available_chargers(self.charger_id)
             next_state = (
                 ChargingStation.build(self.vehicle_id, self.station_id, self.charger_id)
-                if available_chargers is not None
+                if available_chargers > 0
                 else ChargeQueueing.build(
                     self.vehicle_id,
                     self.station_id,

--- a/nrel/hive/state/vehicle_state/vehicle_state.py
+++ b/nrel/hive/state/vehicle_state/vehicle_state.py
@@ -12,9 +12,13 @@ from nrel.hive.state.vehicle_state.vehicle_state_type import VehicleStateType
 from nrel.hive.util.exception import SimulationStateError, StateTransitionError
 from nrel.hive.util.typealiases import VehicleId
 
+import logging
+
 if TYPE_CHECKING:
     from nrel.hive.runner.environment import Environment
     from nrel.hive.state.simulation_state.simulation_state import SimulationState
+
+log = logging.getLogger(__name__)
 
 VehicleStateInstanceId = UUID
 
@@ -69,6 +73,7 @@ class VehicleStateABC(ABC):
             err1, next_state = state._default_terminal_state(sim, env)
             if err1 is not None:
                 state_type = state.vehicle_state_type
+                log.error(err1)
                 err_res = SimulationStateError(
                     f"failure during default update of {state_type} state"
                 )
@@ -83,6 +88,7 @@ class VehicleStateABC(ABC):
                     updated_sim,
                 ) = entity_state_ops.transition_previous_to_next(sim, env, state, next_state)
                 if err2 is not None:
+                    log.error(err2)
                     state_type = state.vehicle_state_type
                     err_res = SimulationStateError(
                         f"failure during default update of {state_type} state"

--- a/tests/test_step_simulation_ops.py
+++ b/tests/test_step_simulation_ops.py
@@ -1,5 +1,7 @@
 from unittest import TestCase
-from nrel.hive.state.simulation_state.update.step_simulation_ops import perform_vehicle_state_updates 
+from nrel.hive.state.simulation_state.update.step_simulation_ops import (
+    perform_vehicle_state_updates,
+)
 from nrel.hive.resources.mock_lobster import *
 
 
@@ -15,7 +17,7 @@ class TestStepSimulationOps(TestCase):
         sim = mock_sim(vehicles=(vehicle1, vehicle2))
         env = mock_env()
 
-        sim = perform_vehicle_state_updates(sim, env) 
+        sim = perform_vehicle_state_updates(sim, env)
 
         vehicle1 = sim.vehicles["1"]
         vehicle2 = sim.vehicles["2"]
@@ -33,4 +35,3 @@ class TestStepSimulationOps(TestCase):
             60,
             "vehicle 2 should have idled for 1 time step (60 s)",
         )
-

--- a/tests/test_step_simulation_ops.py
+++ b/tests/test_step_simulation_ops.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from nrel.hive.state.simulation_state.update.step_simulation_ops import step_vehicle
+from nrel.hive.state.simulation_state.update.step_simulation_ops import perform_vehicle_state_updates 
 from nrel.hive.resources.mock_lobster import *
 
 
@@ -15,10 +15,7 @@ class TestStepSimulationOps(TestCase):
         sim = mock_sim(vehicles=(vehicle1, vehicle2))
         env = mock_env()
 
-        for _ in range(10):
-            err, sim = step_vehicle(sim, env, vehicle_id="2")
-            if err is not None:
-                self.fail(err)
+        sim = perform_vehicle_state_updates(sim, env) 
 
         vehicle1 = sim.vehicles["1"]
         vehicle2 = sim.vehicles["2"]
@@ -26,52 +23,14 @@ class TestStepSimulationOps(TestCase):
         veh1_idle_time = vehicle1.vehicle_state.idle_duration
         veh2_idle_time = vehicle2.vehicle_state.idle_duration
 
-        self.assertEqual(veh1_idle_time, 0, "vehicle 1 should not have idled")
+        self.assertEqual(
+            veh1_idle_time,
+            60,
+            "vehicle 1 should have idled for 1 time step (60 s)",
+        )
         self.assertEqual(
             veh2_idle_time,
-            600,
-            "vehicle 2 should have idled for 10 time steps (600 s)",
+            60,
+            "vehicle 2 should have idled for 1 time step (60 s)",
         )
 
-    # @unittest.skip("refactor so that we aren't injecting VehicleState into vehicles which bypasses VehicleState.enter op")
-    def test_step_vehicle_state_change(self):
-        """
-        build a sim with two charging vehicles and only step one of them until done charging.
-
-        check to make sure only one vehicle transitioned from the charging state to the idle state.
-        """
-        self.skipTest(
-            "refactor so that we aren't injecting VehicleState into vehicles. doing so "
-            "bypasses the VehicleState.enter method, which in this case will lead to an "
-            "unexpected behavior when these vehicles return chargers that they never checked "
-            "out in the first place."
-        )
-        station = mock_station("s1")
-        vehicle1 = mock_vehicle(
-            vehicle_id="1",
-            vehicle_state=ChargingStation.build("1", "s1", mock_dcfc_charger_id()),
-        )
-        vehicle2 = mock_vehicle(
-            vehicle_id="2",
-            vehicle_state=ChargingStation.build("2", "s1", mock_dcfc_charger_id()),
-        )
-        sim = mock_sim(vehicles=(vehicle1, vehicle2), stations=(station,))
-        env = mock_env()
-
-        for _ in range(10):
-            err, sim = step_vehicle(sim, env, vehicle_id="2")
-            if err is not None:
-                self.fail(err)
-
-        vehicle1 = sim.vehicles["1"]
-        vehicle2 = sim.vehicles["2"]
-
-        veh1_state = vehicle1.vehicle_state
-        veh2_state = vehicle2.vehicle_state
-
-        self.assertIsInstance(
-            veh1_state,
-            ChargingStation,
-            "vehicle 1 should still be in charging state",
-        )
-        self.assertIsInstance(veh2_state, Idle, "vehicle 2 should have transitioned to idle")


### PR DESCRIPTION
Applies a couple of bug fixes discovered when creating a new hive scenario:

## charge queue
When transitioning out of dispatch station we were only going into charge queuing if the available chargers result was None. But, there were cases when this evaluated to 0. This has been updated such that the available chargers method only returns an integer and it gets properly checked.

## vehicle state updates
I was running into some very strange behavior in which I would observe the vehicle stepping properly in the internal closure of the `perform_vehicle_state_updates` method, breaking [here](https://github.com/NREL/hive/blob/a0de4ecc07653adaa5bdef955c67eb2b09536b9f/nrel/hive/state/simulation_state/update/step_simulation_ops.py#L126) but then the change would not be reflected in the result [here](https://github.com/NREL/hive/blob/a0de4ecc07653adaa5bdef955c67eb2b09536b9f/nrel/hive/state/simulation_state/update/step_simulation_ops.py#L158). I revised the code to use a for loop and moved the `_step_vehicle` function out of the scope of the `perform_vehicle_state_updates` and the behavior is gone. This smells like something a bit deep and I didn't have time to investigate further.