### PR TITLE
add contributing page to developers page on docs

### DIFF
--- a/docs/source/developer/index.rst
+++ b/docs/source/developer/index.rst
@@ -5,4 +5,5 @@ Developer Docs
    :maxdepth: 2
 
   release 
+  contributing
 


### PR DESCRIPTION
Links in the contributing page to the developer section in the documentation