### PR TITLE
don't run duplicate tests on PR merge

### DIFF
--- a/.github/workflows/release_and_publish_pypi.yaml
+++ b/.github/workflows/release_and_publish_pypi.yaml
@@ -34,7 +34,7 @@ jobs:
       run: |
         python -m build
     - name: Upload artifacts
-    - uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v3
       with:
           path: ./dist/*
     - name: Upload to twine test

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   test:
+      if: github.event.pull_request.merged == false
       runs-on: ubuntu-latest
 
       strategy:


### PR DESCRIPTION
Add a check if we're pulling in an approved PR so we don't re-run CI tests since they're required for getting the PR merged in the first place.