### PR TITLE
fixes for handling LinkIds

### DIFF
--- a/nrel/hive/dispatcher/instruction/instructions.py
+++ b/nrel/hive/dispatcher/instruction/instructions.py
@@ -21,6 +21,7 @@ from nrel.hive.state.vehicle_state.dispatch_station import DispatchStation
 from nrel.hive.state.vehicle_state.dispatch_trip import DispatchTrip
 from nrel.hive.state.vehicle_state.idle import Idle
 from nrel.hive.state.vehicle_state.repositioning import Repositioning
+from nrel.hive.state.vehicle_state.out_of_service import OutOfService
 from nrel.hive.state.vehicle_state.reserve_base import ReserveBase
 from nrel.hive.state.vehicle_state.servicing_pooling_trip import ServicingPoolingTrip
 from nrel.hive.util.exception import SimulationStateError, InstructionError
@@ -340,4 +341,23 @@ class ReserveBaseInstruction(Instruction):
         prev_state = vehicle.vehicle_state
         next_state = ReserveBase.build(self.vehicle_id, self.base_id)
 
+        return None, InstructionResult(prev_state, next_state)
+
+
+@dataclass(frozen=True)
+class OutOfServiceInstruction(Instruction):
+    vehicle_id: VehicleId
+
+    def apply_instruction(
+        self, sim_state: SimulationState, env: Environment
+    ) -> Tuple[Optional[Exception], Optional[InstructionResult]]:
+        vehicle = sim_state.vehicles.get(self.vehicle_id)
+        if not vehicle:
+            msg = (
+                f"vehicle {self.vehicle_id} not found; context: applying out of service instruction"
+            )
+            return (SimulationStateError(msg), None)
+
+        prev_state = vehicle.vehicle_state
+        next_state = OutOfService.build(self.vehicle_id)
         return None, InstructionResult(prev_state, next_state)

--- a/nrel/hive/model/roadnetwork/link_id.py
+++ b/nrel/hive/model/roadnetwork/link_id.py
@@ -1,6 +1,4 @@
-from ast import literal_eval
 from typing import Optional, Tuple, Any
-
 from nrel.hive.util.typealiases import LinkId
 
 NodeId = Any
@@ -39,8 +37,8 @@ def extract_node_ids(
         )
     else:
         try:
-            src = literal_eval(result[0])
-            dst = literal_eval(result[1])
+            src = str(result[0])
+            dst = str(result[1])
         except ValueError:
             return Exception(f"LinkId {link_id} cannot be parsed."), None
 

