### PR TITLE
From row error

### DIFF
--- a/nrel/hive/model/base.py
+++ b/nrel/hive/model/base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
-from typing import Optional, Dict, TYPE_CHECKING
+from typing import Optional, Dict, Tuple, TYPE_CHECKING
 
 import h3
 
@@ -12,7 +12,7 @@ from nrel.hive.model.roadnetwork.roadnetwork import RoadNetwork
 from nrel.hive.util.exception import SimulationStateError
 
 if TYPE_CHECKING:
-    from nrel.hive.util.typealiases import *
+    from nrel.hive.util.typealiases import BaseId, GeoId, MembershipId, StationId
 
 
 @dataclass(frozen=True)
@@ -100,11 +100,12 @@ class Base(Entity):
                 geoid = h3.geo_to_h3(lat, lon, road_network.sim_h3_resolution)
                 stall_count = int(row["stall_count"])
 
-                # allow user to leave station_id blank or use the word "none" to signify no station at base
+                # allow user to leave station_id blank or use the word "none" to signify
+                # no station at base
                 station_id_name = row["station_id"] if len(row["station_id"]) > 0 else "none"
                 station_id = None if station_id_name.lower() == "none" else station_id_name
 
-                # TODO: think about how to assing vehicles to bases based on fleet membership
+                # TODO: think about how to assign vehicles to bases based on fleet membership
 
                 return Base.build(
                     id=base_id,
@@ -114,10 +115,10 @@ class Base(Entity):
                     stall_count=stall_count,
                 )
 
-            except ValueError:
+            except ValueError as e:
                 raise IOError(
-                    f"unable to parse request {base_id} from row due to invalid value(s): {row}"
-                )
+                    f"unable to parse id {base_id} from row due to invalid value(s): {row}"
+                ) from e
 
     def has_available_stall(self, membership: Membership) -> bool:
         """

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,7 +1,11 @@
 from csv import DictReader
 from unittest import TestCase
 
-from nrel.hive.resources.mock_lobster import *
+import h3
+import pytest
+
+from nrel.hive.resources.mock_lobster import mock_base, mock_network
+from nrel.hive.model.base import Base
 
 
 class TestBase(TestCase):
@@ -90,3 +94,15 @@ class TestBase(TestCase):
             frozenset(["fleet_1", "fleet_3"]),
             "should have membership for fleet_1 and fleet_3",
         )
+
+    def test_parse_error_raises(self):
+        source = """base_id,lat,lon,stall_count,station_id
+                            b1,thirtyseven,122,10,s1"""
+
+        network = mock_network()
+        row = next(DictReader(source.split()))
+
+        with pytest.raises(IOError, match="unable to parse id") as exc_info:
+            Base.from_row(row, network)
+
+        assert isinstance(exc_info.value.__cause__, ValueError)

--- a/tests/test_kepler_feature.py
+++ b/tests/test_kepler_feature.py
@@ -1,6 +1,9 @@
 from unittest import TestCase
 
-from nrel.hive.resources.mock_lobster import *
+import h3
+
+from nrel.hive.resources.mock_lobster import DefaultIds, mock_sim, somewhere, somewhere_else
+from nrel.hive.reporting.handler.kepler_feature import Coord, Feature, KeplerFeature
 
 
 class TestKeplerFeature(TestCase):
@@ -13,7 +16,7 @@ class TestKeplerFeature(TestCase):
             feature.coords,
             "Coordinates were not added to the list of coords",
         )
-        self.assertEquals(1, len(feature.coords), "There should only be one coord in coords")
+        self.assertEqual(1, len(feature.coords), "There should only be one coord in coords")
 
     def test_gen_json(self):
         feature = KeplerFeature(DefaultIds.mock_vehicle_id(), "Idle", mock_sim().sim_time)
@@ -66,9 +69,9 @@ class TestKeplerFeature(TestCase):
 
         feature.reset("DispatchTrip", mock_sim().sim_time + 2)
 
-        self.assertEquals(0, len(feature.coords), "Reset did not delete the old coordinates")
-        self.assertEquals("DispatchTrip", feature.state, "State did not change in reset")
-        self.assertEquals(
+        self.assertEqual(0, len(feature.coords), "Reset did not delete the old coordinates")
+        self.assertEqual("DispatchTrip", feature.state, "State did not change in reset")
+        self.assertEqual(
             mock_sim().sim_time + 2, feature.starttime, "Start time did not get updated"
         )
-        self.assertEquals(DefaultIds.mock_vehicle_id(), feature.id, "ID should not change in reset")
+        self.assertEqual(DefaultIds.mock_vehicle_id(), feature.id, "ID should not change in reset")


### PR DESCRIPTION
Fixes #112. This is the first PR that includes `pre-commit` linting and the import changes are a result of that (`ruff` can't analyze * imports, so they should be imported directly from the definition instead).