### PR TITLE
adjust human driver go home logic

### DIFF
--- a/nrel/hive/config/dispatcher_config.py
+++ b/nrel/hive/config/dispatcher_config.py
@@ -17,6 +17,8 @@ class DispatcherConfig(NamedTuple):
     max_search_radius_km: Kilometers
     charging_search_type: ChargingSearchType
 
+    human_driver_off_shift_charge_target: Ratio
+
     idle_time_out_seconds: Seconds
 
     valid_dispatch_states: Tuple[str, ...]

--- a/nrel/hive/resources/defaults/hive_config.yaml
+++ b/nrel/hive/resources/defaults/hive_config.yaml
@@ -22,6 +22,7 @@ dispatcher:
   charging_range_km_soft_threshold: 50          # ignore charging at stations when remaining range is greater than 50km
   base_charging_range_km_threshold: 100         # ignore base charging at bases more than 100 km away
   ideal_fastcharge_soc_limit: 0.8               # fast charging can finish when 80% state-of-charge is reached
+  human_driver_off_shift_charge_target: 1.0     # human drivers w/out home charging will charge to this SOC post shift 
   max_search_radius_km: 100.0                   # when searching, ignore entities that are further than 100km away
   valid_dispatch_states:                        # allow agents to service a trip coming only from these vehicle states
     - idle


### PR DESCRIPTION
Updates the human driver logic such that when they go off-shift, any driver that either cannot get home without running out of energy, or, does't have home charging will attempt to charge at the shift end to a new config parameter `config.distpacher.human_driver_off_shift_charge_target` 