### PR TITLE
Rjf/prevent recursion limit

### DIFF
--- a/nrel/hive/resources/scenarios/manhattan/manhattan.yaml
+++ b/nrel/hive/resources/scenarios/manhattan/manhattan.yaml
@@ -4,7 +4,7 @@ sim:
   request_cancel_time_seconds: 600
   start_time: "2014-12-21 00:00:00"
   end_time: "2014-12-22 00:00:00"
-  sim_h3_search_resolution: 7  # around 12ish hexes covering manhattan
+  sim_h3_search_resolution: 7 # around 12ish hexes covering manhattan
 network:
   network_type: osm_network
 input:
@@ -16,6 +16,7 @@ input:
   rate_structure_file: rate_structure.csv
   charging_price_file: nyc_fixed.csv
 dispatcher:
+  charging_search_type: shortest_time_to_charge
   valid_dispatch_states:
     - idle
     - repositioning


### PR DESCRIPTION
This PR addresses a recursion limit failure in the assignment_ops:shortest_time_to_charge_ranking function which is possible when there are over 1000 vehicles charging and enqueued at a station. This edge case was observed while running freight simulation with tens of thousands of vehicles in locations where the user specified sparse charging stations. the solution refactors the code from a recursive function to a while loop.

Closes #212.