### PR TITLE
upgrade to mypy 1; properly set scenario output dir; add verbose flag

### DIFF
--- a/nrel/hive/app/hive_cosim.py
+++ b/nrel/hive/app/hive_cosim.py
@@ -56,7 +56,7 @@ def crank(
     :param time_steps: the number of steps to take, using the timestep size set in the HiveConfig
     :param progress_bar: show a progress bar in the console
     :param flush_events: write all requested event logs to their file destinations
-    :param track_charge_events: track vehicle charge events 
+    :param track_charge_events: track vehicle charge events
 
     :return: the updated simulation state and all charge events that occurred
     """
@@ -85,7 +85,7 @@ def crank(
 
             updated_events = events + (new_events,)
         else:
-            updated_events = tuple(pd.DataFrame()) 
+            updated_events = tuple(pd.DataFrame())
 
         return rp1, updated_events
 

--- a/nrel/hive/config/global_config.py
+++ b/nrel/hive/config/global_config.py
@@ -24,6 +24,7 @@ class GlobalConfig(NamedTuple):
     log_fleet_time_step_stats: bool
     lazy_file_reading: bool
     wkt_x_y_ordering: bool
+    verbose: bool
 
     @classmethod
     def default_config(cls) -> Dict:
@@ -46,6 +47,7 @@ class GlobalConfig(NamedTuple):
             "log_fleet_time_step_stats",
             "lazy_file_reading",
             "wkt_x_y_ordering",
+            "verbose",
         )
 
     @classmethod

--- a/nrel/hive/resources/defaults/.hive.yaml
+++ b/nrel/hive/resources/defaults/.hive.yaml
@@ -57,3 +57,6 @@ lazy_file_reading: False
 
 # If True, well know text inputs are read (X, Y) 
 wkt_x_y_ordering: True
+
+# If True, we print out more detail information in the logs 
+verbose: True

--- a/nrel/hive/state/simulation_state/simulation_state_ops.py
+++ b/nrel/hive/state/simulation_state/simulation_state_ops.py
@@ -450,7 +450,7 @@ def pop_vehicle_safe(
         if isinstance(remove_result, Failure):
             response = SimulationStateError(f"failure in pop_vehicle for vehicle {vehicle_id}")
             response.__cause__ = remove_result.failure()
-            return Failure(error)
+            return Failure(response)
         else:
             return Success((remove_result.unwrap(), vehicle))
 

--- a/nrel/hive/state/vehicle_state/servicing_ops.py
+++ b/nrel/hive/state/vehicle_state/servicing_ops.py
@@ -76,7 +76,9 @@ def complete_trip_phase(
 
     if not vehicle.vehicle_state.vehicle_state_type == VehicleStateType.SERVICING_POOLING_TRIP:
         return (
-            Exception(f"vehicle state is not ServicingPoolingTrip but {type(vehicle_state)}"),
+            Exception(
+                f"vehicle state is not ServicingPoolingTrip but {type(vehicle.vehicle_state)}"
+            ),
             None,
         )
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dev = [
     "nrel.hive[docs]",
     "pytest",
     "black",
-    "mypy<1",
+    "mypy",
     "twine",
     "types-PyYAML",
     "types-setuptools",


### PR DESCRIPTION
Applies a couple of things:
 - upgrades to mypy 1 and fixes new errors
 - when setting the scenario directory date in the function signature, we lose the ability to reset a scenario in the same python processes and have the date be updated. This moves the date setting to happen when the code is called and not just when it is initialized.
 - adds a new `verbose` flag to the global config to optionally cut down on logging noise when programmatically running several scenarios back-to-back