### PR TITLE
Passenger rust implementation

### DIFF
--- a/nrel/hive/model/base.py
+++ b/nrel/hive/model/base.py
@@ -65,7 +65,6 @@ else:
             stall_count: int,
             membership: Membership = Membership(),
         ):
-
             position = road_network.position_from_geoid(geoid)
             if position is None:
                 raise ValueError("cannot position base on road network")

--- a/rust/pyproject.toml
+++ b/rust/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "hive_core"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",

--- a/rust/src/base.rs
+++ b/rust/src/base.rs
@@ -8,12 +8,10 @@ use pyo3::{
     types::{PyDict, PyType},
 };
 
+use crate::type_aliases::*;
 use crate::{
-    entity_position::EntityPosition, geoid::GeoidString, membership::Membership,
-    road_network::HaversineRoadNetwork, station::StationId,
+    entity_position::EntityPosition, membership::Membership, road_network::HaversineRoadNetwork,
 };
-
-pub type BaseId = String;
 
 #[pyclass]
 #[derive(Clone)]

--- a/rust/src/entity_position.rs
+++ b/rust/src/entity_position.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use pyo3::{prelude::*, types::PyDict};
 
-use crate::{geoid::GeoidString, road_network::LinkId};
+use crate::type_aliases::*;
 
 #[pyclass]
 #[derive(PartialEq, Clone)]

--- a/rust/src/geoid.rs
+++ b/rust/src/geoid.rs
@@ -5,7 +5,7 @@ use h3ron::H3Cell;
 use pyo3::prelude::*;
 use serde::{Deserialize, Serialize};
 
-pub type GeoidString = String;
+use crate::type_aliases::*;
 
 #[pyclass]
 #[derive(PartialEq, Copy, Clone, Serialize, Deserialize)]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,12 +1,14 @@
 use pyo3::prelude::*;
 
+mod type_aliases;
+
 pub mod base;
-pub mod station;
 pub mod entity_position;
 pub mod geoid;
 pub mod link;
 pub mod membership;
 pub mod road_network;
+pub mod station;
 pub mod utils;
 
 use base::Base;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -7,6 +7,7 @@ pub mod entity_position;
 pub mod geoid;
 pub mod link;
 pub mod membership;
+pub mod passenger;
 pub mod road_network;
 pub mod station;
 pub mod utils;
@@ -16,6 +17,7 @@ use entity_position::EntityPosition;
 use geoid::Geoid;
 use link::LinkTraversal;
 use membership::Membership;
+use passenger::Passenger;
 use road_network::HaversineRoadNetwork;
 
 /// A Python module implemented in Rust.
@@ -27,5 +29,6 @@ fn hive_core(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<EntityPosition>()?;
     m.add_class::<LinkTraversal>()?;
     m.add_class::<Base>()?;
+    m.add_class::<Passenger>()?;
     Ok(())
 }

--- a/rust/src/link.rs
+++ b/rust/src/link.rs
@@ -3,8 +3,7 @@ use std::sync::Arc;
 use pyo3::exceptions::PyValueError;
 use pyo3::{prelude::*, types::PyType};
 
-use crate::geoid::GeoidString;
-use crate::road_network::LinkId;
+use crate::type_aliases::*;
 use crate::utils::h3_dist_km;
 
 #[pyclass]

--- a/rust/src/membership.rs
+++ b/rust/src/membership.rs
@@ -5,8 +5,9 @@ use pyo3::{
     prelude::*,
     types::{PyDict, PyType},
 };
-
 use serde::{Deserialize, Serialize};
+
+use crate::type_aliases::*;
 
 const PUBLIC_MEMBERSHIP_ID: &str = "public";
 
