### PR TITLE
Rust haversine road network

### DIFF
--- a/nrel/hive/app/run.py
+++ b/nrel/hive/app/run.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import logging
 import time
+import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Iterable, Optional, Tuple, TypeVar, Union
 
@@ -13,6 +14,8 @@ from nrel.hive.initialization.load import load_simulation, load_config
 from nrel.hive.initialization.initialize_simulation import InitFunction
 from nrel.hive.dispatcher.instruction_generator.instruction_generator import InstructionGenerator
 from nrel.hive.runner.local_simulation_runner import LocalSimulationRunner
+from nrel.hive.util.rust import USE_RUST
+
 
 if TYPE_CHECKING:
     pass
@@ -113,6 +116,8 @@ def _welcome_to_hive():
           ' .  . ' ' .  . '     (__/
     """
 
+    if USE_RUST:
+        log.info("NOTE: Running with an experimental Rust backend")
     log.info(welcome)
 
 

--- a/nrel/hive/model/entity_position.py
+++ b/nrel/hive/model/entity_position.py
@@ -1,13 +1,17 @@
 from typing import NamedTuple
 
+from nrel.hive.util.rust import USE_RUST
 from nrel.hive.util.typealiases import LinkId, GeoId
 
+if USE_RUST:
+    from hive_core import EntityPosition
+else:
 
-class EntityPosition(NamedTuple):
-    """
-    A pairing of a geoid at the simulation resolution and a link id which yields the position of an entity
-    with the context of a link for directionality.
-    """
+    class EntityPosition(NamedTuple):  # type: ignore
+        """
+        A pairing of a geoid at the simulation resolution and a link id which yields the position of an entity
+        with the context of a link for directionality.
+        """
 
-    link_id: LinkId
-    geoid: GeoId
+        link_id: LinkId
+        geoid: GeoId

--- a/nrel/hive/model/entity_position.py
+++ b/nrel/hive/model/entity_position.py
@@ -1,7 +1,9 @@
 from typing import NamedTuple
 
-from nrel.hive.util.rust import USE_RUST
+
 from nrel.hive.util.typealiases import LinkId, GeoId
+from nrel.hive.util.rust import USE_RUST
+
 
 if USE_RUST:
     from hive_core import EntityPosition

--- a/nrel/hive/model/membership.py
+++ b/nrel/hive/model/membership.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 from typing import Tuple, NamedTuple, FrozenSet, TYPE_CHECKING
 
+from nrel.hive.util.rust import USE_RUST
+
 if TYPE_CHECKING:
     from nrel.hive.util.typealiases import MembershipId
 
 PUBLIC_MEMBERSHIP_ID = "public"
-
-USE_RUST = False
 
 
 if USE_RUST:

--- a/nrel/hive/model/membership.py
+++ b/nrel/hive/model/membership.py
@@ -4,6 +4,7 @@ from typing import Tuple, NamedTuple, FrozenSet, TYPE_CHECKING
 
 from nrel.hive.util.rust import USE_RUST
 
+
 if TYPE_CHECKING:
     from nrel.hive.util.typealiases import MembershipId
 

--- a/nrel/hive/model/roadnetwork/haversine_roadnetwork.py
+++ b/nrel/hive/model/roadnetwork/haversine_roadnetwork.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Optional
 
+import os
+
 from nrel.hive.model.roadnetwork.geofence import GeoFence
 from nrel.hive.model.entity_position import EntityPosition
 from nrel.hive.model.roadnetwork.link import Link
@@ -15,6 +17,7 @@ from nrel.hive.util.units import Kilometers
 from nrel.hive.util.rust import USE_RUST
 
 import nrel.hive.model.roadnetwork.haversine_link_id_ops as h_ops
+
 
 if USE_RUST:
     from hive_core import HaversineRoadNetwork

--- a/nrel/hive/model/roadnetwork/haversine_roadnetwork.py
+++ b/nrel/hive/model/roadnetwork/haversine_roadnetwork.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Tuple, Optional
+from typing import Optional
 
 from nrel.hive.model.roadnetwork.geofence import GeoFence
 from nrel.hive.model.entity_position import EntityPosition
@@ -12,83 +12,87 @@ from nrel.hive.model.sim_time import SimTime
 from nrel.hive.util.h3_ops import H3Ops
 from nrel.hive.util.typealiases import GeoId, LinkId, H3Resolution
 from nrel.hive.util.units import Kilometers
+from nrel.hive.util.rust import USE_RUST
 
 import nrel.hive.model.roadnetwork.haversine_link_id_ops as h_ops
 
+if USE_RUST:
+    from hive_core import HaversineRoadNetwork
+else:
 
-class HaversineRoadNetwork(RoadNetwork):
-    """
-    Implements a simple haversine road network where a unique node exists for each unique GeoId in the simulation.
-    This assumes a fully connected graph between each node in which the shortest path is the link that connects any
-    two nodes. LinkId is specified as a concatenation of the GeoId of its endpoints in which the order is given by
-    origin and destination respectively.
+    class HaversineRoadNetwork(RoadNetwork):  # type: ignore
+        """
+        Implements a simple haversine road network where a unique node exists for each unique GeoId in the simulation.
+        This assumes a fully connected graph between each node in which the shortest path is the link that connects any
+        two nodes. LinkId is specified as a concatenation of the GeoId of its endpoints in which the order is given by
+        origin and destination respectively.
 
 
-    :param AVG_SPEED: the average speed over the network
-    :type AVG_SPEED: :py:obj: kilometer/hour
+        :param AVG_SPEED: the average speed over the network
+        :type AVG_SPEED: :py:obj: kilometer/hour
 
-    :param sim_h3_resolution: the h3 simulation level resolution. default 15
-    :type sim_h3_resolution: :py:obj: int
+        :param sim_h3_resolution: the h3 simulation level resolution. default 15
+        :type sim_h3_resolution: :py:obj: int
 
-    """
+        """
 
-    # TODO: Replace speed with more accurate/dynamic estimate.
-    _AVG_SPEED_KMPH = 40  # kilometer / hour
+        # TODO: Replace speed with more accurate/dynamic estimate.
+        _AVG_SPEED_KMPH = 40  # kilometer / hour
 
-    def __init__(
-        self,
-        geofence: Optional[GeoFence] = None,
-        sim_h3_resolution: H3Resolution = 15,
-    ):
-        self.sim_h3_resolution = sim_h3_resolution
-        self.geofence = geofence
+        def __init__(
+            self,
+            geofence: Optional[GeoFence] = None,
+            sim_h3_resolution: H3Resolution = 15,
+        ):
+            self.sim_h3_resolution = sim_h3_resolution
+            self.geofence = geofence
 
-    def route(self, origin: EntityPosition, destination: EntityPosition) -> Route:
-        if origin == destination:
-            return empty_route()
+        def route(self, origin: EntityPosition, destination: EntityPosition) -> Route:
+            if origin == destination:
+                return empty_route()
 
-        link_id = h_ops.geoids_to_link_id(origin.geoid, destination.geoid)
-        link_dist_km = self.distance_by_geoid_km(origin.geoid, destination.geoid)
-        link = LinkTraversal(
-            link_id=link_id,
-            start=origin.geoid,
-            end=destination.geoid,
-            distance_km=link_dist_km,
-            speed_kmph=self._AVG_SPEED_KMPH,
-        )
+            link_id = h_ops.geoids_to_link_id(origin.geoid, destination.geoid)
+            link_dist_km = self.distance_by_geoid_km(origin.geoid, destination.geoid)
+            link = LinkTraversal(
+                link_id=link_id,
+                start=origin.geoid,
+                end=destination.geoid,
+                distance_km=link_dist_km,
+                speed_kmph=self._AVG_SPEED_KMPH,
+            )
 
-        route = (link,)
+            route = (link,)
 
-        return route
+            return route
 
-    def distance_by_geoid_km(self, origin: GeoId, destination: GeoId) -> Kilometers:
-        return H3Ops.great_circle_distance(origin, destination)
+        def distance_by_geoid_km(self, origin: GeoId, destination: GeoId) -> Kilometers:
+            return H3Ops.great_circle_distance(origin, destination)
 
-    def link_from_link_id(self, link_id: LinkId) -> Optional[Link]:
-        src, dst = h_ops.link_id_to_geodis(link_id)
-        dist = self.distance_by_geoid_km(src, dst)
-        link = Link(link_id, src, dst, dist, self._AVG_SPEED_KMPH)
-        return link
+        def link_from_link_id(self, link_id: LinkId) -> Optional[Link]:
+            src, dst = h_ops.link_id_to_geodis(link_id)
+            dist = self.distance_by_geoid_km(src, dst)
+            link = Link(link_id, src, dst, dist, self._AVG_SPEED_KMPH)
+            return link
 
-    def link_from_geoid(self, geoid: GeoId) -> Optional[Link]:
-        link_id = h_ops.geoids_to_link_id(geoid, geoid)
-        return Link(
-            link_id=link_id,
-            start=geoid,
-            end=geoid,
-            distance_km=0,
-            speed_kmph=0,
-        )
+        def link_from_geoid(self, geoid: GeoId) -> Optional[Link]:
+            link_id = h_ops.geoids_to_link_id(geoid, geoid)
+            return Link(
+                link_id=link_id,
+                start=geoid,
+                end=geoid,
+                distance_km=0,
+                speed_kmph=0,
+            )
 
-    def geoid_within_geofence(self, geoid: GeoId) -> bool:
-        return True
-        # TODO: the geofence is slated to be modified and so we're bypassing this check in the meantime.
-        #  we'll need to add it back once we update the geofence implementation.
+        def geoid_within_geofence(self, geoid: GeoId) -> bool:
+            return True
+            # TODO: the geofence is slated to be modified and so we're bypassing this check in the meantime.
+            #  we'll need to add it back once we update the geofence implementation.
 
-        # if not self.geofence:
-        #     raise RuntimeError("Geofence not specified.")
-        # else:
-        #     return self.geofence.contains(geoid)
+            # if not self.geofence:
+            #     raise RuntimeError("Geofence not specified.")
+            # else:
+            #     return self.geofence.contains(geoid)
 
-    def update(self, sim_time: SimTime) -> RoadNetwork:
-        raise NotImplementedError("updates are not implemented")
+        def update(self, sim_time: SimTime) -> RoadNetwork:
+            raise NotImplementedError("updates are not implemented")

--- a/nrel/hive/model/roadnetwork/linktraversal.py
+++ b/nrel/hive/model/roadnetwork/linktraversal.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+
 from typing import Optional, NamedTuple, Tuple, TYPE_CHECKING
 
 from nrel.hive.util.h3_ops import H3Ops

--- a/nrel/hive/resources/scenarios/denver_downtown/denver_demo.yaml
+++ b/nrel/hive/resources/scenarios/denver_downtown/denver_demo.yaml
@@ -28,7 +28,7 @@ sim:
 
 network:
   # (required) what type of network to use; options: osm_network | euclidean
-  network_type: osm_network
+  network_type: euclidean 
 
   # (optional) if no speed exists in the road network data input, we fill it in with this value;
   default_speed_kmph: 40.0

--- a/nrel/hive/util/rust.py
+++ b/nrel/hive/util/rust.py
@@ -1,0 +1,1 @@
+USE_RUST = True

--- a/nrel/hive/util/rust.py
+++ b/nrel/hive/util/rust.py
@@ -1,1 +1,8 @@
-USE_RUST = True 
+import os
+
+rust_environ = os.environ.get("USE_RUST")
+
+if rust_environ is None:
+    USE_RUST = False
+else:
+    USE_RUST = True

--- a/nrel/hive/util/rust.py
+++ b/nrel/hive/util/rust.py
@@ -1,1 +1,1 @@
-USE_RUST = True
+USE_RUST = True 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3,6 +3,62 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf6ccdb167abbf410dcb915cabd428929d7f6a04980b54a11f26a39f1c7f7107"
+dependencies = [
+ "cfg-if",
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "atomic-polyfill"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ff7eb3f316534d83a8a2c3d1674ace8a5a71198eba31e2e2b597833f699b28"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -24,10 +80,149 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "cc"
+version = "1.0.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "critical-section"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6548a0ad5d2549e111e1f6a11a6c2e2d00ce6a3dafe22948d67c2b443f775e52"
+
+[[package]]
+name = "float_next_after"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fc612c5837986b7104a87a0df74a5460931f1c5274be12f8d0f40aa2f30d632"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "geo"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39f57e9624b1a17ce621375464e9878c705d0aaadaf25cb44e4e0005a16de2f"
+dependencies = [
+ "float_next_after",
+ "geo-types",
+ "geographiclib-rs",
+ "log",
+ "num-traits",
+ "robust",
+ "rstar",
+]
+
+[[package]]
+name = "geo-types"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e26879b63ac36ca5492918dc16f8c1e604b0f70f884fffbd3533f89953ab1991"
+dependencies = [
+ "approx",
+ "num-traits",
+ "rstar",
+]
+
+[[package]]
+name = "geographiclib-rs"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04a4efc8e99f43d1d29331a073981bb13074b253edc08ffc8ccf5f384b1d1d1e"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
+name = "h3ron"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d71b40c852263f760233f189e324930e1672276f1c91fe079bd9fd58e590600"
+dependencies = [
+ "ahash 0.8.2",
+ "geo",
+ "geo-types",
+ "h3ron-h3-sys",
+ "hashbrown",
+ "nom",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "h3ron-h3-sys"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c039f9d6d4fc8b77f31739cd5290a70476888f9b57375395d75b9cf1c49f10"
+dependencies = [
+ "cc",
+ "geo-types",
+ "glob",
+ "regex",
+]
+
+[[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.6",
+ "serde",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "spin",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "indoc"
@@ -36,10 +231,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adab1eaa3408fb7f0c777a73e7465fd5656136fc93b670eb6df3c88c2c1344e3"
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+
+[[package]]
+name = "libm"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
 name = "lock_api"
@@ -52,12 +259,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "log"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "memchr"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
 name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "nom"
+version = "7.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5507769c4919c998e69e49c839d9dc6e693ede4cc4290d6ad8b41d4f09c548c"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -177,12 +425,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+
+[[package]]
+name = "robust"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5864e7ef1a6b7bcf1d6ca3f655e65e724ed3b52546a0d0a663c991522f552ea"
+
+[[package]]
+name = "rstar"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b40f1bfe5acdab44bc63e6699c28b74f75ec43afb59f3eda01e145aff86a25fa"
+dependencies = [
+ "heapless",
+ "num-traits",
+ "smallvec",
+]
+
+[[package]]
 name = "rust"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "bincode",
+ "h3ron",
  "pyo3",
  "serde",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
 ]
 
 [[package]]
@@ -190,6 +483,12 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "semver"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
 
 [[package]]
 name = "serde"
@@ -218,6 +517,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
+name = "spin"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "syn"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,6 +549,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9410d0f6853b1d94f0e519fb95df60f29d2c1eff2d921ffdf01a4c8a3b54f12d"
 
 [[package]]
+name = "thiserror"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -245,6 +579,18 @@ name = "unindent"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58ee9362deb4a96cef4d437d1ad49cffc9b9e92d202b6995674e928ce684f112"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "windows-sys"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -352,6 +352,7 @@ version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "268be0c73583c183f2b14052337465768c07726936a260f480f0857cb95ba543"
 dependencies = [
+ "anyhow",
  "cfg-if",
  "indoc",
  "libc",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -50,6 +50,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_approx_eq"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c07dab4369547dbe5114677b33fbbf724971019f3818172d59a97a61c774ffd"
+
+[[package]]
 name = "atomic-polyfill"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -464,6 +470,7 @@ name = "rust"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_approx_eq",
  "bincode",
  "h3ron",
  "pyo3",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib"]
 [dependencies]
 bincode = "1.3.3"
 anyhow = "1.0.68"
+assert_approx_eq = "1.1.0"
 h3ron = { version = "0.16.0", features = ["use-serde", "parse"] }
 serde = { version = "1.0.143", features = ["derive"] }
 pyo3 = { version = "0.17.3", features = ["extension-module", "anyhow"] }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -10,5 +10,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 bincode = "1.3.3"
+anyhow = "1.0.68"
+h3ron = { version = "0.16.0", features = ["use-serde", "parse"] }
 serde = { version = "1.0.143", features = ["derive"] }
 pyo3 = { version = "0.17.3", features = ["extension-module"] }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -13,4 +13,4 @@ bincode = "1.3.3"
 anyhow = "1.0.68"
 h3ron = { version = "0.16.0", features = ["use-serde", "parse"] }
 serde = { version = "1.0.143", features = ["derive"] }
-pyo3 = { version = "0.17.3", features = ["extension-module"] }
+pyo3 = { version = "0.17.3", features = ["extension-module", "anyhow"] }

--- a/rust/src/entity_position.rs
+++ b/rust/src/entity_position.rs
@@ -4,10 +4,10 @@ use serde::{Deserialize, Serialize};
 use crate::geoid::Geoid;
 
 #[pyclass]
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(PartialEq, Clone, Serialize, Deserialize)]
 pub struct EntityPosition {
     #[pyo3(get)]
-    link_id: String,
+    pub link_id: String,
     #[pyo3(get)]
-    geoid: Geoid,
+    pub geoid: Geoid,
 }

--- a/rust/src/entity_position.rs
+++ b/rust/src/entity_position.rs
@@ -1,13 +1,43 @@
-use pyo3::prelude::*;
+use std::collections::HashMap;
+
+use pyo3::{prelude::*, types::PyDict};
 use serde::{Deserialize, Serialize};
 
-use crate::geoid::Geoid;
+use crate::{geoid::GeoidString, road_network::LinkId};
 
 #[pyclass]
 #[derive(PartialEq, Clone, Serialize, Deserialize)]
 pub struct EntityPosition {
     #[pyo3(get)]
-    pub link_id: String,
+    pub link_id: LinkId,
     #[pyo3(get)]
-    pub geoid: Geoid,
+    pub geoid: GeoidString,
+}
+
+#[pymethods]
+impl EntityPosition {
+    #[new]
+    fn new(link_id: LinkId, geoid: GeoidString) -> PyResult<Self> {
+        Ok(EntityPosition {
+            link_id: link_id,
+            geoid: geoid,
+        })
+    }
+
+    fn _asdict(&self) -> HashMap<String, String> {
+        let mut dict = HashMap::new();
+        dict.insert("link_id".to_string(), self.link_id.to_owned());
+        dict.insert("geoid".to_string(), self.geoid.to_owned());
+        dict
+    }
+
+    pub fn copy(&self) -> Self {
+        self.clone()
+    }
+    pub fn __copy__(&self) -> Self {
+        self.clone()
+    }
+    pub fn __deepcopy__(&self, _memo: &PyDict) -> Self {
+        self.clone()
+    }
 }

--- a/rust/src/entity_position.rs
+++ b/rust/src/entity_position.rs
@@ -1,0 +1,13 @@
+use pyo3::prelude::*;
+use serde::{Deserialize, Serialize};
+
+use crate::geoid::Geoid;
+
+#[pyclass]
+#[derive(Clone, Serialize, Deserialize)]
+pub struct EntityPosition {
+    #[pyo3(get)]
+    link_id: String,
+    #[pyo3(get)]
+    geoid: Geoid,
+}

--- a/rust/src/entity_position.rs
+++ b/rust/src/entity_position.rs
@@ -24,6 +24,8 @@ impl EntityPosition {
         })
     }
 
+    // the following methods are needed to support hive reporting
+
     fn _asdict(&self) -> HashMap<String, String> {
         let mut dict = HashMap::new();
         dict.insert("link_id".to_string(), self.link_id.to_owned());

--- a/rust/src/geoid.rs
+++ b/rust/src/geoid.rs
@@ -1,0 +1,19 @@
+use h3ron::H3Cell;
+use pyo3::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[pyclass]
+#[derive(Clone, Serialize, Deserialize)]
+pub struct Geoid {
+    pub h3_cell: H3Cell,
+}
+
+#[pymethods]
+impl Geoid {
+    pub fn __str__(&self) -> String {
+        self.h3_cell.to_string()
+    }
+    pub fn __repr__(&self) -> String {
+        self.h3_cell.to_string()
+    }
+}

--- a/rust/src/geoid.rs
+++ b/rust/src/geoid.rs
@@ -3,7 +3,7 @@ use pyo3::prelude::*;
 use serde::{Deserialize, Serialize};
 
 #[pyclass]
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(PartialEq, Copy, Clone, Serialize, Deserialize)]
 pub struct Geoid {
     pub h3_cell: H3Cell,
 }

--- a/rust/src/geoid.rs
+++ b/rust/src/geoid.rs
@@ -1,6 +1,11 @@
+use std::str::FromStr;
+
+use anyhow::Result;
 use h3ron::H3Cell;
 use pyo3::prelude::*;
 use serde::{Deserialize, Serialize};
+
+pub type GeoidString = String;
 
 #[pyclass]
 #[derive(PartialEq, Copy, Clone, Serialize, Deserialize)]
@@ -15,5 +20,12 @@ impl Geoid {
     }
     pub fn __repr__(&self) -> String {
         self.h3_cell.to_string()
+    }
+}
+
+impl Geoid {
+    pub fn from_string(string: String) -> Result<Self> {
+        let h3_cell = H3Cell::from_str(&string)?;
+        Ok(Geoid { h3_cell })
     }
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,24 +1,23 @@
 use pyo3::prelude::*;
 
+pub mod entity_position;
+pub mod geoid;
+pub mod link;
 pub mod membership;
 pub mod road_network;
-pub mod geoid;
-pub mod entity_position;
-pub mod link;
 pub mod utils;
 
-use membership::Membership;
-use road_network::RoadNetwork;
-use geoid::Geoid;
 use entity_position::EntityPosition;
+use geoid::Geoid;
 use link::LinkTraversal;
-
+use membership::Membership;
+use road_network::HaversineRoadNetwork;
 
 /// A Python module implemented in Rust.
 #[pymodule]
 fn hive_core(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<Membership>()?;
-    m.add_class::<RoadNetwork>()?;
+    m.add_class::<HaversineRoadNetwork>()?;
     m.add_class::<Geoid>()?;
     m.add_class::<EntityPosition>()?;
     m.add_class::<LinkTraversal>()?;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -4,11 +4,14 @@ pub mod membership;
 pub mod road_network;
 pub mod geoid;
 pub mod entity_position;
+pub mod link;
+pub mod utils;
 
 use membership::Membership;
 use road_network::RoadNetwork;
 use geoid::Geoid;
 use entity_position::EntityPosition;
+use link::LinkTraversal;
 
 
 /// A Python module implemented in Rust.
@@ -18,5 +21,6 @@ fn hive_core(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<RoadNetwork>()?;
     m.add_class::<Geoid>()?;
     m.add_class::<EntityPosition>()?;
+    m.add_class::<LinkTraversal>()?;
     Ok(())
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,13 +1,22 @@
 use pyo3::prelude::*;
 
 pub mod membership;
+pub mod road_network;
+pub mod geoid;
+pub mod entity_position;
 
 use membership::Membership;
+use road_network::RoadNetwork;
+use geoid::Geoid;
+use entity_position::EntityPosition;
 
 
 /// A Python module implemented in Rust.
 #[pymodule]
 fn hive_core(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<Membership>()?;
+    m.add_class::<RoadNetwork>()?;
+    m.add_class::<Geoid>()?;
+    m.add_class::<EntityPosition>()?;
     Ok(())
 }

--- a/rust/src/link.rs
+++ b/rust/src/link.rs
@@ -2,16 +2,17 @@ use pyo3::{prelude::*, types::PyType};
 
 use serde::{Deserialize, Serialize};
 
-use crate::geoid::Geoid;
+use crate::geoid::GeoidString;
+use crate::road_network::LinkId;
 use crate::utils::h3_dist_km;
 
 #[pyclass]
 #[derive(Clone, Serialize, Deserialize)]
 pub struct LinkTraversal {
     #[pyo3(get)]
-    pub link_id: String,
-    pub start: Geoid,
-    pub end: Geoid,
+    pub link_id: LinkId,
+    pub start: GeoidString,
+    pub end: GeoidString,
 
     pub distance_km: f64,
     pub speed_kmph: f64,
@@ -23,14 +24,14 @@ impl LinkTraversal {
     fn build(
         _: &PyType,
         link_id: String,
-        start: Geoid,
-        end: Geoid,
+        start: GeoidString,
+        end: GeoidString,
         speed_kmph: f64,
         distance_km: Option<f64>,
     ) -> PyResult<Self> {
         let dist = match distance_km {
             Some(d) => d,
-            None => h3_dist_km(start, end).unwrap(),
+            None => h3_dist_km(&start, &end).unwrap(),
         };
         Ok(LinkTraversal {
             link_id: link_id,

--- a/rust/src/link.rs
+++ b/rust/src/link.rs
@@ -1,0 +1,50 @@
+use pyo3::{prelude::*, types::PyType};
+
+use serde::{Deserialize, Serialize};
+
+use crate::geoid::Geoid;
+use crate::utils::h3_dist_km;
+
+#[pyclass]
+#[derive(Clone, Serialize, Deserialize)]
+pub struct LinkTraversal {
+    #[pyo3(get)]
+    pub link_id: String,
+    pub start: Geoid,
+    pub end: Geoid,
+
+    pub distance_km: f64,
+    pub speed_kmph: f64,
+}
+
+#[pymethods]
+impl LinkTraversal {
+    #[classmethod]
+    fn build(
+        _: &PyType,
+        link_id: String,
+        start: Geoid,
+        end: Geoid,
+        speed_kmph: f64,
+        distance_km: Option<f64>,
+    ) -> PyResult<Self> {
+        let dist = match distance_km {
+            Some(d) => d,
+            None => h3_dist_km(start, end).unwrap(),
+        };
+        Ok(LinkTraversal {
+            link_id: link_id,
+            start: start,
+            end: end,
+            speed_kmph: speed_kmph,
+            distance_km: dist,
+        })
+    }
+
+    #[getter]
+    fn travel_time_seconds(&self) -> f64 {
+        let time_hours = self.distance_km / self.speed_kmph;
+        let time_seconds = time_hours * 3600.0;
+        time_seconds
+    }
+}

--- a/rust/src/link.rs
+++ b/rust/src/link.rs
@@ -11,15 +11,35 @@ use crate::utils::h3_dist_km;
 pub struct LinkTraversal {
     #[pyo3(get)]
     pub link_id: LinkId,
+    #[pyo3(get)]
     pub start: GeoidString,
+    #[pyo3(get)]
     pub end: GeoidString,
 
+    #[pyo3(get)]
     pub distance_km: f64,
+    #[pyo3(get)]
     pub speed_kmph: f64,
 }
 
 #[pymethods]
 impl LinkTraversal {
+    #[new]
+    fn new(
+        link_id: String,
+        start: GeoidString,
+        end: GeoidString,
+        distance_km: f64,
+        speed_kmph: f64,
+    ) -> Self {
+        LinkTraversal {
+            link_id,
+            start,
+            end,
+            distance_km,
+            speed_kmph,
+        }
+    }
     #[classmethod]
     fn build(
         _: &PyType,
@@ -47,5 +67,25 @@ impl LinkTraversal {
         let time_hours = self.distance_km / self.speed_kmph;
         let time_seconds = time_hours * 3600.0;
         time_seconds
+    }
+
+    fn update_start(&self, new_start: GeoidString) -> Self {
+        LinkTraversal {
+            link_id: self.link_id.clone(),
+            start: new_start,
+            end: self.end.clone(),
+            distance_km: self.distance_km,
+            speed_kmph: self.speed_kmph,
+        }
+    }
+
+    fn update_end(&self, new_end: GeoidString) -> Self {
+        LinkTraversal {
+            link_id: self.link_id.clone(),
+            start: self.start.clone(),
+            end: new_end,
+            distance_km: self.distance_km,
+            speed_kmph: self.speed_kmph,
+        }
     }
 }

--- a/rust/src/link.rs
+++ b/rust/src/link.rs
@@ -89,3 +89,25 @@ impl LinkTraversal {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert_approx_eq::assert_approx_eq;
+
+    fn mock_link() -> LinkTraversal {
+        LinkTraversal {
+            link_id: "mock_link".to_string(),
+            start: "8f26dc934cccc69".to_string(),
+            end: "8f26dc934cc4cdb".to_string(),
+            distance_km: 0.14,
+            speed_kmph: 40.0,
+        }
+    }
+
+    #[test]
+    fn test_link_travel_time_seconds() {
+        let link = mock_link();
+        assert_approx_eq!(link.travel_time_seconds(), 12.6);
+    }
+}

--- a/rust/src/road_network.rs
+++ b/rust/src/road_network.rs
@@ -56,15 +56,7 @@ impl HaversineRoadNetwork {
         }
 
         let link_id = geoid_string_to_link_id(&origin.geoid, &destination.geoid);
-        let link_dist_km = match h3_dist_km(&origin.geoid, &destination.geoid) {
-            Err(e) => {
-                return Err(PyValueError::new_err(format!(
-                    "Failure computing h3 distance: {}",
-                    e
-                )))
-            }
-            Ok(dist) => dist,
-        };
+        let link_dist_km = h3_dist_km(&origin.geoid, &origin.geoid)?;
 
         let link = LinkTraversal {
             link_id: link_id,
@@ -85,15 +77,7 @@ impl HaversineRoadNetwork {
     }
 
     fn link_from_link_id(&self, link_id: LinkId) -> PyResult<LinkTraversal> {
-        let (source, dest) = match link_id_to_geoids(&link_id) {
-            Ok((source, dest)) => (source, dest),
-            Err(e) => {
-                return Err(PyValueError::new_err(format!(
-                    "Error converting link id to geoid {}",
-                    e
-                )))
-            }
-        };
+        let (source, dest) = link_id_to_geoids(&link_id)?; 
         let dist_km = self.distance_by_geoid_km(source.clone(), dest.clone())?;
         let link = LinkTraversal {
             link_id: link_id,

--- a/rust/src/road_network.rs
+++ b/rust/src/road_network.rs
@@ -1,12 +1,16 @@
-use std::{any, str::FromStr};
+use std::str::FromStr;
 
 use h3ron::H3Cell;
-use pyo3::prelude::*;
+use pyo3::{exceptions::PyValueError, prelude::*};
 use serde::{Deserialize, Serialize};
 
 use anyhow::{anyhow, Result};
 
-use crate::geoid::Geoid;
+use crate::{
+    entity_position::EntityPosition, geoid::Geoid, link::LinkTraversal, utils::h3_dist_km,
+};
+
+const AVG_SPEED_KMPH: f64 = 40.0;
 
 pub fn geoids_to_link_id(origin: Geoid, destination: Geoid) -> String {
     format!(
@@ -16,7 +20,7 @@ pub fn geoids_to_link_id(origin: Geoid, destination: Geoid) -> String {
     )
 }
 
-pub fn link_id_to_geoids(link_id: String) -> Result<(Geoid, Geoid)> {
+pub fn link_id_to_geoids(link_id: &String) -> Result<(Geoid, Geoid)> {
     let ids: Vec<&str> = link_id.split("-").collect();
     if ids.len() != 2 {
         return Err(anyhow!("LinkId not in expected format of [Geoid]-[Geoid]"));
@@ -33,4 +37,85 @@ pub fn link_id_to_geoids(link_id: String) -> Result<(Geoid, Geoid)> {
 
 #[pyclass]
 #[derive(Clone, Serialize, Deserialize)]
-pub struct RoadNetwork {}
+pub struct RoadNetwork {
+    sim_h3_resolution: usize,
+}
+
+#[pymethods]
+impl RoadNetwork {
+    #[new]
+    fn new(sim_h3_resolution: usize) -> PyResult<Self> {
+        Ok(RoadNetwork { sim_h3_resolution })
+    }
+
+    fn route(
+        &self,
+        origin: EntityPosition,
+        destination: EntityPosition,
+    ) -> PyResult<Vec<LinkTraversal>> {
+        if origin == destination {
+            return Ok(Vec::new());
+        }
+
+        let link_id = geoids_to_link_id(origin.geoid, destination.geoid);
+        let link_dist_km = match h3_dist_km(origin.geoid, destination.geoid) {
+            Err(e) => {
+                return Err(PyValueError::new_err(format!(
+                    "Failure computing h3 distance: {}",
+                    e
+                )))
+            }
+            Ok(dist) => dist,
+        };
+
+        let link = LinkTraversal {
+            link_id: link_id,
+            start: origin.geoid,
+            end: destination.geoid,
+            distance_km: link_dist_km,
+            speed_kmph: AVG_SPEED_KMPH,
+        };
+
+        let route = vec![link];
+
+        Ok(route)
+    }
+
+    fn distance_by_geoid_km(&self, origin: Geoid, destination: Geoid) -> PyResult<f64> {
+        h3_dist_km(origin, destination)
+            .map_err(|e| PyValueError::new_err(format!("Failure computing h3 distance: {}", e)))
+    }
+
+    fn link_from_link_id(&self, link_id: String) -> PyResult<LinkTraversal> {
+        let (source, dest) = match link_id_to_geoids(&link_id) {
+            Ok((source, dest)) => (source, dest),
+            Err(e) => {
+                return Err(PyValueError::new_err(format!(
+                    "Error converting link id to geoid {}",
+                    e
+                )))
+            }
+        };
+        let dist_km = self.distance_by_geoid_km(source, dest)?;
+        let link = LinkTraversal {
+            link_id: link_id,
+            start: source,
+            end: dest,
+            distance_km: dist_km,
+            speed_kmph: AVG_SPEED_KMPH,
+        };
+        Ok(link)
+    }
+
+    fn link_from_geoid(&self, geoid: Geoid) -> LinkTraversal {
+        let link_id = geoids_to_link_id(geoid, geoid);
+        let link = LinkTraversal {
+            link_id: link_id,
+            start: geoid,
+            end: geoid,
+            distance_km: 0.0,
+            speed_kmph: 0.0,
+        };
+        link
+    }
+}

--- a/rust/src/road_network.rs
+++ b/rust/src/road_network.rs
@@ -29,6 +29,7 @@ pub fn link_id_to_geoids(link_id: &LinkId) -> Result<(GeoidString, GeoidString)>
 #[pyclass]
 #[derive(Clone, Serialize, Deserialize)]
 pub struct HaversineRoadNetwork {
+    #[pyo3(get)]
     sim_h3_resolution: usize,
 }
 
@@ -122,5 +123,9 @@ impl HaversineRoadNetwork {
             link_id: link.link_id,
             geoid: geoid,
         }
+    }
+
+    fn geoid_within_geofence(&self, _geoid: GeoidString) -> bool {
+        true
     }
 }

--- a/rust/src/road_network.rs
+++ b/rust/src/road_network.rs
@@ -1,0 +1,36 @@
+use std::{any, str::FromStr};
+
+use h3ron::H3Cell;
+use pyo3::prelude::*;
+use serde::{Deserialize, Serialize};
+
+use anyhow::{anyhow, Result};
+
+use crate::geoid::Geoid;
+
+pub fn geoids_to_link_id(origin: Geoid, destination: Geoid) -> String {
+    format!(
+        "{}-{}",
+        origin.h3_cell.to_string(),
+        destination.h3_cell.to_string()
+    )
+}
+
+pub fn link_id_to_geoids(link_id: String) -> Result<(Geoid, Geoid)> {
+    let ids: Vec<&str> = link_id.split("-").collect();
+    if ids.len() != 2 {
+        return Err(anyhow!("LinkId not in expected format of [Geoid]-[Geoid]"));
+    } else {
+        let start_str = ids[0];
+        let start_h3 = H3Cell::from_str(start_str)?;
+        let start = Geoid { h3_cell: start_h3 };
+        let end_str = ids[1];
+        let end_h3 = H3Cell::from_str(end_str)?;
+        let end = Geoid { h3_cell: end_h3 };
+        return Ok((start, end));
+    }
+}
+
+#[pyclass]
+#[derive(Clone, Serialize, Deserialize)]
+pub struct RoadNetwork {}

--- a/rust/src/road_network.rs
+++ b/rust/src/road_network.rs
@@ -58,13 +58,13 @@ impl HaversineRoadNetwork {
         let link_id = geoid_string_to_link_id(&origin.geoid, &destination.geoid);
         let link_dist_km = h3_dist_km(&origin.geoid, &origin.geoid)?;
 
-        let link = LinkTraversal {
-            link_id: link_id,
-            start: origin.geoid,
-            end: destination.geoid,
-            distance_km: link_dist_km,
-            speed_kmph: AVG_SPEED_KMPH,
-        };
+        let link = LinkTraversal::new(
+            link_id,
+            origin.geoid,
+            destination.geoid,
+            link_dist_km,
+            AVG_SPEED_KMPH,
+        );
 
         let route = vec![link];
 
@@ -79,25 +79,25 @@ impl HaversineRoadNetwork {
     fn link_from_link_id(&self, link_id: LinkId) -> PyResult<LinkTraversal> {
         let (source, dest) = link_id_to_geoids(&link_id)?; 
         let dist_km = self.distance_by_geoid_km(source.clone(), dest.clone())?;
-        let link = LinkTraversal {
-            link_id: link_id,
-            start: source,
-            end: dest,
-            distance_km: dist_km,
-            speed_kmph: AVG_SPEED_KMPH,
-        };
+        let link = LinkTraversal::new( 
+            link_id,
+            source,
+            dest,
+            dist_km,
+            AVG_SPEED_KMPH,
+        );
         Ok(link)
     }
 
     fn link_from_geoid(&self, geoid: GeoidString) -> LinkTraversal {
         let link_id = geoid_string_to_link_id(&geoid, &geoid);
-        let link = LinkTraversal {
-            link_id: link_id,
-            start: geoid.clone(),
-            end: geoid.clone(),
-            distance_km: 0.0,
-            speed_kmph: 0.0,
-        };
+        let link = LinkTraversal::new( 
+            link_id,
+            geoid.clone(),
+            geoid.clone(),
+            0.0,
+            0.0,
+        );
         link
     }
 

--- a/rust/src/road_network.rs
+++ b/rust/src/road_network.rs
@@ -129,3 +129,31 @@ impl HaversineRoadNetwork {
         true
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mock_network() -> HaversineRoadNetwork {
+        HaversineRoadNetwork { sim_h3_resolution: 15 }
+    }
+
+    #[test]
+    fn test_link_id_to_geoids()  {
+        let link_id = "geoid1-geoid2".to_string();
+        let (geoid1, geoid2) = link_id_to_geoids(&link_id).unwrap();
+        assert_eq!(geoid1.as_str(), "geoid1");
+        assert_eq!(geoid2.as_str(), "geoid2");
+    }
+
+    #[test]
+    fn test_position_from_geoid()  {
+        let network = mock_network();
+        let geoid = "8f26dc934cccc69".to_string();
+        let position = network.position_from_geoid(geoid);
+        assert_eq!(position.geoid.as_str(), "8f26dc934cccc69");
+        assert_eq!(position.link_id.as_str(), "8f26dc934cccc69-8f26dc934cccc69");
+
+    }
+
+}

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -1,12 +1,13 @@
 use anyhow::Result;
 use h3ron::H3DirectedEdge;
 
-use crate::geoid::Geoid;
+use crate::geoid::{Geoid, GeoidString};
 
-/// Return the h3 line distance between two Geoids
-pub fn h3_dist_km(origin: Geoid, destination: Geoid) -> Result<f64> {
+/// Return the h3 line distance between two Geoid strings
+pub fn h3_dist_km(origin_string: &GeoidString, destination_string: &GeoidString) -> Result<f64> {
+    let origin = Geoid::from_string(origin_string.to_owned())?;
+    let destination = Geoid::from_string(destination_string.to_owned())?;
     let edge = H3DirectedEdge::from_cells(origin.h3_cell, destination.h3_cell)?;
     let length_km = edge.length_km()?;
     Ok(length_km)
 }
-

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -1,0 +1,12 @@
+use anyhow::Result;
+use h3ron::H3DirectedEdge;
+
+use crate::geoid::Geoid;
+
+/// Return the h3 line distance between two Geoids
+pub fn h3_dist_km(origin: Geoid, destination: Geoid) -> Result<f64> {
+    let edge = H3DirectedEdge::from_cells(origin.h3_cell, destination.h3_cell)?;
+    let length_km = edge.length_km()?;
+    Ok(length_km)
+}
+

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -1,13 +1,30 @@
 use anyhow::Result;
-use h3ron::H3DirectedEdge;
+use h3ron::ToCoordinate;
 
 use crate::geoid::{Geoid, GeoidString};
 
-/// Return the h3 line distance between two Geoid strings
+const EARTH_RADIUS: f64 = 6371.0;
+
+pub fn haversine(lat1: f64, lon1: f64, lat2: f64, lon2: f64) -> f64 {
+    let dlat = (lat2 - lat1).to_radians();
+    let dlon = (lon2 - lon1).to_radians();
+
+    let a = (dlat / 2.0).sin().powi(2)
+        + (dlon / 2.0).sin().powi(2) * lat1.to_radians().cos() * lat2.to_radians().cos();
+
+    let c = 2.0 * a.sqrt().asin();
+
+    let distance = c * EARTH_RADIUS;
+
+    distance
+}
+
+/// Return the line distance between two Geoid strings
 pub fn h3_dist_km(origin_string: &GeoidString, destination_string: &GeoidString) -> Result<f64> {
     let origin = Geoid::from_string(origin_string.to_owned())?;
     let destination = Geoid::from_string(destination_string.to_owned())?;
-    let edge = H3DirectedEdge::from_cells(origin.h3_cell, destination.h3_cell)?;
-    let length_km = edge.length_km()?;
-    Ok(length_km)
+    let origin_coord = origin.h3_cell.to_coordinate()?;
+    let dest_coord = destination.h3_cell.to_coordinate()?;
+    let distance_km = haversine(origin_coord.y, origin_coord.x, dest_coord.y, dest_coord.x);
+    Ok(distance_km)
 }


### PR DESCRIPTION
Adds in a rust haversine road network (and associated data structures like entity position and link traversal). 

Also updates how to run with the rust entities using the `USE_RUST` environment variable:

```shell
USE_RUST=True hive denver_demo.yaml
```