### PR TITLE
restrict to h3 3.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "PyYAML",
     "tqdm",
     "rich",
-    "h3>=3.7.1",
+    "h3 < 4",
     "scipy",
     "returns",
 ]


### PR DESCRIPTION
quick change to address #139, preventing users from mistakenly installing the forthcoming uber h3 4.x series with breaking API changes. leaving the issue open for discussion + work to upgrade to the 4.x API.