@@ -14,7 +15,7 @@ const PUBLIC_MEMBERSHIP_ID: &str = "public";
 #[derive(Clone, Serialize, Deserialize)]
 pub struct Membership {
     #[pyo3(get)]
-    memberships: HashSet<String>,
+    memberships: HashSet<MembershipId>,
 }
 
 impl Default for Membership {

--- a/rust/src/passenger.rs
+++ b/rust/src/passenger.rs
@@ -1,0 +1,105 @@
+use std::sync::Arc;
+
+use pyo3::{
+    prelude::*,
+    types::{PyDict, PyType},
+};
+
+use crate::membership::Membership;
+use crate::type_aliases::*;
+
+#[pyclass]
+#[derive(Clone)]
+pub struct Passenger {
+    id: Arc<PassengerId>,
+    origin: Arc<GeoidString>,
+    destination: Arc<GeoidString>,
+    departure_time: Arc<SimTime>,
+    membership: Arc<Membership>,
+    vehicle_id: Arc<Option<VehicleId>>,
+}
+
+impl Passenger {
+    pub fn new(
+        id: PassengerId,
+        origin: GeoidString,
+        destination: GeoidString,
+        departure_time: SimTime,
+        membership: Option<Membership>,
+        vehicle_id: Option<VehicleId>,
+    ) -> Self {
+        Passenger {
+            id: Arc::new(id),
+            origin: Arc::new(origin),
+            destination: Arc::new(destination),
+            departure_time: Arc::new(departure_time),
+            membership: Arc::new(membership.unwrap_or_default()),
+            vehicle_id: Arc::new(vehicle_id),
+        }
+    }
+}
+
+#[pymethods]
+impl Passenger {
+    pub fn copy(&self) -> Self {
+        self.clone()
+    }
+    pub fn __copy__(&self) -> Self {
+        self.clone()
+    }
+    pub fn __deepcopy__(&self, _memo: &PyDict) -> Self {
+        self.clone()
+    }
+
+    #[getter]
+    pub fn id(&self) -> BaseId {
+        (*self.id).clone()
+    }
+
+    #[getter]
+    pub fn origin(&self) -> GeoidString {
+        (*self.origin).clone()
+    }
+
+    #[getter]
+    pub fn destination(&self) -> GeoidString {
+        (*self.destination).clone()
+    }
+
+    #[getter]
+    pub fn departure_time<'a>(&'a self, py: Python<'a>) -> PyResult<&PyAny> {
+        let locals = PyDict::new(py);
+        let sim_time_mod = PyModule::import(py, "nrel.hive.model.sim_time")?;
+        locals.set_item("SimTime", sim_time_mod.getattr("SimTime")?)?;
+        locals.set_item("departure_time", (*self.departure_time).clone())?;
+        py.eval("SimTime(departure_time)", None, Some(locals))
+    }
+
+    pub fn membership(&self) -> Membership {
+        (*self.membership).clone()
+    }
+
+    pub fn vehicle_id(&self) -> Option<VehicleId> {
+        (*self.vehicle_id).clone()
+    }
+
+    #[classmethod]
+    pub fn build(
+        _cls: &PyType,
+        id: PassengerId,
+        origin: GeoidString,
+        destination: GeoidString,
+        departure_time: SimTime,
+        membership: Option<Membership>,
+        vehicle_id: Option<VehicleId>,
+    ) -> Self {
+        Passenger::new(
+            id,
+            origin,
+            destination,
+            departure_time,
+            membership,
+            vehicle_id,
+        )
+    }
+}

--- a/rust/src/station.rs
+++ b/rust/src/station.rs
@@ -1,1 +1,1 @@
-pub type StationId = String;
+

--- a/rust/src/type_aliases.rs
+++ b/rust/src/type_aliases.rs
@@ -1,0 +1,16 @@
+pub type RequestId = String;
+pub type VehicleId = String;
+pub type StationId = String;
+pub type PowertrainId = String;
+pub type PowercurveId = String;
+pub type BaseId = String;
+pub type PassengerId = String;
+pub type VehicleTypeId = String;
+pub type MechatronicsId = String;
+pub type ChargerId = String;
+pub type MembershipId = String;
+pub type ScheduleId = String;
+pub type EntityId = String;
+pub type SimTime = usize;
+pub type GeoidString = String;
+pub type LinkId = String;

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -1,7 +1,8 @@
 use anyhow::Result;
 use h3ron::ToCoordinate;
 
-use crate::geoid::{Geoid, GeoidString};
+use crate::geoid::Geoid;
+use crate::type_aliases::*;
 
 const EARTH_RADIUS: f64 = 6371.0;
 


### PR DESCRIPTION
I pulled out the type aliases into a separate file (and added a bunch from `typealiases.py` that are unused so far). I also ran `cargo fmt`, which is the source of some of the random formatting changes.

Then I added a `Passenger` rust implementation. It was mostly straightforward, but internally it stores `SimTime` as a type aliased integer rather than custom implementing `SimTime` as a `#[pyclass]` extending `int`. Because the extra methods on `SimTime` are primarily for converting to/from human-readable formats this seems fine to me.