--- a/nrel/hive/model/roadnetwork/link_id.py
+++ b/nrel/hive/model/roadnetwork/link_id.py
@@ -45,9 +45,7 @@ def extract_node_ids(
         return None, (src, dst)
 
 
-def extract_node_ids_int(
-    link_id: LinkId
-) -> Tuple[Optional[Exception], Optional[Tuple[int, int]]]:
+def extract_node_ids_int(link_id: LinkId) -> Tuple[Optional[Exception], Optional[Tuple[int, int]]]:
     """node ids can be strings for the haversine case but for networkx graphs they must be
     integers as they are treated as indices.
 
@@ -67,6 +65,7 @@ def extract_node_ids_int(
             return None, (src, dst)
         except ValueError as e:
             return e, None
+
 
 def reverse_link_id(
     link_id: LinkId,

--- a/nrel/hive/model/roadnetwork/link_id.py
+++ b/nrel/hive/model/roadnetwork/link_id.py
@@ -45,6 +45,29 @@ def extract_node_ids(
         return None, (src, dst)
 
 
+def extract_node_ids_int(
+    link_id: LinkId
+) -> Tuple[Optional[Exception], Optional[Tuple[int, int]]]:
+    """node ids can be strings for the haversine case but for networkx graphs they must be
+    integers as they are treated as indices.
+
+    :param link_id: link id to read
+    :type link_id: LinkId
+    :return: _description_
+    :rtype: Tuple[Optional[Exception], Optional[Tuple[int, int]]]
+    """
+    err, ids = extract_node_ids(link_id)
+    if err is not None or ids is None:
+        return err, None
+    else:
+        try:
+            src_str, dst_str = ids
+            src = int(src_str)
+            dst = int(dst_str)
+            return None, (src, dst)
+        except ValueError as e:
+            return e, None
+
 def reverse_link_id(
     link_id: LinkId,
 ) -> Tuple[Optional[Exception], Optional[LinkId]]:

--- a/nrel/hive/model/station/station.py
+++ b/nrel/hive/model/station/station.py
@@ -70,7 +70,7 @@ class Station(Entity):
     @classmethod
     def build(
         cls,
-        id: StationId,
+        station_id: StationId,
         geoid: GeoId,
         road_network: RoadNetwork,
         chargers: immutables.Map[ChargerId, int],
@@ -100,7 +100,7 @@ class Station(Entity):
                 charger = env.chargers.get(charger_id)
                 if charger is None:
                     msg = (
-                        f"attempting to create station {id} with charger type {charger_id} "
+                        f"attempting to create station {station_id} with charger type {charger_id} "
                         f"but that charger type has not been defined for this scenario"
                     )
                     return TypeError(msg), None
@@ -114,7 +114,7 @@ class Station(Entity):
         if error is not None:
             raise error
         if charger_states is None:
-            msg = f"internal error after building station chargers for station {id}"
+            msg = f"internal error after building station chargers for station {station_id}"
             raise Exception(msg)
 
         energy_dispensed = immutables.Map({energy_type: 0.0 for energy_type in EnergyType})
@@ -122,12 +122,12 @@ class Station(Entity):
         if position is None:
             msg = (
                 "could not find a road network position matching the position "
-                f"provided for station {id}"
+                f"provided for station {station_id}"
             )
             raise H3Error(msg)
 
         return Station(
-            id=id,
+            id=station_id,
             position=position,
             state=charger_states,
             energy_dispensed=energy_dispensed,
@@ -222,7 +222,7 @@ class Station(Entity):
         elif station_id not in builder:
             # create this station
             return Station.build(
-                id=station_id,
+                station_id=station_id,
                 geoid=geoid,
                 road_network=road_network,
                 chargers=immutables.Map({charger_id: charger_count}),

--- a/nrel/hive/model/vehicle/mechatronics/bev.py
+++ b/nrel/hive/model/vehicle/mechatronics/bev.py
@@ -151,8 +151,10 @@ class BEV(MechatronicsInterface):
         :param vehicle:
         :return:
         """
+        battery = vehicle.energy[EnergyType.ELECTRIC]
         full_kwh = self.battery_capacity_kwh - self.battery_full_threshold_kwh
-        return vehicle.energy[EnergyType.ELECTRIC] >= full_kwh
+        is_full = battery >= full_kwh
+        return is_full
 
     def consume_energy(self, vehicle: Vehicle, route: Route) -> Vehicle:
         """

--- a/nrel/hive/resources/mock_lobster.py
+++ b/nrel/hive/resources/mock_lobster.py
@@ -341,7 +341,7 @@ def mock_station_from_geoid(
         env = mock_env()
 
     return Station.build(
-        id=station_id,
+        station_id=station_id,
         geoid=geoid,
         road_network=road_network,
         chargers=chargers,


### PR DESCRIPTION
this PR contains two fixes for buggy behavior surrounding LinkIds:
- removes the use of literal_eval in link_id. this was probably intended to coerce values to be an integer, but creates an unnecessary security issue (code injection) and seems to fail with python 3.10 for handling both strings and ints. this is the desired behavior, since Haversine LinkIds are `\w+-\w` and Osm LinkIds are `\d+-\d+`.
- adds a specialized `extract_node_ids_int` operation for OSM networks for this exact case
- some logging added around building OSM networks
