### PR TITLE
Ndr/update link speed

### DIFF
--- a/tests/test_bev_mechatronics.py
+++ b/tests/test_bev_mechatronics.py
@@ -1,6 +1,14 @@
 from unittest import TestCase
+from nrel.hive.model.energy.energytype import EnergyType
 
-from nrel.hive.resources.mock_lobster import *
+from nrel.hive.resources.mock_lobster import (
+    mock_bev,
+    mock_dcfc_charger,
+    mock_l2_charger,
+    mock_route,
+    mock_vehicle,
+)
+from nrel.hive.util.units import KM_TO_MILE, MILE_TO_KM, hours_to_seconds
 
 
 class TestBEV(TestCase):

--- a/tests/test_cancel_requests.py
+++ b/tests/test_cancel_requests.py
@@ -1,9 +1,10 @@
 from unittest import TestCase
 
 from returns.result import Success
+from nrel.hive.resources.mock_lobster import mock_env, mock_request, mock_sim
+from nrel.hive.state.simulation_state import simulation_state_ops
 
 from nrel.hive.state.simulation_state.update.cancel_requests import CancelRequests
-from nrel.hive.resources.mock_lobster import *
 
 
 class TestCancelRequests(TestCase):

--- a/tests/test_charging_price_update.py
+++ b/tests/test_charging_price_update.py
@@ -1,7 +1,18 @@
 from unittest import TestCase
+import immutables
+
+from pkg_resources import resource_filename
+from nrel.hive.resources.mock_lobster import (
+    mock_dcfc_charger_id,
+    mock_env,
+    mock_l1_charger_id,
+    mock_l2_charger_id,
+    mock_sim,
+    mock_station,
+    mock_station_from_geoid,
+)
 
 from nrel.hive.state.simulation_state.update.charging_price_update import ChargingPriceUpdate
-from nrel.hive.resources.mock_lobster import *
 
 
 class TestChargingPriceUpdate(TestCase):

--- a/tests/test_config_builder.py
+++ b/tests/test_config_builder.py
@@ -55,7 +55,7 @@ class TestConfigBuilder(TestCase):
         }
 
         with self.assertRaises(AttributeError):
