### PR TITLE
list contributors based on NREL SWR

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,18 @@ If you have found HIVE useful for your research, please cite our [technical repo
 }
 ```
 
+## Contributors
+
+HIVE is currently maintained by Nick Reinicke ([@nreinicke] (https://github.com/nreinicke)) and Rob Fitzgerald ([@robfitzgerald](https://github.com/robfitzgerald)). It would not be what it is today without the support of: 
+- Brennan Borlaug
+- Thomas Grushka
+- Jacob Holden
+- Joshua Hoshiko
+- Eleftheria Kontou
+- Matthew Moniot
+- Eric Wood
+- Clement Raimes
+
 ## Notice
 
 Copyright © 2022 Alliance for Sustainable Energy, LLC, Inc. All Rights Reserved


### PR DESCRIPTION
a quick list of contributors based on the [HIVE software record](https://www.osti.gov/biblio/1896384). did i miss anyone? didn't add a CONTRIBUTORS.md file or anything, simply added the list of active maintainers (NickandRob) with github account links and everyone else in a bullet list.

Closes #130.