### PR TITLE
add newtype structs for additional primitives

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -116,6 +116,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6548a0ad5d2549e111e1f6a11a6c2e2d00ce6a3dafe22948d67c2b443f775e52"
 
 [[package]]
+name = "derive-alias"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3dca1db580f7272cecbab39c6289e185f6958abee5317c968f7eacda82c4ec2"
+
+[[package]]
 name = "derive_more"
 version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -491,6 +497,7 @@ dependencies = [
  "anyhow",
  "assert_approx_eq",
  "bincode",
+ "derive-alias",
  "derive_more",
  "geo-types",
  "h3ron",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -17,3 +17,4 @@ geo-types = "^0.7"
 serde = { version = "1.0.143", features = ["derive"] }
 pyo3 = { version = "0.18.0", features = ["extension-module", "anyhow"] }
 derive_more = "0.99.17"
+derive-alias = "0.1.0"

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -13,10 +13,8 @@ pub mod road_network;
 pub mod station;
 pub mod utils;
 
-// externs needed for imports to be available in macros
-pub extern crate derive_more;
+// extern needed for imports to be available in macros
 pub extern crate pyo3;
-pub extern crate serde;
 
 use base::Base;
 use entity_position::EntityPosition;

--- a/rust/src/link.rs
+++ b/rust/src/link.rs
@@ -16,9 +16,9 @@ pub struct LinkTraversal {
     pub end: Arc<GeoidString>,
 
     #[pyo3(get)]
-    pub distance_km: f64,
+    pub distance_km: DistanceKm,
     #[pyo3(get)]
-    pub speed_kmph: f64,
+    pub speed_kmph: SpeedKmph,
 }
 
 #[pymethods]
@@ -28,8 +28,8 @@ impl LinkTraversal {
         link_id: LinkId,
         start: GeoidString,
         end: GeoidString,
-        distance_km: f64,
-        speed_kmph: f64,
+        distance_km: DistanceKm,
+        speed_kmph: SpeedKmph,
     ) -> Self {
         LinkTraversal {
             link_id,
@@ -45,8 +45,8 @@ impl LinkTraversal {
         link_id: LinkId,
         start: GeoidString,
         end: GeoidString,
-        speed_kmph: f64,
-        distance_km: Option<f64>,
+        speed_kmph: SpeedKmph,
+        distance_km: Option<DistanceKm>,
     ) -> PyResult<Self> {
         let dist = match distance_km {
             Some(d) => d,
@@ -60,7 +60,7 @@ impl LinkTraversal {
 
     #[getter]
     fn travel_time_seconds(&self) -> f64 {
-        let time_hours = self.distance_km / self.speed_kmph;
+        let time_hours = (*self.distance_km).clone() / self.speed_kmph.0;
         let time_seconds = time_hours * 3600.0;
         time_seconds
     }
@@ -108,8 +108,8 @@ mod tests {
             "mock_link".to_string().into(),
             "8f26dc934cccc69".to_string().into(),
             "8f26dc934cc4cdb".to_string().into(),
-            0.14,
-            40.0,
+            0.14.into(),
+            40.0.into(),
         )
     }
 

--- a/rust/src/macros.rs
+++ b/rust/src/macros.rs
@@ -1,23 +1,7 @@
-/// Create a newtype struct with the given name and type.
-/// Additionally implement IntoPy so that the struct can be passed to Python.
+/// Add IntoPy for a newtype struct which wraps a type that already implements IntoPy.
 #[macro_export]
-macro_rules! pystruct {
-    ($name:ident, $type:ty) => {
-        #[derive(
-            $crate::derive_more::Deref,
-            $crate::derive_more::Display,
-            $crate::derive_more::From,
-            $crate::derive_more::FromStr,
-            $crate::derive_more::Into,
-            $crate::serde::Deserialize,
-            $crate::serde::Serialize,
-            $crate::pyo3::prelude::FromPyObject,
-            Clone,
-            Eq,
-            Hash,
-            PartialEq,
-        )]
-        pub struct $name($type);
+macro_rules! newtype_into_py {
+    ($name:ident) => {
         impl $crate::pyo3::prelude::IntoPy<$crate::pyo3::prelude::PyObject> for $name {
             fn into_py(self, py: $crate::pyo3::prelude::Python) -> $crate::pyo3::prelude::PyObject {
                 self.0.into_py(py)

--- a/rust/src/road_network.rs
+++ b/rust/src/road_network.rs
@@ -63,7 +63,7 @@ impl HaversineRoadNetwork {
             origin.geoid,
             destination.geoid,
             link_dist_km,
-            AVG_SPEED_KMPH,
+            AVG_SPEED_KMPH.into(),
         );
 
         let route = vec![link];
@@ -75,7 +75,7 @@ impl HaversineRoadNetwork {
         &self,
         origin: GeoidString,
         destination: GeoidString,
-    ) -> PyResult<f64> {
+    ) -> PyResult<DistanceKm> {
         h3_dist_km(&origin, &destination)
             .map_err(|e| PyValueError::new_err(format!("Failure computing h3 distance: {}", e)))
     }
@@ -83,13 +83,19 @@ impl HaversineRoadNetwork {
     pub fn link_from_link_id(&self, link_id: LinkId) -> PyResult<LinkTraversal> {
         let (source, dest) = link_id_to_geoids(&link_id)?;
         let dist_km = self.distance_by_geoid_km(source.clone(), dest.clone())?;
-        let link = LinkTraversal::new(link_id, source, dest, dist_km, AVG_SPEED_KMPH);
+        let link = LinkTraversal::new(link_id, source, dest, dist_km, AVG_SPEED_KMPH.into());
         Ok(link)
     }
 
     pub fn link_from_geoid(&self, geoid: GeoidString) -> LinkTraversal {
         let link_id = geoid_string_to_link_id(&geoid, &geoid);
-        let link = LinkTraversal::new(link_id, geoid.clone(), geoid.clone(), 0.0, 0.0);
+        let link = LinkTraversal::new(
+            link_id,
+            geoid.clone(),
+            geoid.clone(),
+            0.0.into(),
+            0.0.into(),
+        );
         link
     }
 

--- a/rust/src/type_aliases.rs
+++ b/rust/src/type_aliases.rs
@@ -1,18 +1,84 @@
-use crate::pystruct;
+use derive_alias::derive_alias;
+use derive_more::{Add, Deref, Display, Div, From, Into, Sub};
+use pyo3::prelude::*;
+use serde::{Deserialize, Serialize};
 
-pystruct!(BaseId, String);
-pystruct!(ChargerId, String);
-pystruct!(EntityId, String);
-pystruct!(GeoidString, String);
-pystruct!(LinkId, String);
-pystruct!(MechatronicsId, String);
-pystruct!(MembershipId, String);
-pystruct!(PassengerId, String);
-pystruct!(PowercurveId, String);
-pystruct!(PowertrainId, String);
-pystruct!(RequestId, String);
-pystruct!(ScheduleId, String);
-pystruct!(SimTime, usize);
-pystruct!(StationId, String);
-pystruct!(VehicleId, String);
-pystruct!(VehicleTypeId, String);
+use crate::newtype_into_py;
+
+derive_alias! {
+    derive_pystruct => #[derive(Clone, Deref, Display, From, FromPyObject, Into)]
+}
+
+derive_pystruct! { pub struct BaseId(String); }
+newtype_into_py!(BaseId);
+
+derive_pystruct! { pub struct ChargerId(String); }
+newtype_into_py!(ChargerId);
+
+derive_pystruct! {
+    #[derive(Div)]
+    pub struct DistanceKm(f64);
+}
+newtype_into_py!(DistanceKm);
+
+derive_pystruct! { pub struct EntityId(String); }
+newtype_into_py!(EntityId);
+
+derive_pystruct! {
+    #[derive(PartialEq)]
+    pub struct GeoidString(String);
+}
+newtype_into_py!(GeoidString);
+
+derive_pystruct! {
+    #[derive( PartialEq )]
+    pub struct LinkId(String);
+}
+newtype_into_py!(LinkId);
+
+derive_pystruct! { pub struct MechatronicsId(String); }
+newtype_into_py!(MechatronicsId);
+
+derive_pystruct! {
+    #[derive(Deserialize, Eq, Hash, PartialEq, Serialize)]
+    pub struct MembershipId(String);
+}
+newtype_into_py!(MembershipId);
+
+derive_pystruct! {
+    #[derive(Add, PartialEq, PartialOrd, Sub)]
+    pub struct NumStalls(usize);
+}
+newtype_into_py!(NumStalls);
+
+derive_pystruct! { pub struct PassengerId(String); }
+newtype_into_py!(PassengerId);
+
+derive_pystruct! { pub struct PowercurveId(String); }
+newtype_into_py!(PowercurveId);
+
+derive_pystruct! { pub struct PowertrainId(String); }
+newtype_into_py!(PowertrainId);
+
+derive_pystruct! { pub struct RequestId(String); }
+newtype_into_py!(RequestId);
+
+derive_pystruct! { pub struct ScheduleId(String); }
+newtype_into_py!(ScheduleId);
+
+derive_pystruct! {
+    pub struct SpeedKmph(pub f64);
+}
+newtype_into_py!(SpeedKmph);
+
+derive_pystruct! { pub struct SimTime(usize); }
+newtype_into_py!(SimTime);
+
+derive_pystruct! { pub struct StationId(String); }
+newtype_into_py!(StationId);
+
+derive_pystruct! { pub struct VehicleId(String); }
+newtype_into_py!(VehicleId);
+
+derive_pystruct! { pub struct VehicleTypeId(String); }
+newtype_into_py!(VehicleTypeId);

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -6,7 +6,7 @@ use crate::type_aliases::*;
 
 const EARTH_RADIUS: f64 = 6371.0;
 
-pub fn haversine(lat1: f64, lon1: f64, lat2: f64, lon2: f64) -> f64 {
+pub fn haversine(lat1: f64, lon1: f64, lat2: f64, lon2: f64) -> DistanceKm {
     let dlat = (lat2 - lat1).to_radians();
     let dlon = (lon2 - lon1).to_radians();
 
@@ -17,11 +17,14 @@ pub fn haversine(lat1: f64, lon1: f64, lat2: f64, lon2: f64) -> f64 {
 
     let distance = c * EARTH_RADIUS;
 
-    distance
+    distance.into()
 }
 
 /// Return the line distance between two Geoid strings
-pub fn h3_dist_km(origin_string: &GeoidString, destination_string: &GeoidString) -> Result<f64> {
+pub fn h3_dist_km(
+    origin_string: &GeoidString,
+    destination_string: &GeoidString,
+) -> Result<DistanceKm> {
     let origin = Geoid::from_string(origin_string.to_owned())?;
     let destination = Geoid::from_string(destination_string.to_owned())?;
     let origin_coord = origin.h3_cell.to_coordinate()?;


### PR DESCRIPTION
Add newtype structs for distance, speed, and number of stalls.

Some of the derives in the original `pystruct` macro were incompatible with float types (`Eq` and `Hash`), so I had to come up with another approach. It's now a lot more verbose, but it's also much more flexible. This was also nice because it let me add math operations like `Add` and `Sub` on `NumStalls`.