### PR TITLE
version 1.2.2

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,7 +23,7 @@ copyright = "2022, NREL"
 author = "NREL"
 
 # The full version, including alpha/beta/rc tags
-release = "v1.2.1"
+release = "v1.2.2"
 
 # -- General configuration ---------------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nrel.hive"
-version = "1.2.1"
+version = "1.2.2"
 description = "HIVE is a mobility services research platform developed by the Mobility and Advanced Powertrains (MBAP) group at the National Renewable Energy Laboratory in Golden, Colorado, USA."
 readme = "README.md"
 authors = [{ name = "National Renewable Energy Laboratory" }]


### PR DESCRIPTION
includes a missing and urgent update for running shortest path searches based on travel times, as well as documentation improvements. [commit log](https://github.com/NREL/hive/compare/v1.2.1...release-v1.2.2)