### PR TITLE
add pre-commit setup

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,4 +1,4 @@
-name: tests 
+name: tests
 
 on:
   push:
@@ -26,21 +26,25 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install package 
+      - name: Install package
         run: |
-          pip install ".[dev]" 
+          pip install ".[dev]"
 
       - name: Run mypy
-        run: mypy . --ignore-missing-imports 
+        run: mypy . --ignore-missing-imports
 
       - name: Run black
         run: |
           black nrel tests --check
 
-      - name: Python unit tests 
+      # Once all files have passed through pre-commit, the black check can be replaced by pre-commit:
+      # - name: Run pre-commit in CI
+      #   uses: pre-commit/action@v3.0.0
+
+      - name: Python unit tests
         run: |
-          pytest tests/ -v 
-      
+          pytest tests/ -v
+
       - name: HIVE Denver Demo test
         run: |
           hive denver_demo.yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+    -   id: check-yaml
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+-   repo: https://github.com/psf/black
+    rev: 23.1.0
+    hooks:
+    -   id: black
+- repo: https://github.com/charliermarsh/ruff-pre-commit
+  # Ruff version.
+  rev: 'v0.0.263'
+  hooks:
+    - id: ruff

--- a/docs/source/developer/contributing.md
+++ b/docs/source/developer/contributing.md
@@ -27,6 +27,12 @@ This simple guide will walk you through the process of contributing to HIVE.
 1. Click on the "Fork" button in the upper right corner. This creates a copy of the repository under your GitHub account.
 1. Clone your forked repository to your local machine by clicking the "Code" button and copying the URL. Then, open your terminal or command prompt and run git clone [URL], replacing [URL] with the copied URL.
 
+## Installing the development environment
+
+1. Create and activate a new virtual environment with the tool of your choice (e.g. `venv`, `conda`, `pipenv`, etc.).
+1. Install the package and dependencies by running `pip install -e ".[dev]"`. This will install the package in editable mode, so you can make changes to the code and see them reflected in your environment.
+1. Install the pre-commit hook by running `pre-commit install`. This will run the pre-commit checks before each commit, and will prevent you from committing code that doesn't pass the checks.
+
 ## Opening a Pull Request
 
 1. Create a new branch in your local repository by running git checkout -b [branch-name], replacing [branch-name] with a descriptive name for your changes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dev = [
     "twine",
     "types-PyYAML",
     "types-setuptools",
+    "pre-commit",
 ]
 
 [project.urls]
@@ -62,10 +63,13 @@ hive-batch = "nrel.hive.app.run_batch:run"
 [tool.black]
 line-length = 100
 
+[tool.ruff]
+line-length = 100
+
 [tool.setuptools.packages.find]
 where = ["."]  # list of folders that contain the packages (["."] by default)
 include = ["nrel*"]  # package names should match these glob patterns (["*"] by default)
-exclude = ["rust*"] 
+exclude = ["rust*"]
 
 [tool.setuptools.package-data]
 "*" = ["py.typed"]


### PR DESCRIPTION
This adds pre-commit with the following tools:
- Defaults recommended by pre-commit (trailing newline, trailing whitespace, check yaml)
- Ruff
- Black

pre-commit only enforces checks on files changed as part of a commit unless running with `pre-commit run --all-files`. This means that the changes can be made gradually as individual files are changed.

Closes #178 