### PR TITLE
add a quick start and customize page to docs

### DIFF
--- a/docs/source/customize.md
+++ b/docs/source/customize.md
@@ -1,0 +1,17 @@
+# Customize
+
+In addition to using hive as a command line application to run a simulation, you can also use hive as a library for co-simulation or you can extend the existing control logic.
+
+## Co-Simulation
+
+Co-simulation can be done using the `nrel.hive.app.hive_cosim` module.
+
+That module exposes a `crank` function that takes in a RunnerPayload and an integer that defines how many time steps should be run and returns a `CrankResult` object that includes the updated RunnerPayload and its sim time. At this point, you can examine the simulation state and decide what to do next, continuing in this fashion.
+
+## Custom Control Logic
+
+Adding custom control logic can be done by creating a sub class for the `InstructionGenerator` class and overriding the `generate_instructions` method. You can then inject the control module into the simulation at load time using the `load_scenario` function and then, at crank step, you can optionally update your custom control object by getting it with the `get_instruction_generator` function, modifying it and putting it back into the simulation with `update_instruction_generator`.
+
+## Example
+
+See the [cosim_custom_dispatcher.py](https://github.com/NREL/hive/blob/main/examples/cosim_custom_dispatcher.py) file for an example of using custom control logic with the co-simulation API.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -7,7 +7,22 @@ HIVE supports researchers who explore Electric Vehicle (EV) fleet control, Elect
 Out-of-the-box, it provides a baseline set of algorithms for fleet dispatch, but provides a testbed for exploring alternatives from leading research in model-predictive control (MPC) and deep reinforcement learning. 
 HIVE is designed to integrate with vehicle power and energy grid power models in real-time for accurate, high-fidelity energy estimation over arbitrary road networks and demand scenarios.
 
-Checkout the `README <https://github.com/NREL/hive>`_ for installation instructions.
+Quickstart
+----------
+
+You can install hive with `pip install nrel.hive`
+(see the `README <https://github.com/NREL/hive>` for more detailed instructions)
+
+HIVE is typically run using the command line interface (CLI) by calling the `hive` command.
+For example, you can run either of the pre-packaged scenarios with `hive denver_demo.yaml` or `hive manhattan.yaml`.
+
+The model takes in a single configuration file that specifies everything that makes up a single simulation (see the inputs page).  
+
+When the simulation is run (`hive denver_demo.yaml` for example), the model will write several output files that describe what happened during the simulation (see the outputs page).
+
+You can also use hive as library for co-simulation or to implement custom control logic (see the customize page).
+
+Lastly, if you're interested in contributing, checkout the developer page!
 
 .. toctree::
    :maxdepth: 1 
@@ -15,6 +30,7 @@ Checkout the `README <https://github.com/NREL/hive>`_ for installation instructi
    example
    inputs
    outputs
+   customize
    developer/index
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -7,26 +7,10 @@ HIVE supports researchers who explore Electric Vehicle (EV) fleet control, Elect
 Out-of-the-box, it provides a baseline set of algorithms for fleet dispatch, but provides a testbed for exploring alternatives from leading research in model-predictive control (MPC) and deep reinforcement learning. 
 HIVE is designed to integrate with vehicle power and energy grid power models in real-time for accurate, high-fidelity energy estimation over arbitrary road networks and demand scenarios.
 
-Quickstart
-----------
-
-You can install hive with `pip install nrel.hive`
-(see the `README <https://github.com/NREL/hive>` for more detailed instructions)
-
-HIVE is typically run using the command line interface (CLI) by calling the `hive` command.
-For example, you can run either of the pre-packaged scenarios with `hive denver_demo.yaml` or `hive manhattan.yaml`.
-
-The model takes in a single configuration file that specifies everything that makes up a single simulation (see the inputs page).  
-
-When the simulation is run (`hive denver_demo.yaml` for example), the model will write several output files that describe what happened during the simulation (see the outputs page).
-
-You can also use hive as library for co-simulation or to implement custom control logic (see the customize page).
-
-Lastly, if you're interested in contributing, checkout the developer page!
-
 .. toctree::
    :maxdepth: 1 
-   
+
+   quick_start
    example
    inputs
    outputs

--- a/docs/source/quick_start.md
+++ b/docs/source/quick_start.md
@@ -1,0 +1,15 @@
+# Quick Start
+
+You can install hive with `pip install nrel.hive`
+(see the [README](https://github.com/NREL/hive) for more detailed instructions)
+
+HIVE is typically run using the command line interface (CLI) by calling the `hive` command.
+For example, you can run either of the pre-packaged scenarios with `hive denver_demo.yaml` or `hive manhattan.yaml`.
+
+The model takes in a single configuration file that specifies everything that makes up a single simulation (see the inputs page).
+
+When the simulation is run (`hive denver_demo.yaml` for example), the model will write several output files that describe what happened during the simulation (see the outputs page).
+
+You can also use hive as library for co-simulation or to implement custom control logic (see the customize page).
+
+Lastly, if you're interested in contributing, checkout the developer page!


### PR DESCRIPTION
Adds a new quick start section to the docs landing page. Also adds a customize page that starts to explain things like how to run a co-simulation and how to inject custom control logic.