### PR TITLE
add environment init functions

### DIFF
--- a/nrel/hive/model/vehicle/mechatronics/bev.py
+++ b/nrel/hive/model/vehicle/mechatronics/bev.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 
 import logging
 
-from typing import Dict, NamedTuple, TYPE_CHECKING, Tuple
+from typing import Any, Callable, Dict, NamedTuple, TYPE_CHECKING, Optional, Tuple
 
 import immutables
 
@@ -41,11 +41,19 @@ class BEV(MechatronicsInterface):
     battery_full_threshold_kwh: KwH = 0.1
 
     @classmethod
-    def from_dict(cls, d: Dict[str, str]) -> BEV:
+    def from_dict(
+        cls,
+        d: Dict[str, str],
+        custom_powertrain_constructor: Optional[Callable[[Dict[str, Any]], Powertrain]] = None,
+        custom_powercurve_constructor: Optional[Callable[[Dict[str, Any]], Powercurve]] = None,
+    ) -> BEV:
         """
         build from a dictionary
 
         :param d: the dictionary to build from
+        :param custom_powertrain_constructor: An optional custom constuctor to build the Powertrain
+        :param custom_powercurve_constructor: An optional custom constuctor to build the Powercurve
+
         :return: the built Mechatronics object
         """
         nominal_watt_hour_per_mile = d["nominal_watt_hour_per_mile"]
@@ -61,8 +69,16 @@ class BEV(MechatronicsInterface):
         elif not updated_d.get("powercurve_file"):
             raise FileNotFoundError("missing powercurve file in mechatronics config")
 
-        powertrain = build_powertrain(updated_d)
-        powercurve = build_powercurve(updated_d)
+        if custom_powertrain_constructor is None:
+            powertrain = build_powertrain(updated_d)
+        else:
+            powertrain = custom_powertrain_constructor(updated_d)
+
+        if custom_powercurve_constructor is None:
+            powercurve = build_powercurve(updated_d)
+        else:
+            powercurve = custom_powercurve_constructor(updated_d)
+
         idle_kwh_per_hour = float(updated_d["idle_kwh_per_hour"])
         charge_taper_cutoff_kw = float(updated_d["charge_taper_cutoff_kw"])
         return BEV(

--- a/nrel/hive/model/vehicle/mechatronics/ice.py
+++ b/nrel/hive/model/vehicle/mechatronics/ice.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 
 import logging
 
-from typing import Dict, NamedTuple, TYPE_CHECKING, Tuple
+from typing import Any, Callable, Dict, NamedTuple, TYPE_CHECKING, Optional, Tuple
 
 import immutables
 
@@ -35,7 +35,11 @@ class ICE(MechatronicsInterface):
     nominal_miles_per_gallon: MilesPerGallon
 
     @classmethod
-    def from_dict(cls, d: Dict) -> ICE:
+    def from_dict(
+        cls,
+        d: Dict,
+        custom_powertrain_constructor: Optional[Callable[[Dict[str, Any]], Powertrain]] = None,
+    ) -> ICE:
         """
         build from a dictionary
 
@@ -50,11 +54,16 @@ class ICE(MechatronicsInterface):
         updated_d = d.copy()
         updated_d["scale_factor"] = 1 / nominal_miles_per_gallon
 
+        if custom_powertrain_constructor is None:
+            powertrain = build_powertrain(updated_d)
+        else:
+            powertrain = custom_powertrain_constructor(updated_d)
+
         return ICE(
             mechatronics_id=updated_d["mechatronics_id"],
             tank_capacity_gallons=tank_capacity_gallons,
             idle_gallons_per_hour=idle_gallons_per_hour,
-            powertrain=build_powertrain(updated_d),
+            powertrain=powertrain,
             nominal_miles_per_gallon=nominal_miles_per_gallon,
         )
 

--- a/nrel/hive/model/vehicle/mechatronics/powertrain/__init__.py
+++ b/nrel/hive/model/vehicle/mechatronics/powertrain/__init__.py
@@ -1,14 +1,15 @@
 from pathlib import Path
+from typing import Any, Dict, Type
 
 import yaml
 
 from nrel.hive.model.vehicle.mechatronics.powertrain.powertrain import Powertrain
 from nrel.hive.model.vehicle.mechatronics.powertrain.tabular_powertrain import TabularPowertrain
 
-powertrain_models = {"tabular": TabularPowertrain}
+DEFAULT_MODELS: Dict[str, Type[Powertrain]] = {"tabular": TabularPowertrain}
 
 
-def build_powertrain(config: dict) -> Powertrain:
+def build_powertrain(config: Dict[str, Any]) -> Powertrain:
     try:
         file = config["powertrain_file"]
     except KeyError:
@@ -23,9 +24,9 @@ def build_powertrain(config: dict) -> Powertrain:
 
         if not powertrain_type:
             raise KeyError(f"powertrain file {file} missing required 'type' field")
-        elif powertrain_type not in powertrain_models:
+        elif powertrain_type not in DEFAULT_MODELS:
             raise IOError(
-                f"PowerCurve with type {powertrain_type} is not recognized, must be one of {powertrain_models.keys()}"
+                f"PowerCurve with type {powertrain_type} is not recognized, must be one of {DEFAULT_MODELS.keys()}"
             )
         else:
-            return powertrain_models[powertrain_type].from_data(data=config)
+            return DEFAULT_MODELS[powertrain_type].from_data(data=config)

--- a/nrel/hive/model/vehicle/mechatronics/powertrain/powertrain.py
+++ b/nrel/hive/model/vehicle/mechatronics/powertrain/powertrain.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from abc import abstractmethod, ABC
 from dataclasses import dataclass
+from typing import Any, Dict
 
 from nrel.hive.model.roadnetwork.route import Route
 from nrel.hive.util.units import Unit
@@ -27,6 +28,13 @@ class PowertrainABC(ABC):
 
         :param route: a route, either experienced, or, estimated
         :return: energy cost of this route
+        """
+
+    @classmethod
+    @abstractmethod
+    def from_data(cls, data: Dict[str, Any]) -> Powertrain:
+        """
+        Build a Powertrain from a data dictionary
         """
 
 


### PR DESCRIPTION
refactors how we initialize the environment to make it easier to inject custom powertrains; this will be used internally to use routee-powertrain to predict energy consumption.