-            test_class = ConfigBuilder.build(
+            ConfigBuilder.build(
                 default_config={},
                 required_config=required,
                 config_constructor=TestConfigBuilderAssets.constructor,

--- a/tests/test_dict_ops.py
+++ b/tests/test_dict_ops.py
@@ -1,7 +1,6 @@
 from unittest import TestCase
 
 import immutables
-from typing import FrozenSet
 
 from nrel.hive.util import DictOps
 

--- a/tests/test_dict_reader_stepper.py
+++ b/tests/test_dict_reader_stepper.py
@@ -1,9 +1,10 @@
+from typing import Callable
 from unittest import TestCase
 
 from pkg_resources import resource_filename
 
 from nrel.hive.model.sim_time import SimTime
-from nrel.hive.util.iterators import *
+from nrel.hive.util.iterators import DictReaderStepper
 
 
 class TestDictReaderStepper(TestCase):

--- a/tests/test_driver_instruction_ops.py
+++ b/tests/test_driver_instruction_ops.py
@@ -1,7 +1,17 @@
 from unittest import TestCase
+from nrel.hive.dispatcher.instruction.instructions import (
+    DispatchBaseInstruction,
+    DispatchStationInstruction,
+)
 
 from nrel.hive.state.driver_state.driver_instruction_ops import human_go_home
-from nrel.hive.resources.mock_lobster import *
+from nrel.hive.resources.mock_lobster import (
+    mock_base,
+    mock_env,
+    mock_sim,
+    mock_station,
+    mock_vehicle,
+)
 
 
 class TestDriverInstructionOps(TestCase):

--- a/tests/test_h3_ops.py
+++ b/tests/test_h3_ops.py
@@ -1,8 +1,14 @@
 from unittest import TestCase
 
-from nrel.hive.resources.mock_lobster import *
+import h3
+import immutables
+from nrel.hive.model.roadnetwork.link import Link
+from nrel.hive.resources.mock_lobster import mock_request_from_geoids, mock_sim
+from nrel.hive.state.simulation_state import simulation_state_ops
+
 from nrel.hive.util.h3_ops import H3Ops
 from nrel.hive.util.fp import throw_or_return
+from nrel.hive.util.units import hours_to_seconds
 
 
 class TestH3Ops(TestCase):

--- a/tests/test_haversine_roadnetwork.py
+++ b/tests/test_haversine_roadnetwork.py
@@ -1,6 +1,8 @@
 from unittest import TestCase, skip
 
-from nrel.hive.resources.mock_lobster import *
+import h3
+
+from nrel.hive.resources.mock_lobster import mock_network
 
 
 class TestHaversineRoadNetwork(TestCase):

--- a/tests/test_human_driver_state.py
+++ b/tests/test_human_driver_state.py
@@ -1,7 +1,37 @@
 from unittest import TestCase
+from nrel.hive.dispatcher.instruction.instructions import (
+    ChargeBaseInstruction,
+    DispatchBaseInstruction,
+    IdleInstruction,
+    RepositionInstruction,
+    ReserveBaseInstruction,
+)
+from nrel.hive.state.driver_state.human_driver_state.human_driver_state import (
+    HumanAvailable,
+    HumanUnavailable,
+)
+from nrel.hive.state.simulation_state import simulation_state_ops
+from nrel.hive.state.vehicle_state.charging_station import ChargingStation
+from nrel.hive.state.vehicle_state.idle import Idle
+from nrel.hive.state.vehicle_state.reserve_base import ReserveBase
 
-from nrel.hive.resources.mock_lobster import *
 from nrel.hive.util.fp import throw_or_return
+from nrel.hive.resources.mock_lobster import (
+    DefaultIds,
+    mock_base,
+    mock_base_from_geoid,
+    mock_dcfc_charger_id,
+    mock_env,
+    mock_human_driver,
+    mock_request_from_geoids,
+    mock_sim,
+    mock_station,
+    mock_station_from_geoid,
+    mock_vehicle,
+    mock_vehicle_from_geoid,
+    somewhere,
+    somewhere_else,
+)
 
 
 def on_schedule(a, b):
@@ -202,7 +232,8 @@ class TestHumanDriverState(TestCase):
         sim = mock_sim(vehicles=(veh,))
         env = mock_env()
 
-        # the default soc limit for charging at a station is 0.8 so we should generate an idle instruction.
+        # the default soc limit for charging at a station is 0.8
+        # so we should generate an idle instruction.
         i = veh.driver_state.generate_instruction(sim, env)
 
         self.assertIsInstance(i, IdleInstruction)
@@ -218,7 +249,8 @@ class TestHumanDriverState(TestCase):
         sim = mock_sim(vehicles=(veh,), bases=(base,))
         env = mock_env()
 
-        # the driver is at home and idle so it should try to turn off (i.e. transition to ReserveBase).
+        # the driver is at home and idle so it should try to turn off
+        # (i.e. transition to ReserveBase).
         i = veh.driver_state.generate_instruction(sim, env)
 
         self.assertIsInstance(i, ReserveBaseInstruction)

--- a/tests/test_ice_mechatronics.py
+++ b/tests/test_ice_mechatronics.py
@@ -1,6 +1,8 @@
 from unittest import TestCase
+from nrel.hive.model.energy.energytype import EnergyType
 
-from nrel.hive.resources.mock_lobster import *
+from nrel.hive.resources.mock_lobster import mock_gasoline_pump, mock_ice, mock_route, mock_vehicle
+from nrel.hive.util.units import KM_TO_MILE, MILE_TO_KM, hours_to_seconds
 
 
 class TestICE(TestCase):

--- a/tests/test_initialize_simulation.py
+++ b/tests/test_initialize_simulation.py
@@ -1,7 +1,14 @@
+from pathlib import Path
+from typing import Tuple
 import unittest
 
+from pkg_resources import resource_filename
+
 from nrel.hive.app.hive_cosim import crank
+from nrel.hive.config.hive_config import HiveConfig
 from nrel.hive.config.network import Network
+from nrel.hive.dispatcher.instruction.instruction import Instruction
+from nrel.hive.dispatcher.instruction.instructions import IdleInstruction
 from nrel.hive.initialization.load import load_simulation
 from nrel.hive.initialization.initialize_simulation import (
     initialize,
@@ -10,7 +17,9 @@ from nrel.hive.initialization.initialize_simulation import (
 from nrel.hive.initialization.initialize_simulation_with_sampling import (
     initialize_simulation_with_sampling,
 )
-from nrel.hive.resources.mock_lobster import *
+from nrel.hive.resources.mock_lobster import mock_config
+from nrel.hive.runner.environment import Environment
+from nrel.hive.state.simulation_state.simulation_state import SimulationState
 
 import nrel.hive.state.simulation_state.simulation_state_ops as sso
 
@@ -79,7 +88,8 @@ class TestInitializeSimulation(unittest.TestCase):
             ],
         )
 
-        # crank the simulation for 2 steps to make sure we have the applied instructions in the result
+        # crank the simulation for 2 steps to make sure we have the
+        # applied instructions in the result
         result = crank(rp, 2)
 
         applied_instructions = tuple(

--- a/tests/test_instruction_generator_ops.py
+++ b/tests/test_instruction_generator_ops.py
@@ -4,7 +4,13 @@ from nrel.hive.dispatcher.instruction_generator.instruction_generator_ops import
     instruct_vehicles_to_dispatch_to_station,
 )
 from nrel.hive.dispatcher.instruction_generator.charging_search_type import ChargingSearchType
-from nrel.hive.resources.mock_lobster import *
+from nrel.hive.resources.mock_lobster import (
+    mock_env,
+    mock_ice,
+    mock_sim,
+    mock_station,
+    mock_vehicle,
+)
 
 
 class TestInstructionGenerators(TestCase):
@@ -14,7 +20,7 @@ class TestInstructionGenerators(TestCase):
 
         here we create a simulation in which the chargers that exist in the sim can't be used by the
         vehicle; this edge case should not fail but rather result in zero instructions; given the
-        logic splits for each ChargingSearchType, we test ChargingSearchType.NEAREST_SHORTEST_QUEUE here
+        logic splits for each ChargingSearchType, we test ChargingSearchType.NEAREST_SHORTEST_QUEUE
         """
         station = mock_station()
         ice_mechatronics = mock_ice()
@@ -47,7 +53,7 @@ class TestInstructionGenerators(TestCase):
 
         here we create a simulation in which the chargers that exist in the sim can't be used by the
         vehicle; this edge case should not fail but rather result in zero instructions; given the
-        logic splits for each ChargingSearchType, we test ChargingSearchType.SHORTEST_TIME_TO_CHARGE here
+        logic splits for each ChargingSearchType, we test ChargingSearchType.SHORTEST_TIME_TO_CHARGE
         """
         station = mock_station()
         mechatronics = mock_ice()

--- a/tests/test_instruction_generators.py
+++ b/tests/test_instruction_generators.py
@@ -19,14 +19,13 @@ from nrel.hive.resources.mock_lobster import (
     mock_vehicle_from_geoid,
 )
 from nrel.hive.state.simulation_state import simulation_state_ops
-from nrel.hive.util import h3_ops
 
 
 class TestInstructionGenerators(TestCase):
     def test_dispatcher_match_vehicle(self):
         dispatcher = Dispatcher(mock_config().dispatcher)
 
-        somewhere = h3_ops.geo_to_h3(39.7539, -104.974, 15)
+        somewhere = h3.geo_to_h3(39.7539, -104.974, 15)
         near_to_somewhere = h3.geo_to_h3(39.754, -104.975, 15)
         far_from_somewhere = h3.geo_to_h3(39.755, -104.976, 15)
 

--- a/tests/test_instruction_generators.py
+++ b/tests/test_instruction_generators.py
@@ -1,13 +1,32 @@
 from unittest import TestCase
+import h3
 
-from nrel.hive.resources.mock_lobster import *
+from nrel.hive.dispatcher.instruction.instructions import (
+    DispatchStationInstruction,
+    DispatchTripInstruction,
+)
+from nrel.hive.dispatcher.instruction_generator.charging_fleet_manager import ChargingFleetManager
+from nrel.hive.dispatcher.instruction_generator.dispatcher import Dispatcher
+from nrel.hive.resources.mock_lobster import (
+    DefaultIds,
+    mock_config,
+    mock_dcfc_charger_id,
+    mock_env,
+    mock_membership,
+    mock_request_from_geoids,
+    mock_sim,
+    mock_station_from_geoid,
+    mock_vehicle_from_geoid,
+)
+from nrel.hive.state.simulation_state import simulation_state_ops
+from nrel.hive.util import h3_ops
 
 
 class TestInstructionGenerators(TestCase):
     def test_dispatcher_match_vehicle(self):
         dispatcher = Dispatcher(mock_config().dispatcher)
 
-        somewhere = h3.geo_to_h3(39.7539, -104.974, 15)
+        somewhere = h3_ops.geo_to_h3(39.7539, -104.974, 15)
         near_to_somewhere = h3.geo_to_h3(39.754, -104.975, 15)
         far_from_somewhere = h3.geo_to_h3(39.755, -104.976, 15)
 
@@ -105,7 +124,8 @@ class TestInstructionGenerators(TestCase):
         s1_geoid = h3.geo_to_h3(39.01, -104.0, 15)
         s2_geoid = h3.geo_to_h3(39.015, -104.0, 15)  # slightly further away
 
-        # prepare the scenario where the closer station has no available chargers and one enqueued vehicle
+        # prepare the scenario where the closer station has no
+        # available chargers and one enqueued vehicle
         s1 = mock_station_from_geoid(
             station_id="s1",
             geoid=s1_geoid,

--- a/tests/test_local_simulation_runner.py
+++ b/tests/test_local_simulation_runner.py
@@ -1,9 +1,24 @@
 from unittest import TestCase
+from nrel.hive.model.sim_time import SimTime
+from nrel.hive.resources.mock_lobster import (
+    DefaultIds,
+    mock_base,
+    mock_config,
+    mock_env,
+    mock_instruction_generators,
+    mock_request,
+    mock_sim,
+    mock_station,
+    mock_update,
+    mock_vehicle,
+)
 
 from nrel.hive.runner import LocalSimulationRunner
 from nrel.hive.runner import RunnerPayload
+from nrel.hive.state.simulation_state import simulation_state_ops
 from nrel.hive.state.simulation_state.update.cancel_requests import CancelRequests
-from nrel.hive.resources.mock_lobster import *
+from nrel.hive.state.simulation_state.update.step_simulation import StepSimulation
+from nrel.hive.state.simulation_state.update.update import Update
 
 
 class TestLocalSimulationRunner(TestCase):

--- a/tests/test_osm_roadnetwork.py
+++ b/tests/test_osm_roadnetwork.py
@@ -1,6 +1,8 @@
 from unittest import TestCase, skip
 
-from nrel.hive.resources.mock_lobster import *
+import h3
+
+from nrel.hive.resources.mock_lobster import mock_osm_network
 
 
 class TestOSMRoadNetwork(TestCase):

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -1,7 +1,10 @@
 from unittest import TestCase
 from csv import DictReader
 
-from nrel.hive.resources.mock_lobster import *
+import h3
+from requests import Request
+from nrel.hive.model.sim_time import SimTime
+from nrel.hive.resources.mock_lobster import mock_config, mock_env, mock_network, mock_request
 
 from nrel.hive.util.exception import TimeParseError
 
@@ -56,7 +59,8 @@ class TestRequest(TestCase):
         self.assertTrue(req.membership.public)
 
     def test_from_row_with_fleet_id(self):
-        source = """request_id,o_lat,o_lon,d_lat,d_lon,departure_time,cancel_time,passengers,fleet_id
+        source = """
+        request_id,o_lat,o_lon,d_lat,d_lon,departure_time,cancel_time,passengers,fleet_id
         1_a,31.2074449,121.4294263,31.2109091,121.4532226,61200,61800,4,uber
         """
         row = next(DictReader(source.split()))

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 from csv import DictReader
 
 import h3
-from requests import Request
+from nrel.hive.model.request.request import Request
 from nrel.hive.model.sim_time import SimTime
 from nrel.hive.resources.mock_lobster import mock_config, mock_env, mock_network, mock_request
 

--- a/tests/test_routetraversal.py
+++ b/tests/test_routetraversal.py
@@ -2,7 +2,8 @@ from unittest import TestCase
 
 from nrel.hive.model.roadnetwork.linktraversal import traverse_up_to
 from nrel.hive.model.roadnetwork.routetraversal import traverse
-from nrel.hive.resources.mock_lobster import *
+from nrel.hive.resources.mock_lobster import mock_osm_network, mock_osm_route, mock_route
+from nrel.hive.util.units import hours_to_seconds
 
 
 class TestRouteTraversal(TestCase):
@@ -10,26 +11,35 @@ class TestRouteTraversal(TestCase):
         """
         the mock problem is tuned to complete the route with a time step of just beyond 3 time units
         """
-        links = mock_route()
+        rn = mock_osm_network()
+        route = mock_osm_route()
 
-        _, result = traverse(route_estimate=links, duration_seconds=hours_to_seconds(4))
+        _, result = traverse(
+            route_estimate=route, duration_seconds=hours_to_seconds(4), road_network=rn
+        )
         self.assertGreater(result.remaining_time_seconds, 0, "should have more time left")
         self.assertEqual(len(result.remaining_route), 0, "should have no more route")
-        self.assertEqual(len(result.experienced_route), 3, "should have hit all 3 links")
+        self.assertEqual(len(result.experienced_route), len(route), "should have hit all links")
 
     def test_traverse_without_enough_time(self):
         """
-        the mock problem needs more than 1.5 time to complete the route. should end
-        up somewhere in the middle
+        should end up somewhere in the middle
         """
-        links = mock_route()
+        rn = mock_osm_network()
+        route = mock_osm_route()
+        midway = int(len(route) / 2)
+        midway_travel_time_seconds = sum([link.travel_time_seconds for link in route[:midway]])
+
         _, result = traverse(
-            route_estimate=links,
-            duration_seconds=hours_to_seconds(1.5),  # 1.5 hours at 1kmph, 1km per link, 3 links
+            route_estimate=route,
+            duration_seconds=midway_travel_time_seconds,
+            road_network=rn,
         )
         self.assertEqual(result.remaining_time_seconds, 0, "should have no more time left")
-        self.assertEqual(len(result.remaining_route), 2, "should have 2 links remaining")
-        self.assertEqual(len(result.experienced_route), 2, "should have traversed 2 links")
+        self.assertEqual(
+            len(result.remaining_route), len(route[midway:]), "should have some route left"
+        )
+        self.assertEqual(len(result.experienced_route), midway, "should have hit half the links")
 
     def test_traverse_up_to_split(self):
         links = mock_route()

--- a/tests/test_sample_functions.py
+++ b/tests/test_sample_functions.py
@@ -1,7 +1,6 @@
 from unittest import TestCase
 
 from returns.primitives.exceptions import UnwrapFailedError
-from returns.result import Result
 
 from nrel.hive.initialization.sample_requests import default_request_sampler
 from nrel.hive.initialization.sample_vehicles import (
@@ -9,7 +8,16 @@ from nrel.hive.initialization.sample_vehicles import (
     build_default_location_sampling_fn,
     build_default_soc_sampling_fn,
 )
-from nrel.hive.resources.mock_lobster import *
+from nrel.hive.model.energy.energytype import EnergyType
+from nrel.hive.model.roadnetwork.link import Link
+from nrel.hive.model.vehicle.vehicle import Vehicle
+from nrel.hive.resources.mock_lobster import (
+    DefaultIds,
+    mock_base,
+    mock_env,
+    mock_osm_network,
+    mock_sim,
+)
 
 
 class TestSampleVehicles(TestCase):
@@ -26,12 +34,13 @@ class TestSampleVehicles(TestCase):
             self.assertNotEqual(
                 r.origin,
                 r.destination,
-                f"request should not have equal origin and destination",
+                "request should not have equal origin and destination",
             )
 
     def test_sample_n_vehicles_default(self):
         """
-        samples 10 vehicles and expects them to be instantiated with full charge at the same base location
+        samples 10 vehicles and expects them to be instantiated
+        with full charge at the same base location
         """
         n = 10
         base = mock_base()
@@ -51,8 +60,8 @@ class TestSampleVehicles(TestCase):
         )
 
         def check_vehicle(v: Vehicle):
-            self.assertEquals(v.mechatronics_id, DefaultIds.mock_mechatronics_bev_id())
-            self.assertEquals(
+            self.assertEqual(v.mechatronics_id, DefaultIds.mock_mechatronics_bev_id())
+            self.assertEqual(
                 v.energy.get(EnergyType.ELECTRIC),
                 env.mechatronics.get(mechatronics_id).battery_capacity_kwh,
             )

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
 from nrel.hive.model.vehicle.schedules.time_range_schedule import time_range_schedules_from_string
-from nrel.hive.resources.mock_lobster import *
+from nrel.hive.resources.mock_lobster import DefaultIds, mock_sim
 
 
 class TestSchedules(TestCase):

--- a/tests/test_simulation_state_ops.py
+++ b/tests/test_simulation_state_ops.py
@@ -2,8 +2,16 @@ from dataclasses import replace
 from unittest import TestCase
 
 from returns.result import Success
+from nrel.hive.model.entity_position import EntityPosition
 
-from nrel.hive.resources.mock_lobster import *
+from nrel.hive.resources.mock_lobster import (
+    mock_base,
+    mock_request,
+    mock_sim,
+    mock_station,
+    mock_vehicle,
+)
+from nrel.hive.state.simulation_state import simulation_state_ops
 
 
 class TestSimulationStateOps(TestCase):

--- a/tests/test_simulationstate.py
+++ b/tests/test_simulationstate.py
@@ -1,10 +1,42 @@
 from unittest import TestCase
 
+import h3
+import immutables
+from nrel.hive.dispatcher.instruction.instructions import (
+    ChargeBaseInstruction,
+    ChargeStationInstruction,
+    DispatchBaseInstruction,
+    DispatchStationInstruction,
+    DispatchTripInstruction,
+    RepositionInstruction,
+    ReserveBaseInstruction,
+)
+from nrel.hive.model.energy.energytype import EnergyType
+from nrel.hive.model.station.station import Station
+from nrel.hive.resources.mock_lobster import (
+    DefaultIds,
+    mock_base,
+    mock_base_from_geoid,
+    mock_dcfc_charger_id,
+    mock_env,
+    mock_l2_charger_id,
+    mock_request,
+    mock_request_from_geoids,
+    mock_sim,
+    mock_station,
+    mock_station_from_geoid,
+    mock_vehicle,
+    mock_vehicle_from_geoid,
+)
+
 from nrel.hive.state.entity_state import entity_state_ops
+from nrel.hive.state.simulation_state import simulation_state_ops
 from nrel.hive.state.simulation_state.update.step_simulation import perform_vehicle_state_updates
+from nrel.hive.state.vehicle_state.charging_station import ChargingStation
+from nrel.hive.state.vehicle_state.idle import Idle
 from nrel.hive.state.vehicle_state.out_of_service import OutOfService
+from nrel.hive.state.vehicle_state.reserve_base import ReserveBase
 from nrel.hive.state.vehicle_state.servicing_trip import ServicingTrip
-from nrel.hive.resources.mock_lobster import *
 
 
 class TestSimulationState(TestCase):
@@ -353,7 +385,8 @@ class TestSimulationState(TestCase):
         )
         self.assertIsNotNone(sim, "Vehicle should have set instruction.")
 
-        # 1000 seconds should get us there, and 1 more sim step of any size to transition vehicle state
+        # 1000 seconds should get us there, and 1 more sim step
+        # of any size to transition vehicle state
         sim_at_base = perform_vehicle_state_updates(
             sim_updated._replace(sim_timestep_duration_seconds=1000), env
         )
@@ -393,7 +426,8 @@ class TestSimulationState(TestCase):
             instruction_result.prev_state,
             instruction_result.next_state,
         )
-        # 1000 seconds should get us there, and 1 more sim step of any size to transition vehicle state
+        # 1000 seconds should get us there, and 1 more sim step of
+        # any size to transition vehicle state
         sim_at_new_pos = perform_vehicle_state_updates(
             sim_updated._replace(sim_timestep_duration_seconds=1000), env
         )
@@ -436,7 +470,8 @@ class TestSimulationState(TestCase):
             instruction_result.prev_state,
             instruction_result.next_state,
         )
-        # 10 hours should get us charged , and 1 more sim step of any size to transition vehicle state
+        # 10 hours should get us charged , and 1 more sim step
+        # of any size to transition vehicle state
         sim_charged = perform_vehicle_state_updates(
             sim_updated._replace(sim_timestep_duration_seconds=36000), env
         )
@@ -475,7 +510,8 @@ class TestSimulationState(TestCase):
             instruction_result.prev_state,
             instruction_result.next_state,
         )
-        # 10 hours should get us charged, and 1 more sim step of any size to transition vehicle state
+        # 10 hours should get us charged, and 1 more sim step
+        # of any size to transition vehicle state
         sim_charged = perform_vehicle_state_updates(
             sim_updated._replace(sim_timestep_duration_seconds=36000), env
         )

--- a/tests/test_station.py
+++ b/tests/test_station.py
@@ -1,9 +1,21 @@
 from csv import DictReader
 from unittest import TestCase
 
-from nrel.hive.resources.mock_lobster import *
+import h3
+import immutables
+
 
 from returns.result import Failure
+from nrel.hive.model.station.station import Station
+
+from nrel.hive.resources.mock_lobster import (
+    mock_dcfc_charger_id,
+    mock_env,
+    mock_l1_charger_id,
+    mock_l2_charger_id,
+    mock_network,
+    mock_station,
+)
 
 
 class TestStation(TestCase):

--- a/tests/test_station_load_handler.py
+++ b/tests/test_station_load_handler.py
@@ -1,7 +1,16 @@
 from unittest import TestCase
 
 from nrel.hive.reporting import vehicle_event_ops
-from nrel.hive.resources.mock_lobster import *
+from nrel.hive.resources.mock_lobster import (
+    DefaultIds,
+    mock_bev,
+    mock_dcfc_charger_id,
+    mock_env,
+    mock_sim,
+    mock_station,
+    mock_vehicle,
+)
+from nrel.hive.state.vehicle_state.charging_station import ChargingStation
 
 
 class TestStationLoadHandler(TestCase):

--- a/tests/test_step_simulation_ops.py
+++ b/tests/test_step_simulation_ops.py
@@ -1,8 +1,8 @@
 from unittest import TestCase
+from nrel.hive.resources.mock_lobster import mock_env, mock_sim, mock_vehicle
 from nrel.hive.state.simulation_state.update.step_simulation_ops import (
     perform_vehicle_state_updates,
 )
-from nrel.hive.resources.mock_lobster import *
 
 
 class TestStepSimulationOps(TestCase):

--- a/tests/test_update_requests.py
+++ b/tests/test_update_requests.py
@@ -1,7 +1,10 @@
 from unittest import TestCase
 
+from pkg_resources import resource_filename
+from nrel.hive.model.sim_time import SimTime
+from nrel.hive.resources.mock_lobster import mock_config, mock_env, mock_sim
+
 from nrel.hive.state.simulation_state.update.update_requests_from_file import UpdateRequestsFromFile
-from nrel.hive.resources.mock_lobster import *
 
 
 class TestUpdateRequests(TestCase):
@@ -90,7 +93,7 @@ class TestUpdateRequests(TestCase):
             self.assertGreaterEqual(
                 req.value,
                 5,
-                f"should be greater/equal than minimum price of 5",
+                "should be greater/equal than minimum price of 5",
             )
 
     def test_update_lazy_file_reading(self):

--- a/tests/test_update_requests_sampling.py
+++ b/tests/test_update_requests_sampling.py
@@ -1,7 +1,8 @@
 from unittest import TestCase
+from nrel.hive.model.sim_time import SimTime
+from nrel.hive.resources.mock_lobster import mock_env, mock_osm_network, mock_request, mock_sim
 
 from nrel.hive.state.simulation_state.update.update_requests_sampling import UpdateRequestsSampling
-from nrel.hive.resources.mock_lobster import *
 
 
 class TestUpdateRequestsSampling(TestCase):

--- a/tests/test_vehicle.py
+++ b/tests/test_vehicle.py
@@ -1,7 +1,11 @@
 from csv import DictReader
 from unittest import TestCase
 
-from nrel.hive.resources.mock_lobster import *
+import h3
+from nrel.hive.model.vehicle.vehicle import Vehicle
+
+from nrel.hive.resources.mock_lobster import mock_env, mock_network
+from nrel.hive.state.vehicle_state.idle import Idle
 
 
 class TestVehicle(TestCase):

--- a/tests/test_vehicle_state_ops.py
+++ b/tests/test_vehicle_state_ops.py
@@ -1,9 +1,23 @@
 from unittest import TestCase
 
+import h3
+
 from returns.result import Success
+from nrel.hive.model.energy.energytype import EnergyType
+from nrel.hive.resources.mock_lobster import (
+    DefaultIds,
+    mock_base_from_geoid,
+    mock_dcfc_charger_id,
+    mock_env,
+    mock_sim,
+    mock_station_from_geoid,
+    mock_vehicle_from_geoid,
+)
+from nrel.hive.state.simulation_state import simulation_state_ops
 
 from nrel.hive.state.vehicle_state import vehicle_state_ops
-from nrel.hive.resources.mock_lobster import *
+from nrel.hive.state.vehicle_state.charging_base import ChargingBase
+from nrel.hive.state.vehicle_state.repositioning import Repositioning
 
 
 class TestVehicleStateOps(TestCase):


### PR DESCRIPTION
closes #26 by updating a link traversal with the current speed from the road network at the time of traversal.

this also touches almost all the test files since we have pre-commit installed now and since I updated one test, I had to recursively go through all the tests and fix them to get the pre-commit hooks to let me submit this. 