### PR TITLE
expose output_suffix in cosim API

### DIFF
--- a/nrel/hive/app/hive_cosim.py
+++ b/nrel/hive/app/hive_cosim.py
@@ -21,6 +21,7 @@ def load_scenario(
     scenario_file: Path,
     custom_instruction_generators: Optional[Tuple[T, ...]] = None,
     custom_init_functions: Optional[Iterable[InitFunction]] = None,
+    output_suffix: Optional[str] = None
 ) -> RunnerPayload:
     """
     load a HIVE scenario from file and return the initial simulation state
@@ -28,7 +29,7 @@ def load_scenario(
     :return: the initial simulation state payload
     :raises: Error when issues with files
     """
-    config = load_config(scenario_file)
+    config = load_config(scenario_file, output_suffix)
     initial_payload = load_simulation(config, custom_instruction_generators, custom_init_functions)
 
     # add a specialized Reporter handler that catches vehicle charge events

--- a/nrel/hive/app/hive_cosim.py
+++ b/nrel/hive/app/hive_cosim.py
@@ -21,7 +21,7 @@ def load_scenario(
     scenario_file: Path,
     custom_instruction_generators: Optional[Tuple[T, ...]] = None,
     custom_init_functions: Optional[Iterable[InitFunction]] = None,
-    output_suffix: Optional[str] = None
+    output_suffix: Optional[str] = None,
 ) -> RunnerPayload:
     """
     load a HIVE scenario from file and return the initial simulation state

--- a/nrel/hive/dispatcher/instruction/instructions.py
+++ b/nrel/hive/dispatcher/instruction/instructions.py
@@ -150,7 +150,10 @@ class DispatchPoolingTripInstruction(Instruction):
             error = InstructionError(msg)
             return error, None
         else:
-            (disp_error, next_state,) = dispatch_ops.begin_or_replan_dispatch_pooling_state(
+            (
+                disp_error,
+                next_state,
+            ) = dispatch_ops.begin_or_replan_dispatch_pooling_state(
                 sim_state, self.vehicle_id, self.trip_plan
             )
             if disp_error is not None:

--- a/nrel/hive/dispatcher/instruction/instructions.py
+++ b/nrel/hive/dispatcher/instruction/instructions.py
@@ -150,10 +150,7 @@ class DispatchPoolingTripInstruction(Instruction):
             error = InstructionError(msg)
             return error, None
         else:
-            (
-                disp_error,
-                next_state,
-            ) = dispatch_ops.begin_or_replan_dispatch_pooling_state(
+            (disp_error, next_state,) = dispatch_ops.begin_or_replan_dispatch_pooling_state(
                 sim_state, self.vehicle_id, self.trip_plan
             )
             if disp_error is not None:

--- a/nrel/hive/dispatcher/instruction/instructions.py
+++ b/nrel/hive/dispatcher/instruction/instructions.py
@@ -150,12 +150,10 @@ class DispatchPoolingTripInstruction(Instruction):
             error = InstructionError(msg)
             return error, None
         else:
-            (
-                disp_error,
-                next_state,
-            ) = dispatch_ops.begin_or_replan_dispatch_pooling_state(
+            result = dispatch_ops.begin_or_replan_dispatch_pooling_state(
                 sim_state, self.vehicle_id, self.trip_plan
             )
+            disp_error, next_state = result
             if disp_error is not None:
                 return disp_error, None
             elif next_state is None:

--- a/nrel/hive/initialization/load.py
+++ b/nrel/hive/initialization/load.py
@@ -29,6 +29,7 @@ T = TypeVar("T", bound=InstructionGenerator)
 
 def load_config(
     scenario_file: Union[Path, str],
+    output_suffix: Optional[str] = None
 ) -> HiveConfig:
     try:
         scenario_file_path = fs.find_scenario(str(scenario_file))
@@ -39,7 +40,7 @@ def load_config(
     with scenario_file_path.open("r") as f:
         config_builder = yaml.safe_load(f)
 
-    config_or_error = HiveConfig.build(scenario_file_path, config_builder)
+    config_or_error = HiveConfig.build(scenario_file_path, config_builder, output_suffix)
     if isinstance(config_or_error, Exception):
         log.exception("attempted to load scenario config file but failed")
         raise config_or_error

--- a/nrel/hive/initialization/load.py
+++ b/nrel/hive/initialization/load.py
@@ -27,10 +27,7 @@ log = logging.getLogger(__name__)
 T = TypeVar("T", bound=InstructionGenerator)
 
 
-def load_config(
-    scenario_file: Union[Path, str],
-    output_suffix: Optional[str] = None
-) -> HiveConfig:
+def load_config(scenario_file: Union[Path, str], output_suffix: Optional[str] = None) -> HiveConfig:
     try:
         scenario_file_path = fs.find_scenario(str(scenario_file))
     except FileNotFoundError as fe:

--- a/nrel/hive/state/simulation_state/update/step_simulation_ops.py
+++ b/nrel/hive/state/simulation_state/update/step_simulation_ops.py
@@ -158,10 +158,7 @@ def apply_instructions(
         results.append(result)
 
     for instruction_result in results:
-        (
-            update_error,
-            updated_sim,
-        ) = entity_state_ops.transition_previous_to_next(
+        (update_error, updated_sim,) = entity_state_ops.transition_previous_to_next(
             sim, env, instruction_result.prev_state, instruction_result.next_state
         )
         if update_error:

--- a/nrel/hive/state/simulation_state/update/step_simulation_ops.py
+++ b/nrel/hive/state/simulation_state/update/step_simulation_ops.py
@@ -158,12 +158,10 @@ def apply_instructions(
         results.append(result)
 
     for instruction_result in results:
-        (
-            update_error,
-            updated_sim,
-        ) = entity_state_ops.transition_previous_to_next(
+        result = entity_state_ops.transition_previous_to_next(
             sim, env, instruction_result.prev_state, instruction_result.next_state
         )
+        update_error, updated_sim = result
         if update_error:
             log.error(update_error)
             continue

--- a/nrel/hive/state/simulation_state/update/step_simulation_ops.py
+++ b/nrel/hive/state/simulation_state/update/step_simulation_ops.py
@@ -158,7 +158,10 @@ def apply_instructions(
         results.append(result)
 
     for instruction_result in results:
-        (update_error, updated_sim,) = entity_state_ops.transition_previous_to_next(
+        (
+            update_error,
+            updated_sim,
+        ) = entity_state_ops.transition_previous_to_next(
             sim, env, instruction_result.prev_state, instruction_result.next_state
         )
         if update_error:

--- a/nrel/hive/state/simulation_state/update/step_simulation_ops.py
+++ b/nrel/hive/state/simulation_state/update/step_simulation_ops.py
@@ -3,7 +3,7 @@ from dataclasses import asdict
 
 import functools as ft
 import logging
-from typing import Tuple, Optional, TYPE_CHECKING, Callable, NamedTuple
+from typing import List, Tuple, Optional, TYPE_CHECKING, Callable, NamedTuple
 
 from nrel.hive.dispatcher.instruction.instruction import Instruction
 from nrel.hive.dispatcher.instruction.instruction_result import InstructionResult
@@ -140,13 +140,13 @@ def apply_instructions(
     """
     # construct the vehicle state transitions
 
-    results: list[InstructionResult] = []
+    results: List[InstructionResult] = []
     for instruction in instructions:
-        err, result = instruction.apply_instruction(sim, env)
+        err, instruction_result = instruction.apply_instruction(sim, env)
         if err is not None:
             log.error(err)
             continue
-        if result is None:
+        if instruction_result is None:
             log.error("this should not be none if error is not none")
             continue
 
@@ -155,7 +155,7 @@ def apply_instructions(
         )
         sim = sim._replace(applied_instructions=updated_instructions)
 
-        results.append(result)
+        results.append(instruction_result)
 
     for instruction_result in results:
         result = entity_state_ops.transition_previous_to_next(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ docs = [
 dev = [
     "nrel.hive[docs]",
     "pytest",
-    "black",
+    "black==23.1.0",
     "mypy",
     "twine",
     "types-PyYAML",


### PR DESCRIPTION
this quick PR exposes output_suffix via the cosim API so that the suffix can be set before creating the scenario.

in both cases where it has been added to a function signature, it has been done with a default value that is consistent with any existing invocations.