### PR TITLE
ensure filter occurs before sort

### DIFF
--- a/nrel/hive/util/dict_ops.py
+++ b/nrel/hive/util/dict_ops.py
@@ -96,7 +96,8 @@ class DictOps:
     ) -> Tuple[V, ...]:
         """
         helper to iterate through a collection on the SimulationState with optional
-        sort key function and filter function
+        sort key function and filter function. performs filter before sort if both
+        are provided.
 
         :param collection: collection on SimulationState
         :type collection: immutables.Map[K, V]
@@ -108,11 +109,12 @@ class DictOps:
         :rtype: Tuple[V, ...]
         """
 
-        vals = DictOps.iterate_vals(collection, sort_key)
         if filter_function:
-            return tuple(filter(filter_function, vals))
+            entities = immutables.Map({k: v for k, v in collection.items() if filter_function(v)})
         else:
-            return vals
+            entities = collection
+        vals = DictOps.iterate_vals(entities, sort_key)
+        return vals
 
     @classmethod
     def add_to_dict(cls, xs: immutables.Map[K, V], obj_id: K, obj: V) -> immutables.Map[K, V]:


### PR DESCRIPTION
a quick fix. these error messages were observed for larger-running scenarios:

![enqueue.pdf](https://github.com/NREL/hive/files/11748402/enqueue.pdf)

a combined filter + sort was being applied to a collection where it was assumed that the filter occurred before the sort. this behavior was swapped in the recent determinism refactor. this fix ensures filters are applied before the sorts, which should be the default behavior (downsampling the size of $n$ before applying a $O(n\ \log\ n)$ operation is more performant).