### PR TITLE
pull out python 3.7 support

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,7 @@ jobs:
       strategy:
         fail-fast: false
         matrix:
-          python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+          python-version: ['3.8', '3.9', '3.10', '3.11']
 
       env:
         PYTHON: ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For more documentation on how to use HIVE, please see the [HIVE documentation](h
 
 ## Installation
 
-HIVE depends on a Python installation [3.7, 3.8, 3.9, 3.10, 3.11] and the pip package manager ( [python.org](https://www.python.org/downloads/).
+HIVE depends on a Python installation [3.8, 3.9, 3.10, 3.11] and the pip package manager ( [python.org](https://www.python.org/downloads/).
 In our installation example we use [conda](https://www.anaconda.com/products/distribution) |  for managing a HIVE Python environment.
 
 ### (optional) set up a virtual environment using conda

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "scipy",
     "returns",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 
 [project.optional-dependencies]
 docs = [


### PR DESCRIPTION
In May of 2020, we added python 3.7 support since several of the reinforcement learning algorithms we were using did not yet support anything above 3.7. Since then the libraries like RLlib has been updated to support later versions of python. I think it makes sense to drop this now, opening us up to use 3.8 and up specific features. 