### PR TITLE
Rjf/determinism

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,23 +2,23 @@ name: tests
 
 on:
   push:
-      branches: [ main ]
+    branches: [main]
   pull_request:
 
 jobs:
   test:
-      if: github.event.pull_request.merged == false
-      runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == false
+    runs-on: ubuntu-latest
 
-      strategy:
-        fail-fast: false
-        matrix:
-          python-version: ['3.8', '3.9', '3.10', '3.11']
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
-      env:
-        PYTHON: ${{ matrix.python-version }}
+    env:
+      PYTHON: ${{ matrix.python-version }}
 
-      steps:
+    steps:
       - uses: actions/checkout@v3
 
       - name: set up python ${{ matrix.python-version }}
@@ -45,6 +45,10 @@ jobs:
         run: |
           pytest tests/ -v
 
-      - name: HIVE Denver Demo test
+      # - name: HIVE Denver Demo test
+      #   run: |
+      #     hive denver_demo.yaml
+
+      - name: HIVE determinism test
         run: |
-          hive denver_demo.yaml
+          python examples/test_for_determinism.py --iterations 2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,6 +29,7 @@ jobs:
       - name: Install package
         run: |
           pip install ".[dev]"
+          pip install pandas # determinism test dependency
 
       - name: Run mypy
         run: mypy . --ignore-missing-imports
@@ -44,10 +45,6 @@ jobs:
       - name: Python unit tests
         run: |
           pytest tests/ -v
-
-      # - name: HIVE Denver Demo test
-      #   run: |
-      #     hive denver_demo.yaml
 
       - name: HIVE determinism test
         run: |

--- a/docs/source/developer/design.md
+++ b/docs/source/developer/design.md
@@ -19,3 +19,10 @@ Deeper within HIVE, whenever the HAMT data structure is interacted with, we must
     - here, prefer `DictOps.iterate_vals()` or `DictOps.iterate_items()` which first sort by key
     - if key sorting is not preferred, write a specialized sort 
 
+When making a specialized sort function over a set of entities, consider bundling the cost value with the entity id. If two entities have the same value, the id can be used to "break the tie" in a deterministic way. Example:
+
+```python
+vs: List[Vehicle] = ... #
+sorted(vs, key=lambda v: v.distance_traveled_km)          # bad
+sorted(vs, key=lambda v: (v.distance_traveled_km, v.id))  # good
+```

