### PR TITLE
reorder dispatchers so charge instructions trump rides.

### DIFF
--- a/nrel/hive/initialization/load.py
+++ b/nrel/hive/initialization/load.py
@@ -91,8 +91,8 @@ def load_simulation(
 
     if custom_instruction_generators is None:
         instruction_generators = (
-            ChargingFleetManager(env.config.dispatcher),
             Dispatcher(env.config.dispatcher),
+            ChargingFleetManager(env.config.dispatcher),
         )
         update = Update.build(env.config, instruction_generators)
     else:


### PR DESCRIPTION
Updates the order of the default instruction generators such that any charge instructions will override a dispatch instruction. 