### PR TITLE
[#168] Correct build process docs to remove unwanted files first

### DIFF
--- a/docs/source/developer/release.md
+++ b/docs/source/developer/release.md
@@ -7,12 +7,18 @@
 
 1. Create a new branch and open a PR on GitHub which will run all actions
 
-1. Apply any fixes to make the actions pass 
+1. Apply any fixes to make the actions pass
+
+1. Clean your local directory. This will prevent any files not under source control from being built into the distribution.
+
+   ```bash
+   git clean -f -x 
+   ```
 
 1. Build the wheel and source distributions:
 
     ```bash
-    python setup.py bdist_wheel sdist
+    python setup.py clean bdist_wheel sdist
     ```
 
 1. Upload to Test PyPi


### PR DESCRIPTION
Found during discussion of https://github.com/NREL/hive/issues/168

During the Pycon sprint, found that a virtual environment that I'd run `pip install nrel.hive` in was executing code that had a bug that was fixed six months ago. On investigation, found that the wheel had had an old directory bundled into it, most likely from a desktop computer where the working directory hadn't been cleaned up between now and the creation of the `nrel` subdirectory.

```
unzip -l nrel.hive-1.2.2-py3-none-any.whl 
Archive:  nrel.hive-1.2.2-py3-none-any.whl
  Length      Date    Time    Name
---------  ---------- -----   ----
     6148  2023-02-07 23:38   .DS_Store
     1428  2022-08-16 17:54   hive/__init__.py
       94  2022-08-17 15:37   hive/__main__.py
(...)
       56  2022-11-02 21:45   nrel/__init__.py
     1327  2022-11-29 19:20   nrel/hive/__init__.py
       99  2022-10-20 17:47   nrel/hive/__main__.py
```

The `.DS_Store` file also indicates that invisible mac os files are getting distributed, which is not harmful but indicates a dirty build process.

Edited the build process docs to include commands which should clean up extra files before build