--- a/docs/source/developer/design.md
+++ b/docs/source/developer/design.md
@@ -1,0 +1,21 @@
+# Design
+
+This page describes details specific to HIVE for new developers interacting with the library.
+
+## table of contents
+
+- **[determinism](#determinism)**: details related to keeping HIVE runs deterministic
+
+### determinism
+
+#### immutables.Map does not iterate based on insertion order
+
+Most of the HIVE state is stored in hash maps. A [3rd party library](https://github.com/MagicStack/immutables) provides an immutable hash map via the Hash Array Mapped Trie (HAMT) data structure. While it is, for the most part, a drop-in replacement for a python Dict, it has one caveat, which is that insertion order is not guaranteed. This has determinism implications for HIVE. For this reason, any iteration of HAMT data structures must first be _sorted_. This is the default behavior for accessing the entity collections on a `SimulationState`, that they are first sorted by `EntityId`, such as `sim.get_vehicles()`.
+
+Deeper within HIVE, whenever the HAMT data structure is interacted with, we must take care. There are two possible situations:
+  1. the iteration order is irrelevant (for example, when iterating on a collection in order to write reports, or when updating a collection)
+    - here, use of `.items()` iteration is acceptable
+  2. the iteration order is sorted (exclusively when retrieving a Map as an _iterator_)
+    - here, prefer `DictOps.iterate_vals()` or `DictOps.iterate_items()` which first sort by key
+    - if key sorting is not preferred, write a specialized sort 
+

--- a/docs/source/developer/index.rst
+++ b/docs/source/developer/index.rst
@@ -6,4 +6,4 @@ Developer Docs
 
   release 
   contributing
-
+  design

--- a/examples/test_for_determinism.py
+++ b/examples/test_for_determinism.py
@@ -1,0 +1,72 @@
+from pathlib import Path
+from typing import Dict, List
+from pkg_resources import resource_filename
+from nrel.hive.initialization.load import load_config, load_simulation
+import random
+import numpy
+import pandas
+import argparse
+
+from nrel.hive.runner.local_simulation_runner import LocalSimulationRunner
+
+# this utility demonstrates a set of runs have the same high-level results
+if __name__ == "__main__":
+    denver = Path(resource_filename(
+            "nrel.hive.resources.scenarios.denver_downtown", 
+            "denver_demo.yaml"))
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--scenario', type=Path, default=denver)
+    parser.add_argument('--iterations', type=int, default=5)
+    parser.add_argument('--outfile', type=Path, required=False)
+    args = parser.parse_args()
+    
+    iterations = args.iterations
+    data: List[Dict] = []
+    for i in range(iterations):
+        config_no_log = load_config(args.scenario).suppress_logging()
+        config = config_no_log._replace(
+            global_config=config_no_log.global_config._replace(
+                log_stats=True
+            )
+        )
+        if config.sim.seed is not None:
+            random.seed(config.sim.seed)
+            numpy.random.seed(config.sim.seed)
+
+        rp0 = load_simulation(config)
+        rp1 = LocalSimulationRunner.run(rp0)
+        stats = rp1.e.reporter.get_summary_stats(rp1)
+        if stats is None:
+            raise Exception("hive result missing stats object")
+        stats['iteration'] = i
+        # flatten vehicle states
+        vs = stats['vehicle_state'].copy()
+        del stats['vehicle_state']
+        for k, v in vs.items():
+            stats[f'{k}StatePct'] = v['observed_percent']
+            stats[f'{k}StateVkt'] = v['vkt']
+
+        data.append(stats)
+        print(f"finished iteration {i}")
+
+
+    df = pandas.DataFrame(data)
+    
+    test_cols = [
+        'mean_final_soc',
+        'requests_served_percent',
+        'total_vkt',
+        'total_kwh_expended',
+        'total_gge_expended',
+        'total_kwh_dispensed',
+        'total_gge_dispensed'
+    ]
+    for col in test_cols:
+        n = df[col].nunique()
+        if n == 1:
+            print(f'{col} is good, all values match')
+        else:
+            entries = '[' + ', '.join(df[col].unique()) + ']'
+            print(f'{col} no good, has {n} unique entries (should be one): {entries}')
+    if args.outfile:
+        df.to_csv(args.outfile)

--- a/examples/test_for_determinism.py
+++ b/examples/test_for_determinism.py
@@ -23,12 +23,14 @@ if __name__ == "__main__":
     iterations = args.iterations
     data: List[Dict] = []
     for i in range(iterations):
+        # set up config with scenario + limited (stats only) logging
         config_no_log = load_config(args.scenario).suppress_logging()
         config = config_no_log._replace(
             global_config=config_no_log.global_config._replace(
                 log_stats=True
             )
         )
+        # set random seed from Sim config
         if config.sim.seed is not None:
             random.seed(config.sim.seed)
             numpy.random.seed(config.sim.seed)

--- a/examples/test_for_determinism.py
+++ b/examples/test_for_determinism.py
@@ -6,6 +6,7 @@ import random
 import numpy
 import pandas
 import argparse
+import sys
 
 from nrel.hive.runner.local_simulation_runner import LocalSimulationRunner
 
@@ -63,12 +64,19 @@ if __name__ == "__main__":
         'total_kwh_dispensed',
         'total_gge_dispensed'
     ]
+    
+    print(f'testing for determinism between {args.iterations} runs')
+    exit_code = 0
     for col in test_cols:
         n = df[col].nunique()
         if n == 1:
             print(f'{col} is good, all values match')
         else:
+            exit_code = 1
             entries = '[' + ', '.join(df[col].unique()) + ']'
             print(f'{col} no good, has {n} unique entries (should be one): {entries}')
+    
     if args.outfile:
         df.to_csv(args.outfile)
+
+    sys.exit(exit_code)

--- a/nrel/hive/app/hive_cosim.py
+++ b/nrel/hive/app/hive_cosim.py
@@ -30,8 +30,9 @@ def load_scenario(
     """
     config = load_config(scenario_file, output_suffix)
 
-    random.seed(config.sim.seed)
-    numpy.random.seed(config.sim.seed)
+    if config.sim.seed is not None:
+        random.seed(config.sim.seed)
+        numpy.random.seed(config.sim.seed)
 
     initial_payload = load_simulation(config, custom_instruction_generators, custom_init_functions)
 

--- a/nrel/hive/app/hive_cosim.py
+++ b/nrel/hive/app/hive_cosim.py
@@ -3,6 +3,8 @@ from pathlib import Path
 from typing import Iterable, Tuple, NamedTuple, Optional, TypeVar
 
 from tqdm import tqdm
+import random
+import numpy
 
 from nrel.hive.dispatcher.instruction_generator.instruction_generator import InstructionGenerator
 from nrel.hive.initialization.initialize_simulation import InitFunction
@@ -27,6 +29,10 @@ def load_scenario(
     :raises: Error when issues with files
     """
     config = load_config(scenario_file, output_suffix)
+
+    random.seed(config.sim.seed)
+    numpy.random.seed(config.sim.seed)
+
     initial_payload = load_simulation(config, custom_instruction_generators, custom_init_functions)
 
     # add a specialized Reporter handler that catches vehicle charge events

--- a/nrel/hive/app/run.py
+++ b/nrel/hive/app/run.py
@@ -54,8 +54,9 @@ def run_sim(
 
     config = load_config(scenario_file)
 
-    random.seed(config.sim.seed)
-    numpy.random.seed(config.sim.seed)
+    if config.sim.seed is not None:
+        random.seed(config.sim.seed)
+        numpy.random.seed(config.sim.seed)
 
     initial_payload = load_simulation(
         config,

--- a/nrel/hive/app/run.py
+++ b/nrel/hive/app/run.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING, Iterable, Optional, Tuple, TypeVar, Union
 
 import pkg_resources
 import yaml
+import random
+import numpy
 
 from nrel.hive.dispatcher.instruction_generator.instruction_generator import InstructionGenerator
 from nrel.hive.initialization.initialize_simulation import InitFunction
@@ -51,6 +53,9 @@ def run_sim(
     _welcome_to_hive()
 
     config = load_config(scenario_file)
+
+    random.seed(config.sim.seed)
+    numpy.random.seed(config.sim.seed)
 
     initial_payload = load_simulation(
         config,

--- a/nrel/hive/config/sim.py
+++ b/nrel/hive/config/sim.py
@@ -19,7 +19,7 @@ class Sim(NamedTuple):
     request_cancel_time_seconds: int
     schedule_type: ScheduleType
     min_delta_energy_change: Ratio = 0.0001
-    seed: int = 0
+    seed: Optional[int] = 0
 
     @classmethod
     def default_config(cls) -> Dict:

--- a/nrel/hive/config/sim.py
+++ b/nrel/hive/config/sim.py
@@ -19,6 +19,7 @@ class Sim(NamedTuple):
     request_cancel_time_seconds: int
     schedule_type: ScheduleType
     min_delta_energy_change: Ratio = 0.0001
+    seed: int = 0
 
     @classmethod
     def default_config(cls) -> Dict:

--- a/nrel/hive/dispatcher/instruction_generator/assignment_ops.py
+++ b/nrel/hive/dispatcher/instruction_generator/assignment_ops.py
@@ -303,7 +303,7 @@ def shortest_time_to_charge_ranking(
 
             return _time_to_full
 
-        def _sort_enqueue_time(v: Vehicle) -> int:
+        def _sort_enqueue_time(v: Vehicle) -> Tuple[int, str]:
             if isinstance(v.vehicle_state, ChargeQueueing):
                 enqueue_time = int(v.vehicle_state.enqueue_time)
             else:
@@ -311,7 +311,7 @@ def shortest_time_to_charge_ranking(
                     "calling _sort_enqueue_time on a vehicle state that is not ChargeQueueing"
                 )
                 enqueue_time = 0
-            return enqueue_time
+            return (enqueue_time, v.id)
 
         def _greedy_assignment(
             _charging: Tuple[Seconds, ...],
@@ -374,7 +374,6 @@ def shortest_time_to_charge_ranking(
         vehicles_at_station = sim.get_vehicles(filter_function=_veh_at_station)
         vehicles_enqueued = sim.get_vehicles(
             filter_function=_veh_enqueued,
-            sort=True,
             sort_key=_sort_enqueue_time,
         )
 

--- a/nrel/hive/dispatcher/instruction_generator/assignment_ops.py
+++ b/nrel/hive/dispatcher/instruction_generator/assignment_ops.py
@@ -378,7 +378,7 @@ def shortest_time_to_charge_ranking(
         )
 
         estimates: Dict[ChargerId, int] = {}
-        for charger_id in station.state.keys():
+        for charger_id in sorted(station.state.keys()):
             charger_state = station.state.get(charger_id)
             charger = charger_state.charger if charger_state is not None else None
 

--- a/nrel/hive/dispatcher/instruction_generator/dispatcher.py
+++ b/nrel/hive/dispatcher/instruction_generator/dispatcher.py
@@ -96,9 +96,7 @@ class Dispatcher(InstructionGenerator):
             )
 
             unassigned_requests = simulation_state.get_requests(
-                sort=True,
-                sort_key=lambda r: r.value,
-                sort_reversed=True,
+                sort_key=lambda r: -r.value,
                 filter_function=_valid_request,
             )
 

--- a/nrel/hive/dispatcher/instruction_generator/instruction_generator_ops.py
+++ b/nrel/hive/dispatcher/instruction_generator/instruction_generator_ops.py
@@ -16,8 +16,6 @@ from nrel.hive.util.units import Kilometers
 
 log = logging.getLogger(__name__)
 
-random.seed(123)
-
 if TYPE_CHECKING:
     from nrel.hive.model.vehicle.vehicle import Vehicle
     from nrel.hive.state.simulation_state.simulation_state import SimulationState
@@ -85,7 +83,7 @@ class InstructionGenerationResult(NamedTuple):
                 ),
             )
             + acc,
-            simulation_state.vehicles.values(),
+            simulation_state.get_vehicles(),
             (),
         )
 
@@ -313,7 +311,7 @@ def get_nearest_valid_station_distance(
 
     nearest_station = H3Ops.nearest_entity(
         geoid=geoid,
-        entities=simulation_state.stations.values(),
+        entities=simulation_state.get_stations(),
         entity_search=simulation_state.s_search,
         sim_h3_search_resolution=simulation_state.sim_h3_search_resolution,
         max_search_distance_km=max_search_radius_km,

--- a/nrel/hive/initialization/initialize_simulation_with_sampling.py
+++ b/nrel/hive/initialization/initialize_simulation_with_sampling.py
@@ -187,8 +187,6 @@ def _build_stations(
 
     # add all stations to the simulation once we know they are complete
     stations = DictOps.iterate_vals(stations_builder)
-    sim_with_stations = simulation_state_ops.add_entities(
-        simulation_state, stations
-    )
+    sim_with_stations = simulation_state_ops.add_entities(simulation_state, stations)
 
     return sim_with_stations

--- a/nrel/hive/initialization/initialize_simulation_with_sampling.py
+++ b/nrel/hive/initialization/initialize_simulation_with_sampling.py
@@ -186,8 +186,9 @@ def _build_stations(
         )
 
     # add all stations to the simulation once we know they are complete
+    stations = DictOps.iterate_vals(stations_builder)
     sim_with_stations = simulation_state_ops.add_entities(
-        simulation_state, stations_builder.values()
+        simulation_state, stations
     )
 
     return sim_with_stations

--- a/nrel/hive/initialization/sample_requests.py
+++ b/nrel/hive/initialization/sample_requests.py
@@ -67,6 +67,6 @@ def default_request_sampler(
 
         id_counter += 1
 
-    sorted_reqeusts = sorted(requests, key=lambda r: r.departure_time)
+    sorted_reqeusts = sorted(requests, key=lambda r: (r.departure_time, r.id))
 
     return tuple(sorted_reqeusts)

--- a/nrel/hive/model/roadnetwork/roadnetwork.py
+++ b/nrel/hive/model/roadnetwork/roadnetwork.py
@@ -79,7 +79,7 @@ class RoadNetwork(ABC):
                 position = EntityPosition(link.link_id, geoid)
                 return position
             else:
-                hexes_by_dist = sorted(hexes_on_link, key=lambda h: h3.h3_distance(geoid, h))
+                hexes_by_dist = sorted(hexes_on_link, key=lambda h: (h3.h3_distance(geoid, h), h))
                 closest_hex_to_query = hexes_by_dist[0]
                 position = EntityPosition(link.link_id, closest_hex_to_query)
                 return position

--- a/nrel/hive/model/station/station.py
+++ b/nrel/hive/model/station/station.py
@@ -23,6 +23,7 @@ from nrel.hive.model.station.station_ops import (
     station_state_updates,
 )
 from nrel.hive.runner.environment import Environment
+from nrel.hive.util.dict_ops import DictOps
 from nrel.hive.util.error_or_result import ErrorOr
 from nrel.hive.util.exception import H3Error, SimulationStateError
 from nrel.hive.util.typealiases import *
@@ -109,7 +110,7 @@ class Station(Entity):
                     return None, updated_builder
 
         initial = None, immutables.Map[ChargerId, ChargerState]()
-        error, charger_states = ft.reduce(_chargers, chargers.items(), initial)
+        error, charger_states = ft.reduce(_chargers, DictOps.iterate_items(chargers), initial)
         if error is not None:
             raise error
         if charger_states is None:

--- a/nrel/hive/reporting/handler/stateful_handler.py
+++ b/nrel/hive/reporting/handler/stateful_handler.py
@@ -35,7 +35,7 @@ class StatefulHandler(Handler):
         sim_state = runner_payload.s
         if ReportType.DRIVER_STATE in self.global_config.log_sim_config:
             self._report_entities(
-                entities=sim_state.vehicles.values(),
+                entities=sim_state.get_vehicles(),
                 asdict=self.driver_asdict,
                 sim_time=sim_state.sim_time,
                 report_type=ReportType.DRIVER_STATE,
@@ -43,7 +43,7 @@ class StatefulHandler(Handler):
 
         if ReportType.VEHICLE_STATE in self.global_config.log_sim_config:
             self._report_entities(
-                entities=sim_state.vehicles.values(),
+                entities=sim_state.get_vehicles(),
                 asdict=self.vehicle_asdict,
                 sim_time=sim_state.sim_time,
                 report_type=ReportType.VEHICLE_STATE,
@@ -51,7 +51,7 @@ class StatefulHandler(Handler):
 
         if ReportType.STATION_STATE in self.global_config.log_sim_config:
             self._report_entities(
-                entities=sim_state.stations.values(),
+                entities=sim_state.get_stations(),
                 asdict=self.station_asdict,
                 sim_time=sim_state.sim_time,
                 report_type=ReportType.STATION_STATE,

--- a/nrel/hive/reporting/handler/summary_stats.py
+++ b/nrel/hive/reporting/handler/summary_stats.py
@@ -48,19 +48,19 @@ class SummaryStats:
         self.mean_final_soc = mean(
             [
                 env.mechatronics[v.mechatronics_id].fuel_source_soc(v)
-                for v in sim_state.vehicles.values()
+                for v in sim_state.get_vehicles()
             ]
         )
 
         self.station_revenue = reduce(
             lambda income, station: income + station.balance,
-            sim_state.stations.values(),
+            sim_state.get_stations(),
             0.0,
         )
 
         self.fleet_revenue = reduce(
             lambda income, vehicle: income + vehicle.balance,
-            sim_state.vehicles.values(),
+            sim_state.get_vehicles(),
             0.0,
         )
 

--- a/nrel/hive/reporting/handler/time_step_stats_handler.py
+++ b/nrel/hive/reporting/handler/time_step_stats_handler.py
@@ -118,7 +118,7 @@ class TimeStepStatsHandler(Handler):
         )
 
         # get number of active requests in this time step (unassigned)
-        active_requests_count = len(sim_state.get_requests()) - assigned_requests_count
+        active_requests_count = len(sim_state.requests) - assigned_requests_count
 
         # get number of canceled requests in this time step
         if ReportType.CANCEL_REQUEST_EVENT in reports_by_type.keys():
@@ -144,7 +144,7 @@ class TimeStepStatsHandler(Handler):
             }
 
             # get average SOC of vehicles
-            if len(sim_state.get_vehicles()) > 0:
+            if len(sim_state.vehicles) > 0:
                 stats_row["avg_soc_percent"] = 100 * np.mean(
                     [
                         env.mechatronics[v.mechatronics_id].fuel_source_soc(v)

--- a/nrel/hive/reporting/reporter_ops.py
+++ b/nrel/hive/reporting/reporter_ops.py
@@ -40,7 +40,7 @@ def log_station_capacities(sim: SimulationState, env: Environment) -> IOResultE[
     try:
         result: Tuple[Dict[str, Any], ...] = ft.reduce(
             lambda acc, s: acc + (_station_energy(s),),
-            sim.stations.values(),
+            sim.get_stations(),
             (),
         )
 

--- a/nrel/hive/reporting/vehicle_event_ops.py
+++ b/nrel/hive/reporting/vehicle_event_ops.py
@@ -295,7 +295,7 @@ def construct_station_load_events(
 
     # create entries for stations with no charge events reported
     reported_stations: Set[StationId] = set(reported_charge_events_accumulator.keys())
-    unreported_station_ids: Set[StationId] = set(sim.stations.keys()).difference(reported_stations)
+    unreported_station_ids: Set[StationId] = set(sim.get_station_ids()).difference(reported_stations)
     all_stations_accumulator = ft.reduce(
         lambda acc, id: acc.update({id: (0.0, "")}),
         unreported_station_ids,

--- a/nrel/hive/reporting/vehicle_event_ops.py
+++ b/nrel/hive/reporting/vehicle_event_ops.py
@@ -50,6 +50,7 @@ def vehicle_move_event(
     elif len(next_vehicle.energy.keys()) > 1:
         raise NotImplementedError("hive doesn't currently support multiple energy types")
     else:
+        # assumes one energy type per vehicle (no PHEVs)
         energy_units = list(next_vehicle.energy.keys())[0].units
 
     delta_energy = ft.reduce(

--- a/nrel/hive/reporting/vehicle_event_ops.py
+++ b/nrel/hive/reporting/vehicle_event_ops.py
@@ -295,7 +295,9 @@ def construct_station_load_events(
 
     # create entries for stations with no charge events reported
     reported_stations: Set[StationId] = set(reported_charge_events_accumulator.keys())
-    unreported_station_ids: Set[StationId] = set(sim.get_station_ids()).difference(reported_stations)
+    unreported_station_ids: Set[StationId] = set(sim.get_station_ids()).difference(
+        reported_stations
+    )
     all_stations_accumulator = ft.reduce(
         lambda acc, id: acc.update({id: (0.0, "")}),
         unreported_station_ids,

--- a/nrel/hive/state/driver_state/driver_instruction_ops.py
+++ b/nrel/hive/state/driver_state/driver_instruction_ops.py
@@ -271,7 +271,7 @@ def av_dispatch_base_instruction(
 
         best_base = H3Ops.nearest_entity_by_great_circle_distance(
             geoid=veh.geoid,
-            entities=sim.bases.values(),
+            entities=sim.get_bases(),
             entity_search=sim.b_search,
             is_valid=valid_fn,
             sim_h3_search_resolution=sim.sim_h3_search_resolution,

--- a/nrel/hive/state/driver_state/driver_instruction_ops.py
+++ b/nrel/hive/state/driver_state/driver_instruction_ops.py
@@ -70,14 +70,14 @@ def human_charge_at_home(
     chargers = tuple(
         filter(
             my_mechatronics.valid_charger,
-            [env.chargers[cid] for cid in my_station.state.keys()],
+            [env.chargers[cid] for cid in sorted(my_station.state.keys())],
         )
     )
     if not chargers:
         return None
     else:
         # take the lowest power charger
-        charger: Charger = sorted(chargers, key=lambda c: c.rate)[0]
+        charger: Charger = sorted(chargers, key=lambda c: (c.rate, c.id))[0]
         return ChargeBaseInstruction(veh.id, home_base.id, charger.id)
 
 
@@ -156,7 +156,7 @@ def human_look_for_requests(
             # find the most dense request search hex and sends vehicles to the center
             best_search_hex = sorted(
                 [(k, len(v)) for k, v in sim.r_search.items()],
-                key=lambda t: t[1],
+                key=lambda t: (t[1], t[0]),  # fallback to geoid (index 0) to break ties
                 reverse=True,
             )[0][0]
         destination = h3.h3_to_center_child(best_search_hex, sim.sim_h3_location_resolution)
@@ -231,7 +231,7 @@ def av_charge_base_instruction(
     chargers: Tuple[Charger, ...] = tuple(
         filter(
             my_mechatronics.valid_charger,
-            [cs.charger for cs in my_station.state.values()],
+            [cs.charger for cs in sorted(my_station.state.values(), key=lambda c: c.id)],
         )
     )
 

--- a/nrel/hive/state/driver_state/driver_instruction_ops.py
+++ b/nrel/hive/state/driver_state/driver_instruction_ops.py
@@ -21,6 +21,7 @@ from nrel.hive.state.vehicle_state.charging_base import ChargingBase
 from nrel.hive.state.vehicle_state.idle import Idle
 from nrel.hive.state.vehicle_state.reserve_base import ReserveBase
 from nrel.hive.util import TupleOps, H3Ops
+from nrel.hive.util.dict_ops import DictOps
 
 if TYPE_CHECKING:
     from nrel.hive.state.simulation_state.simulation_state import SimulationState
@@ -238,7 +239,7 @@ def av_charge_base_instruction(
         return None
 
     # take the lowest power charger
-    charger: Charger = sorted(chargers, key=lambda c: c.rate)[0]
+    charger: Charger = sorted(chargers, key=lambda c: (c.rate, c.id))[0]
     return ChargeBaseInstruction(veh.id, my_base.id, charger.id)
 
 

--- a/nrel/hive/state/simulation_state/simulation_state.py
+++ b/nrel/hive/state/simulation_state/simulation_state.py
@@ -16,6 +16,7 @@ from nrel.hive.model.roadnetwork.haversine_roadnetwork import HaversineRoadNetwo
 from nrel.hive.model.sim_time import SimTime
 from nrel.hive.state.simulation_state.at_location_response import AtLocationResponse
 from nrel.hive.util import geo
+from nrel.hive.util.dict_ops import DictOps
 from nrel.hive.util.typealiases import (
     RequestId,
     VehicleId,
@@ -51,7 +52,9 @@ class SimulationState(NamedTuple):
     sim_h3_location_resolution: int = 15
     sim_h3_search_resolution: int = 7
 
-    # objects of the simulation
+    # objects of the simulation.
+    # note: if you need to iterate on these collections, prefer the get methods
+    # provided below which ensure entities are properly sorted.
     stations: immutables.Map[StationId, Station] = immutables.Map()
     bases: immutables.Map[BaseId, Base] = immutables.Map()
     vehicles: immutables.Map[VehicleId, Vehicle] = immutables.Map()
@@ -87,137 +90,30 @@ class SimulationState(NamedTuple):
     def get_stations(
         self,
         filter_function: Optional[Callable[[Station], bool]] = None,
-        sort: bool = True,
-        sort_key: Callable = lambda k: k.id,
-        sort_reversed: bool = False,
+        sort_key: Optional[Callable] = None
     ) -> Tuple[Station, ...]:
-        """
-        returns a tuple of stations.
-        users can pass an optional filter and sort function.
-
-
-        :param filter_function: function to filter results
-        :param sort: whether or not to sort the results
-        :param sort_key: the key to sort the results by
-        :param sort_reversed: the order of the resulting sort
-        :return: tuple of sorted and filtered stations
-        """
-        stations = self.stations.values()
-        if filter_function and sort:
-            return tuple(
-                filter(
-                    filter_function,
-                    sorted(stations, key=sort_key, reverse=sort_reversed),
-                )
-            )
-        elif filter_function:
-            return tuple(filter(filter_function, stations))
-        elif sort:
-            return tuple(sorted(stations, key=sort_key, reverse=sort_reversed))
-        else:
-            return tuple(stations)
+        return DictOps.iterate_sim_coll(self.stations, filter_function, sort_key)
 
     def get_bases(
         self,
         filter_function: Optional[Callable[[Base], bool]] = None,
-        sort: bool = True,
-        sort_key: Callable = lambda k: k.id,
-        sort_reversed: bool = False,
+        sort_key: Optional[Callable] = None
     ) -> Tuple[Base, ...]:
-        """
-        returns a tuple of bases.
-        users can pass an optional filter and sort function.
-
-
-        :param filter_function: function to filter results
-        :param sort: whether or not to sort the results
-        :param sort_key: the key to sort the results by
-        :param sort_reversed: the order of the resulting sort
-        :return: tuple of sorted and filtered bases
-        """
-        bases = self.bases.values()
-
-        if filter_function and sort:
-            return tuple(
-                filter(
-                    filter_function,
-                    sorted(bases, key=sort_key, reverse=sort_reversed),
-                )
-            )
-        elif filter_function:
-            return tuple(filter(filter_function, bases))
-        elif sort:
-            return tuple(sorted(bases, key=sort_key, reverse=sort_reversed))
-        else:
-            return tuple(bases)
+        return DictOps.iterate_sim_coll(self.bases, filter_function, sort_key)
 
     def get_vehicles(
         self,
         filter_function: Optional[Callable[[Vehicle], bool]] = None,
-        sort: bool = True,
-        sort_key: Callable = lambda k: k.id,
-        sort_reversed: bool = False,
+        sort_key: Optional[Callable] = None,
     ) -> Tuple[Vehicle, ...]:
-        """
-        returns a tuple of vehicles.
-        users can pass an optional filter and sort function.
-
-
-        :param filter_function: function to filter results
-        :param sort: whether or not to sort the results
-        :param sort_key: the key to sort the results by
-        :param sort_reversed: the order of the resulting sort
-        :return: tuple of sorted and filtered vehicles
-        """
-        vehicles = self.vehicles.values()
-
-        if filter_function and sort:
-            return tuple(
-                sorted(
-                    filter(filter_function, vehicles),
-                    key=sort_key,
-                    reverse=sort_reversed,
-                )
-            )
-        elif filter_function:
-            return tuple(filter(filter_function, vehicles))
-        elif sort:
-            return tuple(sorted(vehicles, key=sort_key, reverse=sort_reversed))
-        else:
-            return tuple(vehicles)
+        return DictOps.iterate_sim_coll(self.vehicles, filter_function, sort_key)
 
     def get_requests(
         self,
         filter_function: Optional[Callable[[Request], bool]] = None,
-        sort: bool = True,
-        sort_key: Callable = lambda k: k.id,
-        sort_reversed: bool = False,
+        sort_key: Optional[Callable] = None,
     ) -> Tuple[Request, ...]:
-        """
-        returns a tuple of requests.
-        users can pass an optional filter and sort function.
-
-
-        :param filter_function: function to filter results
-        :param sort: whether or not to sort the results
-        :param sort_key: the key to sort the results by
-        :param sort_reversed: the order of the resulting sort
-        :return: tuple of sorted and filtered requests
-        """
-        requests = self.requests.values()
-        if filter_function and sort:
-            return tuple(
-                filter(
-                    filter_function,
-                    sorted(requests, key=sort_key, reverse=sort_reversed),
-                )
-            )
-        elif filter_function:
-            return tuple(filter(filter_function, requests))
-        elif sort:
-            return tuple(sorted(requests, key=sort_key, reverse=sort_reversed))
-        else:
-            return tuple(requests)
+        return DictOps.iterate_sim_coll(self.requests, filter_function, sort_key)
 
     def at_geoid(self, geoid: GeoId) -> AtLocationResponse:
         """

--- a/nrel/hive/state/simulation_state/simulation_state.py
+++ b/nrel/hive/state/simulation_state/simulation_state.py
@@ -74,10 +74,13 @@ class SimulationState(NamedTuple):
 
     def get_station_ids(self) -> Tuple[StationId, ...]:
         return tuple(sorted(self.stations.keys()))
+
     def get_vehicle_ids(self) -> Tuple[VehicleId, ...]:
         return tuple(sorted(self.vehicles.keys()))
+
     def get_base_ids(self) -> Tuple[BaseId, ...]:
         return tuple(sorted(self.bases.keys()))
+
     def get_request_ids(self) -> Tuple[RequestId, ...]:
         return tuple(sorted(self.requests.keys()))
 
@@ -220,7 +223,7 @@ class SimulationState(NamedTuple):
         """
         returns a dictionary with the list of ids found at this location for all entities
 
-        :deprecated: no longer used 
+        :deprecated: no longer used
         :param geoid: geoid to look up, should be at the self.sim_h3_location_resolution
         :return: an Optional AtLocationResponse
         """

--- a/nrel/hive/state/simulation_state/simulation_state.py
+++ b/nrel/hive/state/simulation_state/simulation_state.py
@@ -72,11 +72,20 @@ class SimulationState(NamedTuple):
     s_search: immutables.Map[GeoId, FrozenSet[StationId]] = immutables.Map()
     b_search: immutables.Map[GeoId, FrozenSet[BaseId]] = immutables.Map()
 
+    def get_station_ids(self) -> Tuple[StationId, ...]:
+        return tuple(sorted(self.stations.keys()))
+    def get_vehicle_ids(self) -> Tuple[VehicleId, ...]:
+        return tuple(sorted(self.vehicles.keys()))
+    def get_base_ids(self) -> Tuple[BaseId, ...]:
+        return tuple(sorted(self.bases.keys()))
+    def get_request_ids(self) -> Tuple[RequestId, ...]:
+        return tuple(sorted(self.requests.keys()))
+
     def get_stations(
         self,
         filter_function: Optional[Callable[[Station], bool]] = None,
-        sort: bool = False,
-        sort_key: Callable = lambda k: k,
+        sort: bool = True,
+        sort_key: Callable = lambda k: k.id,
         sort_reversed: bool = False,
     ) -> Tuple[Station, ...]:
         """
@@ -108,8 +117,8 @@ class SimulationState(NamedTuple):
     def get_bases(
         self,
         filter_function: Optional[Callable[[Base], bool]] = None,
-        sort: bool = False,
-        sort_key: Callable = lambda k: k,
+        sort: bool = True,
+        sort_key: Callable = lambda k: k.id,
         sort_reversed: bool = False,
     ) -> Tuple[Base, ...]:
         """
@@ -142,8 +151,8 @@ class SimulationState(NamedTuple):
     def get_vehicles(
         self,
         filter_function: Optional[Callable[[Vehicle], bool]] = None,
-        sort: bool = False,
-        sort_key: Callable = lambda k: k,
+        sort: bool = True,
+        sort_key: Callable = lambda k: k.id,
         sort_reversed: bool = False,
     ) -> Tuple[Vehicle, ...]:
         """
@@ -177,8 +186,8 @@ class SimulationState(NamedTuple):
     def get_requests(
         self,
         filter_function: Optional[Callable[[Request], bool]] = None,
-        sort: bool = False,
-        sort_key: Callable = lambda k: k,
+        sort: bool = True,
+        sort_key: Callable = lambda k: k.id,
         sort_reversed: bool = False,
     ) -> Tuple[Request, ...]:
         """
@@ -211,6 +220,7 @@ class SimulationState(NamedTuple):
         """
         returns a dictionary with the list of ids found at this location for all entities
 
+        :deprecated: no longer used 
         :param geoid: geoid to look up, should be at the self.sim_h3_location_resolution
         :return: an Optional AtLocationResponse
         """

--- a/nrel/hive/state/simulation_state/simulation_state.py
+++ b/nrel/hive/state/simulation_state/simulation_state.py
@@ -90,14 +90,14 @@ class SimulationState(NamedTuple):
     def get_stations(
         self,
         filter_function: Optional[Callable[[Station], bool]] = None,
-        sort_key: Optional[Callable] = None
+        sort_key: Optional[Callable] = None,
     ) -> Tuple[Station, ...]:
         return DictOps.iterate_sim_coll(self.stations, filter_function, sort_key)
 
     def get_bases(
         self,
         filter_function: Optional[Callable[[Base], bool]] = None,
-        sort_key: Optional[Callable] = None
+        sort_key: Optional[Callable] = None,
     ) -> Tuple[Base, ...]:
         return DictOps.iterate_sim_coll(self.bases, filter_function, sort_key)
 

--- a/nrel/hive/state/simulation_state/update/cancel_requests.py
+++ b/nrel/hive/state/simulation_state/update/cancel_requests.py
@@ -61,7 +61,7 @@ class CancelRequests(SimulationUpdateFunction):
 
         updated = ft.reduce(
             _remove_from_sim,
-            simulation_state.requests.keys(),
+            simulation_state.get_request_ids(),
             simulation_state,
         )
 

--- a/nrel/hive/state/simulation_state/update/charging_price_update.py
+++ b/nrel/hive/state/simulation_state/update/charging_price_update.py
@@ -140,7 +140,9 @@ class ChargingPriceUpdate(SimulationUpdateFunction):
             # apply update to all stations
             # if these updates are in the form of GeoIds, map them to StationIds
             as_station_updates = _map_to_station_ids(charger_update, sim_state)
-            station_ids_to_update = set(sim_state.get_station_ids()).union(as_station_updates.keys())
+            station_ids_to_update = set(sim_state.get_station_ids()).union(
+                as_station_updates.keys()
+            )
 
             # we are applying only the updates related to valid StationIds with updates
             result = ft.reduce(

--- a/nrel/hive/state/simulation_state/update/charging_price_update.py
+++ b/nrel/hive/state/simulation_state/update/charging_price_update.py
@@ -131,7 +131,7 @@ class ChargingPriceUpdate(SimulationUpdateFunction):
             # apply it to every station here.
             result = ft.reduce(
                 lambda sim, s_id: _update_station_prices(sim, s_id, charger_update["default"]),
-                sim_state.stations.keys(),
+                sim_state.get_station_ids(),
                 sim_state,
             )
             return result, self
@@ -140,7 +140,7 @@ class ChargingPriceUpdate(SimulationUpdateFunction):
             # apply update to all stations
             # if these updates are in the form of GeoIds, map them to StationIds
             as_station_updates = _map_to_station_ids(charger_update, sim_state)
-            station_ids_to_update = set(sim_state.stations.keys()).union(as_station_updates.keys())
+            station_ids_to_update = set(sim_state.get_station_ids()).union(as_station_updates.keys())
 
             # we are applying only the updates related to valid StationIds with updates
             result = ft.reduce(

--- a/nrel/hive/state/simulation_state/update/step_simulation.py
+++ b/nrel/hive/state/simulation_state/update/step_simulation.py
@@ -97,7 +97,7 @@ class StepSimulation(SimulationUpdateFunction):
 
         # pops the top instruction from the stack. this could be replaced with something like a priority queue
         final_instructions: Tuple[Instruction, ...] = ()
-        for vid in i_stack.keys():
+        for vid in sorted(i_stack.keys()):
             i, _ = DictOps.pop_from_stack_dict(i_stack, vid)
             if not i:
                 continue

--- a/nrel/hive/state/simulation_state/update/step_simulation_ops.py
+++ b/nrel/hive/state/simulation_state/update/step_simulation_ops.py
@@ -101,7 +101,7 @@ def perform_vehicle_state_updates(
             lambda v: isinstance(v.vehicle_state, ChargeQueueing), vs
         )
 
-        # sort queueing vehicles by enqueue time followed by id as a 
+        # sort queueing vehicles by enqueue time followed by id as a
         # deterministic tie-breaker via their VehicleId
         sorted_charge_queueing_vehicles = tuple(
             sorted(

--- a/nrel/hive/state/simulation_state/update/step_simulation_ops.py
+++ b/nrel/hive/state/simulation_state/update/step_simulation_ops.py
@@ -101,19 +101,23 @@ def perform_vehicle_state_updates(
             lambda v: isinstance(v.vehicle_state, ChargeQueueing), vs
         )
 
+        # sort queueing vehicles by enqueue time followed by id as a 
+        # deterministic tie-breaker via their VehicleId
         sorted_charge_queueing_vehicles = tuple(
             sorted(
                 charge_queueing_vehicles,
-                key=lambda v: v.vehicle_state.enqueue_time
+                key=lambda v: (v.vehicle_state.enqueue_time, v.id)
                 if isinstance(v.vehicle_state, ChargeQueueing)
-                else 0,
+                else (0, v.id),
             )
         )
+        sorted_other_vehicles = tuple(sorted(other_vehicles, key=lambda v: v.id))
+        return sorted_other_vehicles + sorted_charge_queueing_vehicles
 
-        return other_vehicles + sorted_charge_queueing_vehicles
-
-    # why sort here? see _sort_by_vehicle_state for an explanation
-    vehicles = _sort_by_vehicle_state(tuple(simulation_state.get_vehicles()))
+    # why sort here? see _sort_by_vehicle_state (above) for an explanation
+    # this code doesn't use built-in sorting iterator methods because of the
+    # initial partitioning step required.
+    vehicles = _sort_by_vehicle_state(tuple(simulation_state.vehicles.values()))
 
     for veh in vehicles:
         simulation_state = step_vehicle(simulation_state, env, veh)

--- a/nrel/hive/state/simulation_state/update/step_simulation_ops.py
+++ b/nrel/hive/state/simulation_state/update/step_simulation_ops.py
@@ -70,7 +70,7 @@ def perform_driver_state_updates(
         else:
             return updated_sim
 
-    next_state = ft.reduce(_step_drivers, simulation_state.vehicles.values(), simulation_state)
+    next_state = ft.reduce(_step_drivers, simulation_state.get_vehicles(), simulation_state)
     return next_state
 
 
@@ -113,7 +113,7 @@ def perform_vehicle_state_updates(
         return other_vehicles + sorted_charge_queueing_vehicles
 
     # why sort here? see _sort_by_vehicle_state for an explanation
-    vehicles = _sort_by_vehicle_state(tuple(simulation_state.vehicles.values()))
+    vehicles = _sort_by_vehicle_state(tuple(simulation_state.get_vehicles()))
 
     for veh in vehicles:
         simulation_state = step_vehicle(simulation_state, env, veh)

--- a/nrel/hive/util/dict_ops.py
+++ b/nrel/hive/util/dict_ops.py
@@ -1,6 +1,19 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Iterator, List, NamedTuple, Tuple, Optional, TypeVar, FrozenSet, TYPE_CHECKING, Hashable, Union
+from typing import (
+    Any,
+    Callable,
+    Iterator,
+    List,
+    NamedTuple,
+    Tuple,
+    Optional,
+    TypeVar,
+    FrozenSet,
+    TYPE_CHECKING,
+    Hashable,
+    Union,
+)
 
 import h3
 import immutables
@@ -9,7 +22,6 @@ if TYPE_CHECKING:
     from nrel.hive.util.typealiases import EntityId, GeoId
     from nrel.hive.model.entity import Entity
     from _typeshed import SupportsRichComparison
-
 
 
 class EntityUpdateResult(NamedTuple):
@@ -23,9 +35,11 @@ class DictOps:
     V = TypeVar("V")
 
     @classmethod
-    def iterate_vals(cls, xs: immutables.Map[K, V], key: Optional[Callable[[V], SupportsRichComparison]]=None) -> Tuple[V, ...]:
+    def iterate_vals(
+        cls, xs: immutables.Map[K, V], key: Optional[Callable[[V], SupportsRichComparison]] = None
+    ) -> Tuple[V, ...]:
         """
-        helper function for iterating on Maps in HIVE which sorts values by key unless a key function 
+        helper function for iterating on Maps in HIVE which sorts values by key unless a key function
         is provided. for all stateful Map collections that are being iterated on in HIVE, we need
         to sort them _somehow_ to guarantee deterministic runs.
 
@@ -34,7 +48,7 @@ class DictOps:
 
         :param xs: collection to iterate values of
         :type xs: immutables.Map[K, V]
-        :return: values of xs, sorted by key 
+        :return: values of xs, sorted by key
         :rtype: Tuple[V, ...]
         """
         # forcing ignore here after numerous attempts to set the bounds for K
@@ -47,17 +61,21 @@ class DictOps:
         else:
             vs = sorted(xs.values(), key=key)  # type: ignore
             return vs
-    
+
     @classmethod
-    def iterate_items(cls, xs: immutables.Map[K, V], key: Optional[Callable[[Tuple[K, V]], SupportsRichComparison]]=None) -> List[Tuple[K, V]]:
+    def iterate_items(
+        cls,
+        xs: immutables.Map[K, V],
+        key: Optional[Callable[[Tuple[K, V]], SupportsRichComparison]] = None,
+    ) -> List[Tuple[K, V]]:
         """
-        helper function for iterating on Maps in HIVE which sorts values by key unless a key function 
+        helper function for iterating on Maps in HIVE which sorts values by key unless a key function
         is provided. for all stateful Map collections that are being iterated on in HIVE, we need
         to sort them _somehow_ to guarantee deterministic runs.
 
         :param xs: collection to iterate values of
         :type xs: immutables.Map[K, V]
-        :return: values of xs, sorted by key 
+        :return: values of xs, sorted by key
         :rtype: Tuple[V, ...]
         """
         # forcing ignore here after numerous attempts to set the bounds for K
@@ -71,10 +89,10 @@ class DictOps:
 
     @classmethod
     def iterate_sim_coll(
-            cls,
-            collection: immutables.Map[K, V],
-            filter_function: Optional[Callable[[V], bool]] = None,
-            sort_key: Optional[Callable] = None
+        cls,
+        collection: immutables.Map[K, V],
+        filter_function: Optional[Callable[[V], bool]] = None,
+        sort_key: Optional[Callable] = None,
     ) -> Tuple[V, ...]:
         """
         helper to iterate through a collection on the SimulationState with optional
@@ -89,13 +107,12 @@ class DictOps:
         :return: _description_
         :rtype: Tuple[V, ...]
         """
-        
-        vals = DictOps.iterate_vals(collection, sort_key) 
+
+        vals = DictOps.iterate_vals(collection, sort_key)
         if filter_function:
             return tuple(filter(filter_function, vals))
         else:
             return vals
-
 
     @classmethod
     def add_to_dict(cls, xs: immutables.Map[K, V], obj_id: K, obj: V) -> immutables.Map[K, V]:

--- a/nrel/hive/util/dict_ops.py
+++ b/nrel/hive/util/dict_ops.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import NamedTuple, Tuple, Optional, TypeVar, FrozenSet, TYPE_CHECKING
+from typing import Any, Callable, Iterator, List, NamedTuple, Tuple, Optional, TypeVar, FrozenSet, TYPE_CHECKING, Hashable, Union
 
 import h3
 import immutables
@@ -8,6 +8,8 @@ import immutables
 if TYPE_CHECKING:
     from nrel.hive.util.typealiases import EntityId, GeoId
     from nrel.hive.model.entity import Entity
+    from _typeshed import SupportsRichComparison
+
 
 
 class EntityUpdateResult(NamedTuple):
@@ -19,6 +21,81 @@ class EntityUpdateResult(NamedTuple):
 class DictOps:
     K = TypeVar("K")
     V = TypeVar("V")
+
+    @classmethod
+    def iterate_vals(cls, xs: immutables.Map[K, V], key: Optional[Callable[[V], SupportsRichComparison]]=None) -> Tuple[V, ...]:
+        """
+        helper function for iterating on Maps in HIVE which sorts values by key unless a key function 
+        is provided. for all stateful Map collections that are being iterated on in HIVE, we need
+        to sort them _somehow_ to guarantee deterministic runs.
+
+        if no key function is provided, the values are sorted by Map key. if a key function is provided,
+        it takes the value type as input and returns a sortable value.
+
+        :param xs: collection to iterate values of
+        :type xs: immutables.Map[K, V]
+        :return: values of xs, sorted by key 
+        :rtype: Tuple[V, ...]
+        """
+        # forcing ignore here after numerous attempts to set the bounds for K
+        # to be "Union[SupportsRichComparison, Hashable]"
+        if len(xs) == 0:
+            return ()
+        elif key is None:
+            _, vs = zip(*sorted(xs.items(), key=lambda p: p[0]))  # type: ignore
+            return vs
+        else:
+            vs = sorted(xs.values(), key=key)  # type: ignore
+            return vs
+    
+    @classmethod
+    def iterate_items(cls, xs: immutables.Map[K, V], key: Optional[Callable[[Tuple[K, V]], SupportsRichComparison]]=None) -> List[Tuple[K, V]]:
+        """
+        helper function for iterating on Maps in HIVE which sorts values by key unless a key function 
+        is provided. for all stateful Map collections that are being iterated on in HIVE, we need
+        to sort them _somehow_ to guarantee deterministic runs.
+
+        :param xs: collection to iterate values of
+        :type xs: immutables.Map[K, V]
+        :return: values of xs, sorted by key 
+        :rtype: Tuple[V, ...]
+        """
+        # forcing ignore here after numerous attempts to set the bounds for K
+        # to be "Union[SupportsRichComparison, Hashable]"
+        if len(xs) == 0:
+            return []
+        else:
+            fn = key if key is not None else lambda p: p[0]  # type: ignore
+            items = sorted(xs.items(), key=fn)  # type: ignore
+            return items
+
+    @classmethod
+    def iterate_sim_coll(
+            cls,
+            collection: immutables.Map[K, V],
+            filter_function: Optional[Callable[[V], bool]] = None,
+            sort_key: Optional[Callable] = None
+    ) -> Tuple[V, ...]:
+        """
+        helper to iterate through a collection on the SimulationState with optional
+        sort key function and filter function
+
+        :param collection: collection on SimulationState
+        :type collection: immutables.Map[K, V]
+        :param filter_function: _description_, defaults to None
+        :type filter_function: Optional[Callable[[V], bool]], optional
+        :param sort_key: _description_, defaults to None
+        :type sort_key: Optional[Callable], optional
+        :return: _description_
+        :rtype: Tuple[V, ...]
+        """
+        
+        vals = DictOps.iterate_vals(collection, sort_key) 
+        if filter_function:
+            return tuple(filter(filter_function, vals))
+        else:
+            return vals
+
 
     @classmethod
     def add_to_dict(cls, xs: immutables.Map[K, V], obj_id: K, obj: V) -> immutables.Map[K, V]:

--- a/nrel/hive/util/h3_ops.py
+++ b/nrel/hive/util/h3_ops.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, Optional, TYPE_CHECKING, FrozenSet, Iterable, Call
 import h3
 import immutables
 from math import radians, cos, sin, asin, sqrt, ceil
+from nrel.hive.util.dict_ops import DictOps
 
 from nrel.hive.util.exception import H3Error
 from nrel.hive.util.typealiases import EntityId, GeoId
@@ -148,7 +149,7 @@ class H3Ops:
         cls,
         geoid: GeoId,
         entities: Dict[EntityId, Entity],
-        entity_locations: Dict[GeoId, Tuple[EntityId, ...]],
+        entity_locations: immutables.Map[GeoId, Tuple[EntityId, ...]],
         is_valid: Callable = lambda x: True,
     ) -> Optional[Entity]:
         """
@@ -164,7 +165,7 @@ class H3Ops:
 
         best_dist_km = 1000000.0
         best_e = None
-        for e_geoid, e_ids in entity_locations.items():
+        for e_geoid, e_ids in DictOps.iterate_items(entity_locations):
             dist_km = cls.great_circle_distance(geoid, e_geoid)
             for e_id in e_ids:
                 if e_id not in entities:

--- a/tests/test_h3_ops.py
+++ b/tests/test_h3_ops.py
@@ -68,7 +68,7 @@ class TestH3Ops(TestCase):
 
         nearest = H3Ops.nearest_entity_by_great_circle_distance(
             geoid=somewhere,
-            entities=tuple(sim_with_reqs.requests.values()),
+            entities=tuple(sim_with_reqs.get_requests()),
             entity_search=sim_with_reqs.r_search,
             sim_h3_search_resolution=sim_with_reqs.sim_h3_search_resolution,
         )

--- a/tests/test_run_cosim.py
+++ b/tests/test_run_cosim.py
@@ -9,14 +9,6 @@ from nrel.hive.runner.runner_payload import RunnerPayload
 
 
 class TestRunCosim(TestCase):
-    
-    def test_roooga(self):
-        scenario = Path(resource_filename(
-            "nrel.hive.resources.scenarios.denver_downtown", 
-            "denver_demo.yaml"))
-        rp = hive_cosim.load_scenario(scenario)
-        result = hive_cosim.crank(rp, 1440)
-        print(f"final time: {result.runner_payload.s.sim_time}")
 
     def test_load_and_run_denver(self):
         # read scenario

--- a/tests/test_run_cosim.py
+++ b/tests/test_run_cosim.py
@@ -9,7 +9,6 @@ from nrel.hive.runner.runner_payload import RunnerPayload
 
 
 class TestRunCosim(TestCase):
-
     def test_load_and_run_denver(self):
         # read scenario
         sim = mock_sim()

--- a/tests/test_run_cosim.py
+++ b/tests/test_run_cosim.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+from pkg_resources import resource_filename
 from unittest import TestCase
 
 from nrel.hive.app import hive_cosim
@@ -7,6 +9,15 @@ from nrel.hive.runner.runner_payload import RunnerPayload
 
 
 class TestRunCosim(TestCase):
+    
+    def test_roooga(self):
+        scenario = Path(resource_filename(
+            "nrel.hive.resources.scenarios.denver_downtown", 
+            "denver_demo.yaml"))
+        rp = hive_cosim.load_scenario(scenario)
+        result = hive_cosim.crank(rp, 1440)
+        print(f"final time: {result.runner_payload.s.sim_time}")
+
     def test_load_and_run_denver(self):
         # read scenario
         sim = mock_sim()

--- a/tests/test_sample_functions.py
+++ b/tests/test_sample_functions.py
@@ -68,7 +68,7 @@ class TestSampleVehicles(TestCase):
             self.assertEquals(v.position, base.position)
 
         self.assertEqual(len(result.unwrap().vehicles), n, f"should have {n} vehicles")
-        map(check_vehicle, result.unwrap().vehicles.values())
+        map(check_vehicle, result.unwrap().get_vehicles())
 
     def test_sample_n_with_failure(self):
         """

--- a/tests/test_simulation_state_ops.py
+++ b/tests/test_simulation_state_ops.py
@@ -39,19 +39,19 @@ class TestSimulationStateOps(TestCase):
 
         reqs = [mock_request(i) for i in range(10)]
         sim_with_reqs = simulation_state_ops.add_entities_safe(sim, reqs).unwrap()
-        self.assertEqual(len(sim_with_reqs.requests.values()), 10)
+        self.assertEqual(len(sim_with_reqs.get_requests()), 10)
 
         vehicles = [mock_vehicle(i) for i in range(10)]
         sim_with_vehicles = simulation_state_ops.add_entities_safe(sim, vehicles).unwrap()
-        self.assertEqual(len(sim_with_vehicles.vehicles.values()), 10)
+        self.assertEqual(len(sim_with_vehicles.get_vehicles()), 10)
 
         stations = [mock_station(i) for i in range(10)]
         sim_with_stations = simulation_state_ops.add_entities_safe(sim, stations).unwrap()
-        self.assertEqual(len(sim_with_stations.stations.values()), 10)
+        self.assertEqual(len(sim_with_stations.get_stations()), 10)
 
         bases = [mock_base(i) for i in range(10)]
         sim_with_bases = simulation_state_ops.add_entities_safe(sim, bases).unwrap()
-        self.assertEqual(len(sim_with_bases.bases.values()), 10)
+        self.assertEqual(len(sim_with_bases.get_bases()), 10)
 
     def test_modify_entity(self):
         sim = mock_sim()
@@ -72,12 +72,12 @@ class TestSimulationStateOps(TestCase):
         stations = [mock_station(i) for i in range(10)]
         sim_w_stations = simulation_state_ops.add_entities(sim, stations)
 
-        updated_stations = [s.add_membership("test!") for s in sim_w_stations.stations.values()]
+        updated_stations = [s.add_membership("test!") for s in sim_w_stations.get_stations()]
 
         sim_w_new_stations = simulation_state_ops.modify_entities(sim_w_stations, updated_stations)
 
         self.assertTrue(
-            all(["test!" in s.membership.memberships for s in sim_w_new_stations.stations.values()])
+            all(["test!" in s.membership.memberships for s in sim_w_new_stations.get_stations()])
         )
 
     def test_add_request(self):

--- a/tests/test_simulationstate.py
+++ b/tests/test_simulationstate.py
@@ -632,9 +632,7 @@ class TestSimulationState(TestCase):
             )
         )
 
-        sorted_bases = sim.get_bases(
-            sort_key=lambda b: -b.total_stalls
-        )
+        sorted_bases = sim.get_bases(sort_key=lambda b: -b.total_stalls)
 
         self.assertEqual(sorted_bases[0].id, "b2", "base 2 has the most stalls")
 

--- a/tests/test_simulationstate.py
+++ b/tests/test_simulationstate.py
@@ -633,7 +633,7 @@ class TestSimulationState(TestCase):
         )
 
         sorted_bases = sim.get_bases(
-            sort=True, sort_reversed=True, sort_key=lambda b: b.total_stalls
+            sort_key=lambda b: -b.total_stalls
         )
 
         self.assertEqual(sorted_bases[0].id, "b2", "base 2 has the most stalls")
@@ -664,9 +664,7 @@ class TestSimulationState(TestCase):
         )
 
         sorted_and_filtered_vehicles = sim.get_vehicles(
-            sort=True,
-            sort_key=lambda v: v.energy[EnergyType.ELECTRIC],
-            sort_reversed=True,
+            sort_key=lambda v: -v.energy[EnergyType.ELECTRIC],
         )
 
         self.assertEqual(sorted_and_filtered_vehicles[0].id, "v1", "v1 has highest soc")
@@ -680,6 +678,6 @@ class TestSimulationState(TestCase):
         sim = simulation_state_ops.add_request_safe(sim, r2).unwrap()
         sim = simulation_state_ops.add_request_safe(sim, r1).unwrap()
 
-        sorted_requests = sim.get_requests(sort=True, sort_key=lambda r: r.departure_time)
+        sorted_requests = sim.get_requests(sort_key=lambda r: r.departure_time)
 
         self.assertEqual(sorted_requests[0].id, "r1", "r1 has lowest departure time")

--- a/tests/test_update_requests.py
+++ b/tests/test_update_requests.py
@@ -32,7 +32,7 @@ class TestUpdateRequests(TestCase):
         fn = UpdateRequestsFromFile.build(req_file, rate_structure_file)
         result, _ = fn.update(sim, env)
         self.assertEqual(len(result.requests), 2, "should have added the reqs")
-        for req in result.requests.values():
+        for req in result.get_requests():
             self.assertLess(req.departure_time, sim_time, f"should be less than {sim_time}")
 
     def test_update_some_aready_cancelled(self):
@@ -61,7 +61,7 @@ class TestUpdateRequests(TestCase):
         fn = UpdateRequestsFromFile.build(req_file, rate_structure_file)
         result, _ = fn.update(sim, env)
         self.assertEqual(expected_reqs, len(result.requests), "should have added the reqs")
-        for req in result.requests.values():
+        for req in result.get_requests():
             self.assertLess(req.departure_time, sim_time, f"should be less than {sim_time}")
 
     def test_update_rate_structure(self):
@@ -88,7 +88,7 @@ class TestUpdateRequests(TestCase):
         )
         fn = UpdateRequestsFromFile.build(req_file, rate_structure_file)
         result, _ = fn.update(sim, env)
-        for req in result.requests.values():
+        for req in result.get_requests():
             print(req)
             self.assertGreaterEqual(
                 req.value,
@@ -120,5 +120,5 @@ class TestUpdateRequests(TestCase):
         fn = UpdateRequestsFromFile.build(req_file, rate_structure_file, lazy_file_reading=True)
         result, _ = fn.update(sim, env)
         self.assertEqual(len(result.requests), 2, "should have added the reqs")
-        for req in result.requests.values():
+        for req in result.get_requests():
             self.assertLess(req.departure_time, sim_time, f"should be less than {sim_time}")

--- a/tests/test_update_requests_sampling.py
+++ b/tests/test_update_requests_sampling.py
@@ -19,7 +19,7 @@ class TestUpdateRequestsSampling(TestCase):
         result, _ = fn.update(sim, env)
         self.assertEqual(len(result.requests), 5, "should have added 5 requests")
 
-        for r in result.requests.values():
+        for r in result.get_requests():
             self.assertNotEqual(
                 r.origin,
                 r.destination,


### PR DESCRIPTION
some efforts here to address non-determinism in hive. still seeing it after these changes. for now,

- removed any iterations on sim.(vehicles|bases|stations|requests) directly, replaced with calls to
  - sim.get_x_ids() in place of sim.x.keys()
  - sim.get_xs() in place of sim.x.values()
- set python and numpy random seed at "run" entry points (app run, cosim run) fed from a config.sim.seed value

any thoughts on what else i could do here?

edit: i just went through and added a ton more to this. details:
  - rewrote sim entity getters to use shared code
  - any sorts by keys that are not unique have entity id added (see doc note)
  - identified + updated many additional iterators that could be sorted
  - added developer documentation entry explaining deterministic sorts

i was able to observe 50 denver_demo runs in a row that had the same result. i'm also seeing those runs take 15 seconds which i believe is a bit longer than before. we may see a bigger performance hit with larger runs.

note: when i run `hive` at the command line twice in a row, i'm still seeing different results still. maybe we're not controlling for randomness as well when calling it there for some reason. to provide an example, i've added `examples/test_for_determinism.py` which runs a quick set of 5 iterations of denver and confirms whether all results match or not.