### PR TITLE
add ability to specify custom instruction generator function

### DIFF
--- a/docs/source/customize.md
+++ b/docs/source/customize.md
@@ -10,7 +10,12 @@ That module exposes a `crank` function that takes in a RunnerPayload and an inte
 
 ## Custom Control Logic
 
-Adding custom control logic can be done by creating a sub class for the `InstructionGenerator` class and overriding the `generate_instructions` method. You can then inject the control module into the simulation at load time using the `load_scenario` function and then, at crank step, you can optionally update your custom control object by getting it with the `get_instruction_generator` function, modifying it and putting it back into the simulation with `update_instruction_generator`.
+Adding custom control logic can be done in two ways:
+
+1. Creating a sub class for the `InstructionGenerator` class and overriding the `generate_instructions` method.
+1. Creating a function that takes in the simulation state and the environment and returning an instruction set.
+
+You can then inject the control module into the simulation at load time using the `load_scenario` function and then, at crank step, you can optionally update your custom control object by getting it with the `get_instruction_generator` function, modifying it and putting it back into the simulation with `update_instruction_generator`.
 
 ## Example
 

--- a/nrel/hive/dispatcher/instruction_generator/instruction_function.py
+++ b/nrel/hive/dispatcher/instruction_generator/instruction_function.py
@@ -21,7 +21,8 @@ class AnonGenerator(InstructionGenerator):
 
     @property
     def name(self) -> str:
-        return self.__class__.__name__
+        # return the name of the function
+        return self.instruction_function.__name__
 
     def generate_instructions(
         self,

--- a/nrel/hive/dispatcher/instruction_generator/instruction_function.py
+++ b/nrel/hive/dispatcher/instruction_generator/instruction_function.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import Tuple, Callable, TYPE_CHECKING, Union
+
+from nrel.hive.dispatcher.instruction_generator.instruction_generator import InstructionGenerator
+from nrel.hive.state.simulation_state.simulation_state import SimulationState
+from nrel.hive.runner.environment import Environment
+from nrel.hive.dispatcher.instruction.instruction import Instruction
+
+
+InstructionFunction = Callable[[SimulationState, Environment], Tuple[Instruction, ...]]
+
+
+class AnonGenerator(InstructionGenerator):
+    """
+    A class that wraps an instruction function as an instruction generator
+    """
+
+    def __init__(self, instruction_function: InstructionFunction):
+        self.instruction_function = instruction_function
+
+    @property
+    def name(self) -> str:
+        return self.__class__.__name__
+
+    def generate_instructions(
+        self,
+        simulation_state: SimulationState,
+        environment: Environment,
+    ) -> Tuple[InstructionGenerator, Tuple[Instruction, ...]]:
+        return self, self.instruction_function(simulation_state, environment)
+
+
+def instruction_generator_from_function(
+    ig_or_if: Union[InstructionFunction, InstructionGenerator],
+) -> InstructionGenerator:
+    """
+    A helper function to wrap an instruction function as an instruction generator
+    """
+    # check if the input is a callable
+    if callable(ig_or_if):
+        return AnonGenerator(ig_or_if)
+
+    # otherwise, assume it is already an instruction generator
+    return ig_or_if

--- a/tests/test_initialize_simulation.py
+++ b/tests/test_initialize_simulation.py
@@ -1,11 +1,11 @@
 import unittest
 
+from nrel.hive.app.hive_cosim import crank
 from nrel.hive.config.network import Network
 from nrel.hive.initialization.load import load_simulation
 from nrel.hive.initialization.initialize_simulation import (
     initialize,
     default_init_functions,
-    osm_init_function,
 )
 from nrel.hive.initialization.initialize_simulation_with_sampling import (
     initialize_simulation_with_sampling,
@@ -53,6 +53,19 @@ class TestInitializeSimulation(unittest.TestCase):
         self.assertIsNone(sim.vehicles.get("v1"), "should not have loaded vehicle v1")
         self.assertIsNone(sim.bases.get("b1"), "should not have loaded base b1")
         self.assertIsNone(sim.stations.get("s1"), "should not have loaded station s1")
+
+    def test_load_simulation_with_custom_instruction_function(self):
+        conf = mock_config().suppress_logging()
+
+        def custom_instruction_function(
+            sim: SimulationState, env: Environment
+        ) -> Tuple[Instruction, ...]:
+            dummy_instructions = (IdleInstruction("v1"), IdleInstruction("v2"))
+            return dummy_instructions
+
+        rp = load_simulation(conf, custom_instruction_generators=[custom_instruction_function])
+
+        result = crank(rp, 1)
 
     def test_initialize_simulation_with_sampling(self):
         conf = (

--- a/tests/test_initialize_simulation.py
+++ b/tests/test_initialize_simulation.py
@@ -57,15 +57,40 @@ class TestInitializeSimulation(unittest.TestCase):
     def test_load_simulation_with_custom_instruction_function(self):
         conf = mock_config().suppress_logging()
 
-        def custom_instruction_function(
+        dummy_instruction1 = IdleInstruction("v1")
+        dummy_instruction2 = IdleInstruction("v2")
+        dummy_instructions = (dummy_instruction1, dummy_instruction2)
+
+        def custom_instruction_function_1(
             sim: SimulationState, env: Environment
         ) -> Tuple[Instruction, ...]:
-            dummy_instructions = (IdleInstruction("v1"), IdleInstruction("v2"))
-            return dummy_instructions
+            return tuple([dummy_instruction1])
 
-        rp = load_simulation(conf, custom_instruction_generators=[custom_instruction_function])
+        def custom_instruction_function_2(
+            sim: SimulationState, env: Environment
+        ) -> Tuple[Instruction, ...]:
+            return tuple([dummy_instruction2])
 
-        result = crank(rp, 1)
+        rp = load_simulation(
+            conf,
+            custom_instruction_generators=[
+                custom_instruction_function_1,
+                custom_instruction_function_2,
+            ],
+        )
+
+        # crank the simulation for 2 steps to make sure we have the applied instructions in the result
+        result = crank(rp, 2)
+
+        applied_instructions = tuple(
+            sorted(
+                result.runner_payload.s.applied_instructions.values(), key=lambda i: i.vehicle_id
+            )
+        )
+
+        self.assertEqual(
+            dummy_instructions, applied_instructions, "should have applied the dummy instructions"
+        )
 
     def test_initialize_simulation_with_sampling(self):
         conf = (


### PR DESCRIPTION
Closes #129 by adding the ability to specify custom control logic as either a `InstructionGenerator` or an `InstructionFunction` which is any callable that has the signature `Callable[[SimulationState, Environment], Tuple[Instruction, ...]]`

@robfitzgerald I'm interested to hear if this satisfies what you had in mind with #129 